### PR TITLE
add eta to log

### DIFF
--- a/mmcv/runner/hooks/logger/text.py
+++ b/mmcv/runner/hooks/logger/text.py
@@ -1,8 +1,13 @@
-from .base import LoggerHook
 import datetime
+
+from .base import LoggerHook
 
 
 class TextLoggerHook(LoggerHook):
+
+    def __init__(self, interval=10, ignore_last=True, reset_flag=False):
+        super(TextLoggerHook, self).__init__(interval, ignore_last, reset_flag)
+        self.time_sec_tot = 0
 
     def log(self, runner):
         if runner.mode == 'train':
@@ -15,10 +20,10 @@ class TextLoggerHook(LoggerHook):
             log_str = 'Epoch({}) [{}][{}]\t'.format(runner.mode, runner.epoch,
                                                     runner.inner_iter + 1)
         if 'time' in runner.log_buffer.output:
-            tot_time_sec = runner.log_buffer.output['time'] + \
-                runner.log_buffer.output['data_time']
-            eta_sec = tot_time_sec * \
-                (len(runner.data_loader) * runner.max_epochs - runner._iter)
+            self.time_sec_tot += (runner.log_buffer.output['time'] * 
+                                  self.interval)
+            time_sec_avg = self.time_sec_tot / (runner.iter + 1)
+            eta_sec = time_sec_avg * (runner.max_iters - runner.iter - 1)
             eta_str = str(datetime.timedelta(seconds=int(eta_sec)))
             log_str += ('eta: {}, '.format(eta_str))
             log_str += (

--- a/mmcv/runner/hooks/logger/text.py
+++ b/mmcv/runner/hooks/logger/text.py
@@ -25,7 +25,7 @@ class TextLoggerHook(LoggerHook):
             time_sec_avg = self.time_sec_tot / (runner.iter + 1)
             eta_sec = time_sec_avg * (runner.max_iters - runner.iter - 1)
             eta_str = str(datetime.timedelta(seconds=int(eta_sec)))
-            log_str += ('eta: {}, '.format(eta_str))
+            log_str += 'eta: {}, '.format(eta_str)
             log_str += (
                 'time: {log[time]:.3f}, data_time: {log[data_time]:.3f}, '.
                 format(log=runner.log_buffer.output))

--- a/mmcv/runner/hooks/logger/text.py
+++ b/mmcv/runner/hooks/logger/text.py
@@ -17,8 +17,8 @@ class TextLoggerHook(LoggerHook):
         if 'time' in runner.log_buffer.output:
             tot_time_sec = runner.log_buffer.output['time'] + \
                 runner.log_buffer.output['data_time']
-            eta_sec = tot_time_sec*(len(runner.data_loader)*runner.max_epochs - \
-                                      runner._iter)
+            eta_sec = tot_time_sec * \
+                (len(runner.data_loader) * runner.max_epochs - runner._iter)
             eta_str = str(datetime.timedelta(seconds=int(eta_sec)))
             log_str += ('eta: {}, '.format(eta_str))
             log_str += (

--- a/mmcv/runner/hooks/logger/text.py
+++ b/mmcv/runner/hooks/logger/text.py
@@ -20,7 +20,7 @@ class TextLoggerHook(LoggerHook):
             log_str = 'Epoch({}) [{}][{}]\t'.format(runner.mode, runner.epoch,
                                                     runner.inner_iter + 1)
         if 'time' in runner.log_buffer.output:
-            self.time_sec_tot += (runner.log_buffer.output['time'] * 
+            self.time_sec_tot += (runner.log_buffer.output['time'] *
                                   self.interval)
             time_sec_avg = self.time_sec_tot / (runner.iter + 1)
             eta_sec = time_sec_avg * (runner.max_iters - runner.iter - 1)

--- a/mmcv/runner/hooks/logger/text.py
+++ b/mmcv/runner/hooks/logger/text.py
@@ -1,4 +1,5 @@
 from .base import LoggerHook
+import datetime
 
 
 class TextLoggerHook(LoggerHook):
@@ -14,6 +15,12 @@ class TextLoggerHook(LoggerHook):
             log_str = 'Epoch({}) [{}][{}]\t'.format(runner.mode, runner.epoch,
                                                     runner.inner_iter + 1)
         if 'time' in runner.log_buffer.output:
+            tot_time_sec = runner.log_buffer.output['time'] + \
+                runner.log_buffer.output['data_time']
+            eta_sec = tot_time_sec*(len(runner.data_loader)*runner.max_epochs - \
+                                      runner._iter)
+            eta_str = str(datetime.timedelta(seconds=int(eta_sec)))
+            log_str += ('eta: {}, '.format(eta_str))
             log_str += (
                 'time: {log[time]:.3f}, data_time: {log[data_time]:.3f}, '.
                 format(log=runner.log_buffer.output))


### PR DESCRIPTION
Add eta to text log. Here is output from mmdet:
``2018-12-08 07:17:36,804 - INFO - Epoch [3][100/7330]    lr: 0.02000, eta: 9:45:12, time: 0.473, data_time: 0.007, loss_rpn_cls: 0.0338, loss_rpn_reg: 0.0327, loss_cls: 0.2254, acc: 92.6582, loss_reg: 0.1204, loss: 0.4123``
p/s: Not sure ``time`` is already included ``data_time`` or not. 