### PR TITLE
Use collections.abc instead of collections

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -1,11 +1,11 @@
 import os.path as osp
 import sys
 from argparse import ArgumentParser
-from collections import Iterable
 from importlib import import_module
 
 from addict import Dict
 
+from .misc import collections_abc
 from .path import check_file_exist
 
 
@@ -39,7 +39,7 @@ def add_args(parser, cfg, prefix=''):
             parser.add_argument('--' + prefix + k, action='store_true')
         elif isinstance(v, dict):
             add_args(parser, v, k + '.')
-        elif isinstance(v, Iterable):
+        elif isinstance(v, collections_abc.Iterable):
             parser.add_argument('--' + prefix + k, type=type(v[0]), nargs='+')
         else:
             print('connot parse key {} of type {}'.format(prefix + k, type(v)))

--- a/mmcv/utils/misc.py
+++ b/mmcv/utils/misc.py
@@ -3,6 +3,12 @@ import functools
 import itertools
 import subprocess
 from importlib import import_module
+# ABCs from collections will be deprecated in python 3.8+,
+# while collections.abc is not available in python 2.7
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc
 
 import six
 
@@ -24,7 +30,7 @@ def iter_cast(inputs, dst_type, return_type=None):
     Returns:
         iterator or specified type: The converted object.
     """
-    if not isinstance(inputs, collections.Iterable):
+    if not isinstance(inputs, collections_abc.Iterable):
         raise TypeError('inputs must be an iterable object')
     if not isinstance(dst_type, type):
         raise TypeError('"dst_type" must be a valid type')
@@ -65,7 +71,7 @@ def is_seq_of(seq, expected_type, seq_type=None):
         bool: Whether the sequence is valid.
     """
     if seq_type is None:
-        exp_seq_type = collections.Sequence
+        exp_seq_type = collections_abc.Sequence
     else:
         assert isinstance(seq_type, type)
         exp_seq_type = seq_type

--- a/mmcv/utils/progressbar.py
+++ b/mmcv/utils/progressbar.py
@@ -1,7 +1,7 @@
-import collections
 import sys
 from multiprocessing import Pool
 
+from .misc import collections_abc
 from .timer import Timer
 
 
@@ -76,11 +76,11 @@ def track_progress(func, tasks, bar_width=50, **kwargs):
     """
     if isinstance(tasks, tuple):
         assert len(tasks) == 2
-        assert isinstance(tasks[0], collections.Iterable)
+        assert isinstance(tasks[0], collections_abc.Iterable)
         assert isinstance(tasks[1], int)
         task_num = tasks[1]
         tasks = tasks[0]
-    elif isinstance(tasks, collections.Iterable):
+    elif isinstance(tasks, collections_abc.Iterable):
         task_num = len(tasks)
     else:
         raise TypeError(
@@ -141,11 +141,11 @@ def track_parallel_progress(func,
     """
     if isinstance(tasks, tuple):
         assert len(tasks) == 2
-        assert isinstance(tasks[0], collections.Iterable)
+        assert isinstance(tasks[0], collections_abc.Iterable)
         assert isinstance(tasks[1], int)
         task_num = tasks[1]
         tasks = tasks[0]
-    elif isinstance(tasks, collections.Iterable):
+    elif isinstance(tasks, collections_abc.Iterable):
         task_num = len(tasks)
     else:
         raise TypeError(


### PR DESCRIPTION
ABCs imported from `collections` will be deprecated in python 3.8+, while `collections.abc` is not available in python 2.7