### PR TITLE
Make latest checkpoint symlink relative

### DIFF
--- a/mmcv/runner/runner.py
+++ b/mmcv/runner/runner.py
@@ -243,11 +243,13 @@ class Runner(object):
         else:
             meta.update(epoch=self.epoch + 1, iter=self.iter)
 
-        filename = osp.join(out_dir, filename_tmpl.format(self.epoch + 1))
-        linkname = osp.join(out_dir, 'latest.pth')
+        filename = filename_tmpl.format(self.epoch + 1)
+        filepath = osp.join(out_dir, filename)
+        linkpath = osp.join(out_dir, 'latest.pth')
         optimizer = self.optimizer if save_optimizer else None
-        save_checkpoint(self.model, filename, optimizer=optimizer, meta=meta)
-        mmcv.symlink(filename, linkname)
+        save_checkpoint(self.model, filepath, optimizer=optimizer, meta=meta)
+        # use relative symlink
+        mmcv.symlink(filename, linkpath)
 
     def train(self, data_loader, **kwargs):
         self.model.train()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -2,8 +2,6 @@ import os.path as osp
 import tempfile
 import warnings
 
-import mmcv.runner
-
 
 def test_save_checkpoint():
     try:
@@ -12,6 +10,8 @@ def test_save_checkpoint():
     except ImportError:
         warnings.warn('Skipping test_save_checkpoint in the absense of torch')
         return
+
+    import mmcv.runner
 
     model = nn.Linear(1, 1)
     runner = mmcv.runner.Runner(

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,7 +10,7 @@ def test_save_checkpoint():
         import torch
         import torch.nn as nn
     except ImportError:
-        warnings.warn('Skipping test_save_checkpoint in the absense of pytorch')
+        warnings.warn('Skipping test_save_checkpoint in the absense of torch')
         return
 
     model = nn.Linear(1, 1)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,12 +1,18 @@
 import os.path as osp
 import tempfile
+import warnings
 
 import mmcv.runner
-import torch
-import torch.nn as nn
 
 
 def test_save_checkpoint():
+    try:
+        import torch
+        import torch.nn as nn
+    except ImportError:
+        warnings.warn('Skipping test_save_checkpoint in the absense of pytorch')
+        return
+
     model = nn.Linear(1, 1)
     runner = mmcv.runner.Runner(
         model=model,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,26 @@
+import os.path as osp
+import tempfile
+
+import mmcv.runner
+import torch
+import torch.nn as nn
+
+
+def test_save_checkpoint():
+    model = nn.Linear(1, 1)
+    runner = mmcv.runner.Runner(
+        model=model,
+        batch_processor=lambda x: x
+    )
+
+    with tempfile.TemporaryDirectory() as root:
+        runner.save_checkpoint(root)
+
+        latest_path = osp.join(root, 'latest.pth')
+        epoch1_path = osp.join(root, 'epoch_1.pth')
+
+        assert osp.exists(latest_path)
+        assert osp.exists(epoch1_path)
+        assert osp.realpath(latest_path) == epoch1_path
+
+        torch.load(latest_path)


### PR DESCRIPTION
As for now the latest checkpoint is a symlink with a full path in it:
```
-rw-r--r-- 1 nizhib nizhib 683M Jun  7 15:33 epoch_80.pth
-rw-r--r-- 1 nizhib nizhib 683M Jun  7 15:40 epoch_90.pth
lrwxrwxrwx 1 nizhib nizhib   90 Jun  7 15:46 latest.pth -> /home/nizhib/Code/japan/output/detector/cascade_rcnn_dconv_c3-c5_r101_fpn_1x/epoch_100.pth
```
The request applied makes it relative:
```
-rw-r--r-- 1 nizhib nizhib 683M Jun  7 15:33 epoch_80.pth
-rw-r--r-- 1 nizhib nizhib 683M Jun  7 15:40 epoch_90.pth
lrwxrwxrwx 1 nizhib nizhib   13 Jun  9 13:20 latest.pth -> epoch_100.pth
```

Resolves #74.