### PR TITLE
Fixing build-errors on Windows

### DIFF
--- a/mmcv/video/optflow_warp/flow_warp.cpp
+++ b/mmcv/video/optflow_warp/flow_warp.cpp
@@ -38,8 +38,8 @@ void BilinearInterpolate(const double* img, int width, int height, int channels,
 
   double dx, dy, s;
 
-  dx = __max(__min(x - xx, double(1)), double(0));
-  dy = __max(__min(y - yy, double(1)), double(0));
+  dx = __max__(__min__(x - xx, double(1)), double(0));
+  dy = __max__(__min__(y - yy, double(1)), double(0));
 
   for (m = 0; m <= 1; m++)
     for (n = 0; n <= 1; n++) {
@@ -60,8 +60,8 @@ void NNInterpolate(const double* img, int width, int height, int channels,
 
   double dx, dy;
 
-  dx = __max(__min(x - xx, double(1)), double(0));
-  dy = __max(__min(y - yy, double(1)), double(0));
+  dx = __max__(__min__(x - xx, double(1)), double(0));
+  dy = __max__(__min__(y - yy, double(1)), double(0));
 
   m = (dx < 0.5) ? 0 : 1;
   n = (dy < 0.5) ? 0 : 1;

--- a/mmcv/video/optflow_warp/flow_warp.hpp
+++ b/mmcv/video/optflow_warp/flow_warp.hpp
@@ -15,16 +15,16 @@ void NNInterpolate(const double* img, int width, int height, int channels,
                    double x, double y, double* out);
 
 template <typename T>
-inline T __min(T a, T b) {
+inline T __min__(T a, T b) {
   return a > b ? b : a;
 }
 
 template <typename T>
-inline T __max(T a, T b) {
+inline T __max__(T a, T b) {
   return (a < b) ? b : a;
 }
 
 template <typename T>
 inline T EnforceRange(const T x, const int MaxValue) {
-  return __min(__max(x, 0), MaxValue);
+  return __min__(__max__(x, 0), MaxValue);
 }


### PR DESCRIPTION
`__max` and `__min` had been define as macro in visual studio compile tools.
Renaming to `__max__` and `__min__` to fix the build-errors.