### PR TITLE
add tensor shape check when loading checkpoint

### DIFF
--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -2,11 +2,13 @@ import os
 import os.path as osp
 import pkgutil
 import time
+import warnings
 from collections import OrderedDict
 from importlib import import_module
 
 import mmcv
 import torch
+import torchvision
 from torch.utils import model_zoo
 
 from .utils import get_dist_info
@@ -54,6 +56,7 @@ def load_state_dict(module, state_dict, strict=False, logger=None):
             message. If not specified, print function will be used.
     """
     unexpected_keys = []
+    err_msg = []
     own_state = module.state_dict()
     for name, param in state_dict.items():
         if name not in own_state:
@@ -62,18 +65,19 @@ def load_state_dict(module, state_dict, strict=False, logger=None):
         if isinstance(param, torch.nn.Parameter):
             # backwards compatibility for serialized parameters
             param = param.data
-
-        try:
-            own_state[name].copy_(param)
-        except Exception:
-            raise RuntimeError(
+        if param.size() != own_state[name].size():
+            err_msg.append(
                 'While copying the parameter named {}, '
                 'whose dimensions in the model are {} and '
                 'whose dimensions in the checkpoint are {}.'.format(
-                    name, own_state[name].size(), param.size()))
+                    name, own_state[name].size(), param.size()
+                )
+            )
+            continue
+        own_state[name].copy_(param)
+
     missing_keys = set(own_state.keys()) - set(state_dict.keys())
 
-    err_msg = []
     if unexpected_keys:
         err_msg.append('unexpected key in source state_dict: {}\n'.format(
             ', '.join(unexpected_keys)))
@@ -85,7 +89,7 @@ def load_state_dict(module, state_dict, strict=False, logger=None):
         if strict:
             raise RuntimeError(err_msg)
         elif logger is not None:
-            logger.warn(err_msg)
+            logger.warning(err_msg)
         else:
             print(err_msg)
 
@@ -102,6 +106,18 @@ def load_url_dist(url):
         if rank > 0:
             checkpoint = model_zoo.load_url(url)
     return checkpoint
+
+
+def get_torchvision_models():
+    model_urls = dict()
+    for _, name, ispkg in pkgutil.walk_packages(torchvision.models.__path__):
+        if ispkg:
+            continue
+        _zoo = import_module('torchvision.models.{}'.format(name))
+        if hasattr(_zoo, 'model_urls'):
+            _urls = getattr(_zoo, 'model_urls')
+            model_urls.update(_urls)
+    return model_urls
 
 
 def load_checkpoint(model,
@@ -124,16 +140,14 @@ def load_checkpoint(model,
     """
     # load checkpoint from modelzoo or file or url
     if filename.startswith('modelzoo://'):
-        import torchvision
-        model_urls = dict()
-        for _, name, ispkg in pkgutil.walk_packages(
-                torchvision.models.__path__):
-            if not ispkg:
-                _zoo = import_module('torchvision.models.{}'.format(name))
-                if hasattr(_zoo, 'model_urls'):
-                    _urls = getattr(_zoo, 'model_urls')
-                    model_urls.update(_urls)
+        warnings.warn('The URL scheme of "modelzoo://" is deprecated, please '
+                      'use "torchvision://" instead')
+        model_urls = get_torchvision_models()
         model_name = filename[11:]
+        checkpoint = load_url_dist(model_urls[model_name])
+    elif filename.startswith('torchvision://'):
+        model_urls = get_torchvision_models()
+        model_name = filename[14:]
         checkpoint = load_url_dist(model_urls[model_name])
     elif filename.startswith('open-mmlab://'):
         model_name = filename[13:]


### PR DESCRIPTION
In many occasions, we need to initialize the model from the coco pretrain models in the model zoo. It is common that the users' datasets have different number of categories, which makes it not convenient to load from the 81 categories coco model directly. Thus I feel maybe it is meaningful to add a few lines to check the shape of the model paremeters and skip those with different shapes. 