### PR TITLE
Added the ability to write images to tensorboard

### DIFF
--- a/mmcv/runner/hooks/logger/tensorboard.py
+++ b/mmcv/runner/hooks/logger/tensorboard.py
@@ -46,9 +46,11 @@ class TensorboardLoggerHook(LoggerHook):
             record = runner.log_buffer.output[var]
             if isinstance(record, str):
                 self.writer.add_text(tag, record, runner.iter)
+            elif isinstance(record, torch.Tensor):  # logs images
+                if len(record.shape) == 4:
+                    self.writer.add_image(tag, record, runner.iter)
             else:
-                self.writer.add_scalar(tag, runner.log_buffer.output[var],
-                                       runner.iter)
+                self.writer.add_scalar(tag, record, runner.iter)
 
     @master_only
     def after_run(self, runner):


### PR DESCRIPTION
Added a few lines in `mmcv/runner/hooks/logger/tensorboard.py` which checks if the logged object in the log_buffer is a rank-4 tensor and if it is, adds it to tensorboard using `SummaryWriter.add_image()`. Also replaced a redundant call to `runner.log_buffer.output[var]` with a previously assigned variable `record`.