### PR TITLE
is_filepath may be not right?

### DIFF
--- a/mmcv/utils/path.py
+++ b/mmcv/utils/path.py
@@ -14,7 +14,7 @@ else:
 
 
 def is_filepath(x):
-    if is_str(x) or isinstance(x, Path):
+    if os.path.isfile(x) or isinstance(x, Path):
         return True
     else:
         return False


### PR DESCRIPTION
"""
I see the is_filepath now is implemented as follows:
`def is_filepath(x):
    if is_str(x) or isinstance(x, Path):
        return True
    else:
        return False`

I think if is_str(x) return True, the x also may be not a valid filepath(example x = 'slgljglsjgj'
it is a string, but not a valid filepath.
"""