### PR TITLE
Report number of matching state_dict keys

### DIFF
--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -84,12 +84,10 @@ def load_state_dict(module, state_dict, strict=False, logger=None):
     err_msg = []
     if unexpected_keys:
         err_msg.append('{} unexpected keys in source state_dict: {}\n'.format(
-            len(unexpected_keys),
-            ', '.join(unexpected_keys)))
+            len(unexpected_keys), ', '.join(unexpected_keys)))
     if missing_keys:
         err_msg.append('{} missing keys in source state_dict: {}\n'.format(
-            len(missing_keys),
-            ', '.join(missing_keys)))
+            len(missing_keys), ', '.join(missing_keys)))
     if shape_mismatch_pairs:
         mismatch_info = 'these keys have mismatched shape:\n'
         header = ['key', 'expected shape', 'loaded shape']


### PR DESCRIPTION
When trying to load pretrained weights, it would be useful to know how many weights successfully loaded in addition to knowing which weights were missing / unexpected. This PR adds a few lines to report those numbers when the weights don't match exactly. 