### PR TITLE
fix dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+*.egg-info
+.eggs/
+.mypy-cache
+pip-wheel-metadata

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get install -y ffmpeg
 
 install:
-  - pip install Cython opencv-python pyyaml codecov flake8 yapf isort
+  - pip install -e . codecov flake8 yapf isort
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - sudo apt-get install -y ffmpeg
 
 install:
-  - pip install -e . codecov flake8 yapf isort
+  - rm -rf .eggs && pip install -e . codecov flake8 yapf isort
 
 cache:
   pip: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.7
+
+WORKDIR /mmcv
+
+COPY . /mmcv
+
+RUN pip install -e .

--- a/README.rst
+++ b/README.rst
@@ -48,3 +48,7 @@ or install from source
     git clone https://github.com/open-mmlab/mmcv.git
     cd mmcv
     pip install -e .
+
+Note: If you would like to use :code:`opencv-python-headless` instead of :code:`opencv-python`,
+e.g., in a minimum container environment or servers without GUI,
+you can first install it before installing MMCV to skip the installation of :code:`opencv-python`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-addict
-numpy>=1.11.1
-pyyaml
-six
-requests
-opencv-python

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,11 @@ from Cython.Distutils import build_ext  # noqa: E402
 
 
 def choose_requirement(main, secondary):
-    """If some version version of main requirement installed, return main,
+    """If some version of main requirement installed, return main,
     else return secondary.
-
     """
     try:
-        name = re.split(r"[!<>=]", main)[0]
+        name = re.split(r'[!<>=]', main)[0]
         get_distribution(name)
     except DistributionNotFound:
         return secondary
@@ -34,8 +33,7 @@ install_requires = [
     'requests',
 ]
 # If first not installed install second package
-CHOOSE_INSTALL_REQUIRES = [('opencv-python>=4.1.1',
-                            'opencv-python-headless>=4.1.1')]
+CHOOSE_INSTALL_REQUIRES = [('opencv-python>=3', 'opencv-python-headless>=3')]
 
 for main, secondary in CHOOSE_INSTALL_REQUIRES:
     install_requires.append(choose_requirement(main, secondary))

--- a/setup.py
+++ b/setup.py
@@ -12,17 +12,17 @@ import numpy  # noqa: E402
 from Cython.Distutils import build_ext  # noqa: E402
 
 
-def choose_requirement(main, secondary):
-    """If some version of main requirement installed, return main,
+def choose_requirement(primary, secondary):
+    """If some version of primary requirement installed, return primary,
     else return secondary.
     """
     try:
-        name = re.split(r'[!<>=]', main)[0]
+        name = re.split(r'[!<>=]', primary)[0]
         get_distribution(name)
     except DistributionNotFound:
         return secondary
 
-    return str(main)
+    return str(primary)
 
 
 install_requires = [
@@ -33,7 +33,7 @@ install_requires = [
     'requests',
 ]
 # If first not installed install second package
-CHOOSE_INSTALL_REQUIRES = [('opencv-python>=3', 'opencv-python-headless>=3')]
+CHOOSE_INSTALL_REQUIRES = [('opencv-python-headless>=3', 'opencv-python>=3')]
 
 for main, secondary in CHOOSE_INSTALL_REQUIRES:
     install_requires.append(choose_requirement(main, secondary))

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,45 @@
 import platform
+import re
 import sys
 from io import open  # for Python 2 (identical to builtin in Python 3)
-from setuptools import Extension, find_packages, setup, dist
+from setuptools import Extension, dist, find_packages, setup
+
+from pkg_resources import DistributionNotFound, get_distribution
 
 dist.Distribution().fetch_build_eggs(['Cython', 'numpy>=1.11.1'])
 
 import numpy  # noqa: E402
 from Cython.Distutils import build_ext  # noqa: E402
 
+
+def choose_requirement(main, secondary):
+    """If some version version of main requirement installed, return main,
+    else return secondary.
+
+    """
+    try:
+        name = re.split(r"[!<>=]", main)[0]
+        get_distribution(name)
+    except DistributionNotFound:
+        return secondary
+
+    return str(main)
+
+
 install_requires = [
-    'numpy>=1.11.1', 'pyyaml', 'six', 'addict', 'requests', 'opencv-python',
-    'Cython'
+    'numpy>=1.11.1',
+    'pyyaml',
+    'six',
+    'addict',
+    'requests',
 ]
+# If first not installed install second package
+CHOOSE_INSTALL_REQUIRES = [('opencv-python>=4.1.1',
+                            'opencv-python-headless>=4.1.1')]
+
+for main, secondary in CHOOSE_INSTALL_REQUIRES:
+    install_requires.append(choose_requirement(main, secondary))
+
 if sys.version_info < (3, 3):
     install_requires.append('backports.shutil_get_terminal_size')
 if sys.version_info < (3, 4):


### PR DESCRIPTION
This PR  changes install_requires.

1. Dependency on opencv-python is resolved in the same way as done in [albumentations]()https://github.com/albu/albumentations/blob/master/setup.py#L12) library. `opencv-python` is used if it has already been installed. Otherwise `opencv-python-headless` is used which is good for minimal container environments.

2. Cython is build-time dependency and is removed from install_requires