### PR TITLE
process the case that no weight in the module

### DIFF
--- a/mmcv/cnn/weight_init.py
+++ b/mmcv/cnn/weight_init.py
@@ -2,7 +2,8 @@ import torch.nn as nn
 
 
 def constant_init(module, val, bias=0):
-    nn.init.constant_(module.weight, val)
+    if hasattr(module, 'weight') and module.weight is not None:
+        nn.init.constant_(module.weight, val)
     if hasattr(module, 'bias') and module.bias is not None:
         nn.init.constant_(module.bias, bias)
 


### PR DESCRIPTION
The `constant_init` is used to initialize `BN` layer typically. If `BN` layer is instanced with `affine=False`, the `weight` will be `None`. Add code to process the case.