### PR TITLE
Fix int supprt in mmcv.slice_list

### DIFF
--- a/mmcv/utils/misc.py
+++ b/mmcv/utils/misc.py
@@ -110,8 +110,11 @@ def slice_list(in_list, lens):
     Returns:
         list: A list of sliced list.
     """
+    if isinstance(lens, int):
+        assert len(in_list) % lens == 0
+        lens = [lens] * (len(in_list) / lens)
     if not isinstance(lens, list):
-        raise TypeError('"indices" must be a list of integers')
+        raise TypeError('"indices" must be an interger a list of integers')
     elif sum(lens) != len(in_list):
         raise ValueError(
             'sum of lens and list length does not match: {} != {}'.format(


### PR DESCRIPTION
According to the docs, the second argument of `mmcv.slice_list` may be an integer, but the original implement does not support `int`.