### PR TITLE
Use cv2 to normalize img

### DIFF
--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -15,7 +15,9 @@ def imnormalize(img, mean, std, to_rgb=True):
 
 
 def imdenormalize(img, mean, std, to_bgr=True):
-    img = (img * std) + mean
+    mean = mean.reshape(1, 3).astype(np.float64)
+    std = std.reshape(1, 3).astype(np.float64)
+    img = cv2.add(cv2.multiply(img, std), mean)
     if to_bgr:
         img = rgb2bgr(img)
     return img

--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -18,12 +18,8 @@ def imdenormalize(img, mean, std, to_bgr=True):
     assert img.dtype != np.uint8
     mean = mean.reshape(1, -1).astype(np.float64)
     std = std.reshape(1, -1).astype(np.float64)
-    print(img[0, 0])
     img = cv2.multiply(img, std)  # make a copy
-    print(img[0, 0])
-
     cv2.add(img, mean, img)  # inplace
-    print(img[0, 0])
     if to_bgr:
         cv2.cvtColor(img, cv2.COLOR_RGB2BGR, img)  # inplace
     print(img[0, 0])

--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -11,8 +11,8 @@ def imnormalize(img, mean, std, to_rgb=True):
     stdinv = 1 / np.float64(std.reshape(1, -1))
     if to_rgb:
         img = bgr2rgb(img)
-    img = cv2.subtract(img, mean)  # make a copy
-    cv2.multiply(img, stdinv, img)  # inplace
+    cv2.subtract(img, mean, img)
+    cv2.multiply(img, stdinv, img)
     return img
 
 

--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -22,5 +22,4 @@ def imdenormalize(img, mean, std, to_bgr=True):
     cv2.add(img, mean, img)  # inplace
     if to_bgr:
         cv2.cvtColor(img, cv2.COLOR_RGB2BGR, img)  # inplace
-    print(img[0, 0])
     return img

--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -1,4 +1,5 @@
 # Copyright (c) Open-MMLab. All rights reserved.
+import cv2
 import numpy as np
 
 from .colorspace import bgr2rgb, rgb2bgr
@@ -6,9 +7,11 @@ from .colorspace import bgr2rgb, rgb2bgr
 
 def imnormalize(img, mean, std, to_rgb=True):
     img = img.astype(np.float32)
+    mean = mean.reshape(1, 3).astype(np.float64)
+    std = std.reshape(1, 3).astype(np.float64)
     if to_rgb:
         img = bgr2rgb(img)
-    return (img - mean) / std
+    return cv2.divide(cv2.subtract(img, mean), std)
 
 
 def imdenormalize(img, mean, std, to_bgr=True):

--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -15,10 +15,16 @@ def imnormalize(img, mean, std, to_rgb=True):
 
 
 def imdenormalize(img, mean, std, to_bgr=True):
+    assert img.dtype != np.uint8
     mean = mean.reshape(1, -1).astype(np.float64)
     std = std.reshape(1, -1).astype(np.float64)
+    print(img[0, 0])
     img = cv2.multiply(img, std)  # make a copy
-    img = cv2.add(img, mean, img)  # inplace
+    print(img[0, 0])
+
+    cv2.add(img, mean, img)  # inplace
+    print(img[0, 0])
     if to_bgr:
         cv2.cvtColor(img, cv2.COLOR_RGB2BGR, img)  # inplace
+    print(img[0, 0])
     return img

--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -7,16 +7,16 @@ from .colorspace import bgr2rgb, rgb2bgr
 
 def imnormalize(img, mean, std, to_rgb=True):
     img = img.astype(np.float32)
-    mean = mean.reshape(1, 3).astype(np.float64)
-    stdinv = 1 / std.reshape(1, 3).astype(np.float64)
+    mean = mean.reshape(1, -1).astype(np.float64)
+    stdinv = 1 / std.reshape(1, -1).astype(np.float64)
     if to_rgb:
         img = bgr2rgb(img)
     return cv2.multiply(cv2.subtract(img, mean), stdinv)
 
 
 def imdenormalize(img, mean, std, to_bgr=True):
-    mean = mean.reshape(1, 3).astype(np.float64)
-    std = std.reshape(1, 3).astype(np.float64)
+    mean = mean.reshape(1, -1).astype(np.float64)
+    std = std.reshape(1, -1).astype(np.float64)
     img = cv2.add(cv2.multiply(img, std), mean)
     if to_bgr:
         img = rgb2bgr(img)

--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -10,7 +10,7 @@ def imnormalize(img, mean, std, to_rgb=True):
     mean = np.float64(mean.reshape(1, -1))
     stdinv = 1 / np.float64(std.reshape(1, -1))
     if to_rgb:
-        img = bgr2rgb(img)
+        cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)
     cv2.subtract(img, mean, img)
     cv2.multiply(img, stdinv, img)
     return img

--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -2,17 +2,15 @@
 import cv2
 import numpy as np
 
-from .colorspace import bgr2rgb, rgb2bgr
-
 
 def imnormalize(img, mean, std, to_rgb=True):
     img = np.float32(img)
     mean = np.float64(mean.reshape(1, -1))
     stdinv = 1 / np.float64(std.reshape(1, -1))
     if to_rgb:
-        cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)
-    cv2.subtract(img, mean, img)
-    cv2.multiply(img, stdinv, img)
+        cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)  # inplace
+    cv2.subtract(img, mean, img)  # inplace
+    cv2.multiply(img, stdinv, img)  # inplace
     return img
 
 
@@ -22,5 +20,5 @@ def imdenormalize(img, mean, std, to_bgr=True):
     img = cv2.multiply(img, std)  # make a copy
     img = cv2.add(img, mean, img)  # inplace
     if to_bgr:
-        img = rgb2bgr(img)
+        cv2.cvtColor(img, cv2.COLOR_RGB2BGR, img)  # inplace
     return img

--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -8,10 +8,10 @@ from .colorspace import bgr2rgb, rgb2bgr
 def imnormalize(img, mean, std, to_rgb=True):
     img = img.astype(np.float32)
     mean = mean.reshape(1, 3).astype(np.float64)
-    std = std.reshape(1, 3).astype(np.float64)
+    stdinv = 1 / std.reshape(1, 3).astype(np.float64)
     if to_rgb:
         img = bgr2rgb(img)
-    return cv2.divide(cv2.subtract(img, mean), std)
+    return cv2.multiply(cv2.subtract(img, mean), stdinv)
 
 
 def imdenormalize(img, mean, std, to_bgr=True):

--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def imnormalize(img, mean, std, to_rgb=True):
-    img = np.float32(img)
+    img = np.float32(img) if img.dtype != np.float32 else img.copy()
     mean = np.float64(mean.reshape(1, -1))
     stdinv = 1 / np.float64(std.reshape(1, -1))
     if to_rgb:

--- a/mmcv/image/transforms/normalize.py
+++ b/mmcv/image/transforms/normalize.py
@@ -6,18 +6,21 @@ from .colorspace import bgr2rgb, rgb2bgr
 
 
 def imnormalize(img, mean, std, to_rgb=True):
-    img = img.astype(np.float32)
-    mean = mean.reshape(1, -1).astype(np.float64)
-    stdinv = 1 / std.reshape(1, -1).astype(np.float64)
+    img = np.float32(img)
+    mean = np.float64(mean.reshape(1, -1))
+    stdinv = 1 / np.float64(std.reshape(1, -1))
     if to_rgb:
         img = bgr2rgb(img)
-    return cv2.multiply(cv2.subtract(img, mean), stdinv)
+    img = cv2.subtract(img, mean)  # make a copy
+    cv2.multiply(img, stdinv, img)  # inplace
+    return img
 
 
 def imdenormalize(img, mean, std, to_bgr=True):
     mean = mean.reshape(1, -1).astype(np.float64)
     std = std.reshape(1, -1).astype(np.float64)
-    img = cv2.add(cv2.multiply(img, std), mean)
+    img = cv2.multiply(img, std)  # make a copy
+    img = cv2.add(img, mean, img)  # inplace
     if to_bgr:
         img = rgb2bgr(img)
     return img

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -20,6 +20,8 @@ class TestImage(object):
         cls.gray_img_path = osp.join(
             osp.dirname(__file__), 'data/grayscale.jpg')
         cls.img = cv2.imread(cls.img_path)
+        cls.mean = np.float32(np.array([123.675, 116.28, 103.53]))
+        cls.std = np.float32(np.array([58.395, 57.12, 57.375]))
 
     def assert_img_equal(self, img, ref_img, ratio_thr=0.999):
         assert img.shape == ref_img.shape
@@ -55,6 +57,18 @@ class TestImage(object):
         rewrite_img = mmcv.imread(out_file)
         os.remove(out_file)
         self.assert_img_equal(img, rewrite_img)
+
+    def test_imnormalize(self):
+        img = self.img
+        baseline = (img[:, :, ::-1] - self.mean) / self.std
+        img = mmcv.imnormalize(img, self.mean, self.std)
+        assert np.allclose(img, baseline)
+
+    def imdenormalize(self):
+        img = self.img
+        baseline = img[:, :, ::-1] * self.std + self.mean
+        img = mmcv.imdenormalize(img, self.mean, self.std)
+        assert np.allclose(img, baseline)
 
     def test_bgr2gray(self):
         in_img = np.random.rand(10, 10, 3).astype(np.float32)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -67,13 +67,12 @@ class TestImage(object):
         assert np.allclose(img, baseline)
 
     def test_imdenormalize(self):
-        rgbimg = self.img[:, :, ::-1]
-        normalizedimg = (rgbimg - self.mean) / self.std
-        rgbbaseline = (normalizedimg * self.std + self.mean)
-        bgrbaseline = baseline[:, :, ::-1]
-        img = mmcv.imdenormalize(normalizedimg, self.mean, self.std)
+        normimg = (self.img[:, :, ::-1] - self.mean) / self.std
+        rgbbaseline = (normimg * self.std + self.mean)
+        bgrbaseline = rgbbaseline[:, :, ::-1]
+        img = mmcv.imdenormalize(normimg, self.mean, self.std)
         assert np.allclose(img, bgrbaseline)
-        img = mmcv.imdenormalize(normalizedimg, self.mean, self.std, to_bgr=False)
+        img = mmcv.imdenormalize(normimg, self.mean, self.std, to_bgr=False)
         assert np.allclose(img, rgbbaseline)
 
     def test_bgr2gray(self):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -68,7 +68,7 @@ class TestImage(object):
 
     def test_imdenormalize(self):
         img = (self.img[:, :, ::-1] - self.mean) / self.std
-        baseline = (self.img * self.std + self.mean)[:, :, ::-1]
+        baseline = (img * self.std + self.mean)[:, :, ::-1]
         img = mmcv.imdenormalize(img, self.mean, self.std)
         assert np.allclose(img, baseline)
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -59,10 +59,11 @@ class TestImage(object):
         self.assert_img_equal(img, rewrite_img)
 
     def test_imnormalize(self):
-        baseline = (self.img[:, :, ::-1] - self.mean) / self.std
+        rgbimg = self.img[:, :, ::-1]
+        baseline = (rgbimg - self.mean) / self.std
         img = mmcv.imnormalize(self.img, self.mean, self.std)
         assert np.allclose(img, baseline)
-        img = mmcv.imnormalize(self.img[:, :, ::-1], self.mean, self.std, to_rgb=False)
+        img = mmcv.imnormalize(rgbimg, self.mean, self.std, to_rgb=False)
         assert np.allclose(img, baseline)
 
     def test_imdenormalize(self):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -59,14 +59,15 @@ class TestImage(object):
         self.assert_img_equal(img, rewrite_img)
 
     def test_imnormalize(self):
-        img = self.img
-        baseline = (img[:, :, ::-1] - self.mean) / self.std
-        img = mmcv.imnormalize(img, self.mean, self.std)
+        baseline = (self.img[:, :, ::-1] - self.mean) / self.std
+        img = mmcv.imnormalize(self.img, self.mean, self.std)
+        assert np.allclose(img, baseline)
+        img = mmcv.imnormalize(self.img[:, :, ::-1], self.mean, self.std, to_rgb=False)
         assert np.allclose(img, baseline)
 
     def test_imdenormalize(self):
+        baseline = (self.img * self.std + self.mean)[:, :, ::-1]
         img = (self.img[:, :, ::-1] - self.mean) / self.std
-        baseline = (img * self.std + self.mean)[:, :, ::-1]
         img = mmcv.imdenormalize(img, self.mean, self.std)
         assert np.allclose(img, baseline)
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -64,9 +64,9 @@ class TestImage(object):
         img = mmcv.imnormalize(img, self.mean, self.std)
         assert np.allclose(img, baseline)
 
-    def imdenormalize(self):
-        img = self.img
-        baseline = img[:, :, ::-1] * self.std + self.mean
+    def test_imdenormalize(self):
+        img = (self.img[:, :, ::-1] - self.mean) / self.std
+        baseline = (img * self.std + self.mean)[:, :, ::-1]
         img = mmcv.imdenormalize(img, self.mean, self.std)
         assert np.allclose(img, baseline)
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -67,8 +67,8 @@ class TestImage(object):
         assert np.allclose(img, baseline)
 
     def test_imdenormalize(self):
-        baseline = (self.img * self.std + self.mean)[:, :, ::-1]
         img = (self.img[:, :, ::-1] - self.mean) / self.std
+        baseline = (self.img * self.std + self.mean)[:, :, ::-1]
         img = mmcv.imdenormalize(img, self.mean, self.std)
         assert np.allclose(img, baseline)
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -67,10 +67,14 @@ class TestImage(object):
         assert np.allclose(img, baseline)
 
     def test_imdenormalize(self):
-        img = (self.img[:, :, ::-1] - self.mean) / self.std
-        baseline = (img * self.std + self.mean)[:, :, ::-1]
-        img = mmcv.imdenormalize(img, self.mean, self.std)
-        assert np.allclose(img, baseline)
+        rgbimg = self.img[:, :, ::-1]
+        normalizedimg = (rgbimg - self.mean) / self.std
+        rgbbaseline = (normalizedimg * self.std + self.mean)
+        bgrbaseline = baseline[:, :, ::-1]
+        img = mmcv.imdenormalize(normalizedimg, self.mean, self.std)
+        assert np.allclose(img, bgrbaseline)
+        img = mmcv.imdenormalize(normalizedimg, self.mean, self.std, to_bgr=False)
+        assert np.allclose(img, rgbbaseline)
 
     def test_bgr2gray(self):
         in_img = np.random.rand(10, 10, 3).astype(np.float32)


### PR DESCRIPTION
About 3x speed up.

```python
Python 3.7.3 (default, Mar 27 2019, 22:11:17) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.6.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import cv2                                                  

In [2]: import numpy as np                                          

In [3]: img = np.random.randn(100,200,3).astype(np.float32)         

In [4]: mean = np.array([1,2,3])                                    

In [5]: std = mean / 10                                             

In [6]: %timeit (img - mean) / std                                  
291 µs ± 1.53 µs per loop (mean ± std. dev. of 7 runs, 1000 loops ea
ch)

In [7]: %timeit cv2.divide(cv2.subtract(img, mean.reshape(1,3)
   ...: .astype(np.float64)), std.reshape(1,3).astype(np.float64))  
87.9 µs ± 201 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

Difference is small
```python
In [8]: ans_cv2 = cv2.divide(cv2.subtract(img, mean.reshape(1,3).astype(np
    ...: .float64)), std.reshape(1,3).astype(np.float64))                  

In [9]: ans_np = (img - mean) / std                                       

In [10]: np.abs(ans_np - ans_cv2).max()                                    
Out[10]: 4.291534423828125e-06
```