### PR TITLE
Image decoding optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 before_install:
   - sudo add-apt-repository -y ppa:mc3man/xerus-media
   - sudo apt-get update
-  - sudo apt-get install -y ffmpeg libjpeg-turbo8
+  - sudo apt-get install -y ffmpeg libjpeg-turbo*
   - pip install -U git+git://github.com/lilohuang/PyTurboJPEG.git
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: python
 before_install:
   - sudo add-apt-repository -y ppa:mc3man/xerus-media
   - sudo apt-get update
-  - sudo apt-get install -y ffmpeg libjpeg-turbo
+  - sudo apt-get install -y ffmpeg libjpeg-turbo8
   - pip install -U git+git://github.com/lilohuang/PyTurboJPEG.git
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ language: python
 before_install:
   - sudo add-apt-repository -y ppa:mc3man/xerus-media
   - sudo apt-get update
-  - sudo apt-get install -y ffmpeg
+  - sudo apt-get install -y ffmpeg libjpeg-turbo
+  - pip install -U git+git://github.com/lilohuang/PyTurboJPEG.git
 
 install:
   - rm -rf .eggs && pip install -e . codecov flake8 yapf isort mock

--- a/mmcv/image/__init__.py
+++ b/mmcv/image/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Open-MMLab. All rights reserved.
-from .io import imfrombytes, imread, imwrite
+from .io import imfrombytes, imread, imwrite, usebackend
 from .transforms import (bgr2gray, bgr2hls, bgr2hsv, bgr2rgb, gray2bgr,
                          gray2rgb, hls2bgr, hsv2bgr, imcrop, imdenormalize,
                          imflip, iminvert, imnormalize, impad,
@@ -11,5 +11,5 @@ __all__ = [
     'rgb2gray', 'gray2bgr', 'gray2rgb', 'bgr2rgb', 'rgb2bgr', 'bgr2hsv',
     'hsv2bgr', 'bgr2hls', 'hls2bgr', 'iminvert', 'imflip', 'imrotate',
     'imcrop', 'impad', 'impad_to_multiple', 'imnormalize', 'imdenormalize',
-    'imresize', 'imresize_like', 'imrescale'
+    'imresize', 'imresize_like', 'imrescale', 'usebackend'
 ]

--- a/mmcv/image/__init__.py
+++ b/mmcv/image/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Open-MMLab. All rights reserved.
-from .io import imfrombytes, imread, imwrite, usebackend
+from .io import imfrombytes, imread, imwrite, supported_backends, use_backend
 from .transforms import (bgr2gray, bgr2hls, bgr2hsv, bgr2rgb, gray2bgr,
                          gray2rgb, hls2bgr, hsv2bgr, imcrop, imdenormalize,
                          imflip, iminvert, imnormalize, impad,
@@ -11,5 +11,6 @@ __all__ = [
     'rgb2gray', 'gray2bgr', 'gray2rgb', 'bgr2rgb', 'rgb2bgr', 'bgr2hsv',
     'hsv2bgr', 'bgr2hls', 'hls2bgr', 'iminvert', 'imflip', 'imrotate',
     'imcrop', 'impad', 'impad_to_multiple', 'imnormalize', 'imdenormalize',
-    'imresize', 'imresize_like', 'imrescale', 'usebackend'
+    'imresize', 'imresize_like', 'imrescale', 'use_backend',
+    'supported_backends'
 ]

--- a/mmcv/image/io.py
+++ b/mmcv/image/io.py
@@ -35,7 +35,7 @@ def usebackend(backend):
 
     Args:
         backend (str): The image decoding backend type. Options are "cv2" and
-            "turbojpeg".
+            "turbojpeg" (see https://github.com/lilohuang/PyTurboJPEG).
     """
     assert backend in supported_backends
     global imread_backend

--- a/mmcv/image/io.py
+++ b/mmcv/image/io.py
@@ -82,6 +82,8 @@ def imread(img_or_path, flag='color', channel_order='bgr'):
             with open(img_or_path, 'rb') as in_file:
                 img = jpeg.decode(in_file.read(),
                                   _jpegflag(flag, channel_order))
+                if img.shape[-1] == 1:
+                    img = img[:, :, 0]
             return img
         else:
             flag = imread_flags[flag] if is_str(flag) else flag
@@ -107,6 +109,8 @@ def imfrombytes(content, flag='color', channel_order='bgr'):
     """
     if imread_backend == 'turbojpeg':
         img = jpeg.decode(content, _jpegflag(flag, channel_order))
+        if img.shape[-1] == 1:
+            img = img[:, :, 0]
         return img
     else:
         img_np = np.frombuffer(content, np.uint8)

--- a/mmcv/image/io.py
+++ b/mmcv/image/io.py
@@ -34,8 +34,9 @@ def use_backend(backend):
     """Select a backend for image decoding.
 
     Args:
-        backend (str): The image decoding backend type. Options are "cv2" and
-            "turbojpeg" (see https://github.com/lilohuang/PyTurboJPEG).
+        backend (str): The image decoding backend type. Options are `cv2` and
+            `turbojpeg` (see https://github.com/lilohuang/PyTurboJPEG).
+            `turbojpeg` is faster but it only supports `.jpeg` file format.
     """
     assert backend in supported_backends
     global imread_backend
@@ -69,6 +70,8 @@ def imread(img_or_path, flag='color', channel_order='bgr'):
             as is.
         flag (str): Flags specifying the color type of a loaded image,
             candidates are `color`, `grayscale` and `unchanged`.
+            Note that the `turbojpeg` backened does not support `unchanged`.
+        channel_order (str): Order of channel, candidates are `bgr` and `rgb`.
 
     Returns:
         ndarray: Loaded image array.

--- a/mmcv/image/io.py
+++ b/mmcv/image/io.py
@@ -13,6 +13,13 @@ else:
     from cv2 import CV_LOAD_IMAGE_COLOR as IMREAD_COLOR
     from cv2 import CV_LOAD_IMAGE_GRAYSCALE as IMREAD_GRAYSCALE
     from cv2 import CV_LOAD_IMAGE_UNCHANGED as IMREAD_UNCHANGED
+try:
+    from turbojpeg import TJCS_RGB, TJPF_BGR, TJPF_GRAY, TurboJPEG
+except ImportError:
+    TJCS_RGB = TJPF_GRAY = TJPF_BGR = TurboJPEG = None
+
+jpeg = None
+supported_backends = ['cv2', 'turbojpeg']
 
 imread_flags = {
     'color': IMREAD_COLOR,
@@ -20,8 +27,40 @@ imread_flags = {
     'unchanged': IMREAD_UNCHANGED
 }
 
+imread_backend = 'cv2'
 
-def imread(img_or_path, flag='color'):
+
+def usebackend(backend):
+    """Select a backend for imread
+
+    Args:
+        backend (str): The image decoding backend type. Options are "cv2" and
+            "turbojpeg".
+    """
+    assert backend in supported_backends
+    global imread_backend
+    imread_backend = backend
+    if imread_backend == 'turbojpeg':
+        global jpeg
+        if jpeg is None:
+            jpeg = TurboJPEG()
+
+
+def _jpegflag(flag='color', channel_order='bgr'):
+    if flag == 'color':
+        if channel_order == 'bgr':
+            return TJPF_BGR
+        elif channel_order == 'rgb':
+            return TJCS_RGB
+        else:
+            raise ValueError('channel order must be "rgb" or "bgr"')
+    elif flag == 'grayscale':
+        return TJPF_GRAY
+    else:
+        raise ValueError('flag must be "color" or "grayscale"')
+
+
+def imread(img_or_path, flag='color', channel_order='bgr'):
     """Read an image.
 
     Args:
@@ -37,15 +76,26 @@ def imread(img_or_path, flag='color'):
     if isinstance(img_or_path, np.ndarray):
         return img_or_path
     elif is_str(img_or_path):
-        flag = imread_flags[flag] if is_str(flag) else flag
-        check_file_exist(img_or_path,
-                         'img file does not exist: {}'.format(img_or_path))
-        return cv2.imread(img_or_path, flag)
+        if imread_backend == 'turbojpeg':
+            check_file_exist(img_or_path,
+                             'img file does not exist: {}'.format(img_or_path))
+            with open(img_or_path, 'rb') as in_file:
+                img = jpeg.decode(in_file.read(),
+                                  _jpegflag(flag, channel_order))
+            return img
+        else:
+            flag = imread_flags[flag] if is_str(flag) else flag
+            check_file_exist(img_or_path,
+                             'img file does not exist: {}'.format(img_or_path))
+            img = cv2.imread(img_or_path, flag)
+            if flag == IMREAD_COLOR and channel_order == 'rgb':
+                cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)
+            return img
     else:
         raise TypeError('"img" must be a numpy array or a filename')
 
 
-def imfrombytes(content, flag='color'):
+def imfrombytes(content, flag='color', channel_order='bgr'):
     """Read an image from bytes.
 
     Args:
@@ -55,10 +105,16 @@ def imfrombytes(content, flag='color'):
     Returns:
         ndarray: Loaded image array.
     """
-    img_np = np.frombuffer(content, np.uint8)
-    flag = imread_flags[flag] if is_str(flag) else flag
-    img = cv2.imdecode(img_np, flag)
-    return img
+    if imread_backend == 'turbojpeg':
+        img = jpeg.decode(content, _jpegflag(flag, channel_order))
+        return img
+    else:
+        img_np = np.frombuffer(content, np.uint8)
+        flag = imread_flags[flag] if is_str(flag) else flag
+        img = cv2.imdecode(img_np, flag)
+        if flag == IMREAD_COLOR and channel_order == 'rgb':
+            cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)
+        return img
 
 
 def imwrite(img, file_path, params=None, auto_mkdir=True):

--- a/mmcv/image/io.py
+++ b/mmcv/image/io.py
@@ -42,6 +42,8 @@ def use_backend(backend):
     global imread_backend
     imread_backend = backend
     if imread_backend == 'turbojpeg':
+        if TurboJPEG is None:
+            raise ValueError('`PyTurboJPEG` is not installed')
         global jpeg
         if jpeg is None:
             jpeg = TurboJPEG()

--- a/mmcv/image/io.py
+++ b/mmcv/image/io.py
@@ -30,8 +30,8 @@ imread_flags = {
 imread_backend = 'cv2'
 
 
-def usebackend(backend):
-    """Select a backend for imread
+def use_backend(backend):
+    """Select a backend for image decoding.
 
     Args:
         backend (str): The image decoding backend type. Options are "cv2" and
@@ -76,9 +76,9 @@ def imread(img_or_path, flag='color', channel_order='bgr'):
     if isinstance(img_or_path, np.ndarray):
         return img_or_path
     elif is_str(img_or_path):
+        check_file_exist(img_or_path,
+                         'img file does not exist: {}'.format(img_or_path))
         if imread_backend == 'turbojpeg':
-            check_file_exist(img_or_path,
-                             'img file does not exist: {}'.format(img_or_path))
             with open(img_or_path, 'rb') as in_file:
                 img = jpeg.decode(in_file.read(),
                                   _jpegflag(flag, channel_order))
@@ -87,8 +87,6 @@ def imread(img_or_path, flag='color', channel_order='bgr'):
             return img
         else:
             flag = imread_flags[flag] if is_str(flag) else flag
-            check_file_exist(img_or_path,
-                             'img file does not exist: {}'.format(img_or_path))
             img = cv2.imread(img_or_path, flag)
             if flag == IMREAD_COLOR and channel_order == 'rgb':
                 cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -32,7 +32,7 @@ class TestImage(object):
 
     def test_imread(self):
         # backend cv2
-        mmcv.usebackend('cv2')
+        mmcv.use_backend('cv2')
 
         img_cv2_color_bgr = mmcv.imread(self.img_path)
         assert img_cv2_color_bgr.shape == (300, 400, 3)
@@ -51,7 +51,7 @@ class TestImage(object):
             mmcv.imread(1)
 
         # backend turbojpeg
-        mmcv.usebackend('turbojpeg')
+        mmcv.use_backend('turbojpeg')
 
         img_turbojpeg_color_bgr = mmcv.imread(self.img_path)
         assert img_turbojpeg_color_bgr.shape == (300, 400, 3)
@@ -84,27 +84,27 @@ class TestImage(object):
             mmcv.imread(1)
 
         with pytest.raises(AssertionError):
-            mmcv.usebackend('unsupport_backend')
+            mmcv.use_backend('unsupport_backend')
 
-        mmcv.usebackend('cv2')
+        mmcv.use_backend('cv2')
 
     def test_imfrombytes(self):
         # backend cv2
-        mmcv.usebackend('cv2')
+        mmcv.use_backend('cv2')
         with open(self.img_path, 'rb') as f:
             img_bytes = f.read()
         img_cv2 = mmcv.imfrombytes(img_bytes)
         assert img_cv2.shape == (300, 400, 3)
 
         # backend turbojpeg
-        mmcv.usebackend('turbojpeg')
+        mmcv.use_backend('turbojpeg')
         with open(self.img_path, 'rb') as f:
             img_bytes = f.read()
         img_turbojpeg = mmcv.imfrombytes(img_bytes)
         assert img_turbojpeg.shape == (300, 400, 3)
         assert_array_equal(img_cv2, img_turbojpeg)
 
-        mmcv.usebackend('cv2')
+        mmcv.use_backend('cv2')
 
     def test_imwrite(self):
         img = mmcv.imread(self.img_path)


### PR DESCRIPTION
🏃Work In Progress
Use TurboJPEG instead of cv2 for RGB image decoding and increase the speed of image decoding about 3 times. Still have several items to be improved:

- [x] Provide backend switch option
- [ ] Write test cases
- [x] Write docstring
 