### PR TITLE
add pretty_text

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -206,12 +206,12 @@ class Config(object):
             s = first + '\n' + s
             return s
 
-        def _format_basic_types(k, v, end=''):
+        def _format_basic_types(k, v):
             if isinstance(v, str):
                 v_str = "'{}'".format(v)
             else:
                 v_str = str(v)
-            attr_str = '{}={}{}'.format(str(k), v_str, end)
+            attr_str = '{}={}'.format(str(k), v_str)
             attr_str = _indent(attr_str, indent)
 
             return attr_str
@@ -233,17 +233,16 @@ class Config(object):
             r = ''
             s = []
             for idx, (k, v) in enumerate(d.items()):
+                is_last = idx >= len(d) - 1
+                end = '' if outest_level or is_last else ','
                 if isinstance(v, dict):
                     v_str = '\n' + _format_dict(v)
                     attr_str = '{}=dict({}'.format(str(k), v_str)
-                    attr_str = _indent(attr_str, indent) + ')'
+                    attr_str = _indent(attr_str, indent) + ')' + end
                 elif isinstance(v, list):
-                    attr_str = _format_list(k, v)
+                    attr_str = _format_list(k, v) + end
                 else:
-                    if not outest_level and idx < len(d) - 1:
-                        attr_str = _format_basic_types(k, v, ',')
-                    else:
-                        attr_str = _format_basic_types(k, v)
+                    attr_str = _format_basic_types(k, v) + end
 
                 s.append(attr_str)
             r += '\n'.join(s)

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -191,6 +191,63 @@ class Config(object):
     def text(self):
         return self._text
 
+    @property
+    def pretty_text(self):
+
+        def _indent(s_, num_spaces):
+            s = s_.split('\n')
+            if len(s) == 1:
+                return s_
+            first = s.pop(0)
+            s = [(num_spaces * ' ') + line for line in s]
+            s = '\n'.join(s)
+            s = first + '\n' + s
+            return s
+
+        def _format_basic_type(k, v):
+            if isinstance(v, str):
+                v_str = "'{}'".format(v)
+            else:
+                v_str = str(v)
+            attr_str = '{}={}'.format(str(k), v_str)
+            attr_str = _indent(attr_str, 2)
+
+            return attr_str
+
+        def _format_list(k, v):
+            # check if all items in the list are dict
+            if all(isinstance(_, dict) for _ in v):
+                v_str = '[\n'
+                v_str += '\n'.join(
+                    'dict({}),'.format(_indent(_format_dict(v_), 2))
+                    for v_ in v).rstrip(',')
+                attr_str = '{}={}'.format(str(k), v_str)
+                attr_str = _indent(attr_str, 2) + ']'
+            else:
+                attr_str = _format_basic_type(k, v)
+            return attr_str
+
+        def _format_dict(d):
+            r = ''
+            s = []
+            for k, v in d.items():
+                if isinstance(v, dict):
+                    v_str = '\n' + _format_dict(v)
+                    attr_str = '{}=dict({}'.format(str(k), v_str)
+                    attr_str = _indent(attr_str, 2) + ')'
+                elif isinstance(v, list):
+                    attr_str = _format_list(k, v)
+                else:
+                    attr_str = _format_basic_type(k, v)
+                s.append(attr_str)
+            r += '\n'.join(s)
+            return r
+
+        cfg_dict = self._cfg_dict.to_dict()
+        text = _format_dict(cfg_dict)
+
+        return text
+
     def __repr__(self):
         return 'Config (path: {}): {}'.format(self.filename,
                                               self._cfg_dict.__repr__())

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -204,12 +204,12 @@ class Config(object):
             s = first + '\n' + s
             return s
 
-        def _format_basic_type(k, v):
+        def _format_basic_type(k, v, end=''):
             if isinstance(v, str):
                 v_str = "'{}'".format(v)
             else:
                 v_str = str(v)
-            attr_str = '{}={}'.format(str(k), v_str)
+            attr_str = '{}={}{}'.format(str(k), v_str, end)
             attr_str = _indent(attr_str, 2)
 
             return attr_str
@@ -227,10 +227,10 @@ class Config(object):
                 attr_str = _format_basic_type(k, v)
             return attr_str
 
-        def _format_dict(d):
+        def _format_dict(d, outest_level=False):
             r = ''
             s = []
-            for k, v in d.items():
+            for idx, (k, v) in enumerate(d.items()):
                 if isinstance(v, dict):
                     v_str = '\n' + _format_dict(v)
                     attr_str = '{}=dict({}'.format(str(k), v_str)
@@ -238,13 +238,17 @@ class Config(object):
                 elif isinstance(v, list):
                     attr_str = _format_list(k, v)
                 else:
-                    attr_str = _format_basic_type(k, v)
+                    if not outest_level and idx < len(d) - 1:
+                        attr_str = _format_basic_type(k, v, ',')
+                    else:
+                        attr_str = _format_basic_type(k, v)
+
                 s.append(attr_str)
             r += '\n'.join(s)
             return r
 
         cfg_dict = self._cfg_dict.to_dict()
-        text = _format_dict(cfg_dict)
+        text = _format_dict(cfg_dict, outest_level=True)
 
         return text
 

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -191,8 +191,7 @@ class Config(object):
     def text(self):
         return self._text
 
-    @property
-    def pretty_text(self):
+    def pretty_text(self, indent=4):
 
         def _indent(s_, num_spaces):
             s = s_.split('\n')
@@ -204,13 +203,13 @@ class Config(object):
             s = first + '\n' + s
             return s
 
-        def _format_basic_type(k, v, end=''):
+        def _format_basic_types(k, v, end=''):
             if isinstance(v, str):
                 v_str = "'{}'".format(v)
             else:
                 v_str = str(v)
             attr_str = '{}={}{}'.format(str(k), v_str, end)
-            attr_str = _indent(attr_str, 2)
+            attr_str = _indent(attr_str, indent)
 
             return attr_str
 
@@ -219,12 +218,12 @@ class Config(object):
             if all(isinstance(_, dict) for _ in v):
                 v_str = '[\n'
                 v_str += '\n'.join(
-                    'dict({}),'.format(_indent(_format_dict(v_), 2))
+                    'dict({}),'.format(_indent(_format_dict(v_), indent))
                     for v_ in v).rstrip(',')
                 attr_str = '{}={}'.format(str(k), v_str)
-                attr_str = _indent(attr_str, 2) + ']'
+                attr_str = _indent(attr_str, indent) + ']'
             else:
-                attr_str = _format_basic_type(k, v)
+                attr_str = _format_basic_types(k, v)
             return attr_str
 
         def _format_dict(d, outest_level=False):
@@ -234,14 +233,14 @@ class Config(object):
                 if isinstance(v, dict):
                     v_str = '\n' + _format_dict(v)
                     attr_str = '{}=dict({}'.format(str(k), v_str)
-                    attr_str = _indent(attr_str, 2) + ')'
+                    attr_str = _indent(attr_str, indent) + ')'
                 elif isinstance(v, list):
                     attr_str = _format_list(k, v)
                 else:
                     if not outest_level and idx < len(d) - 1:
-                        attr_str = _format_basic_type(k, v, ',')
+                        attr_str = _format_basic_types(k, v, ',')
                     else:
-                        attr_str = _format_basic_type(k, v)
+                        attr_str = _format_basic_types(k, v)
 
                 s.append(attr_str)
             r += '\n'.join(s)

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -191,7 +191,10 @@ class Config(object):
     def text(self):
         return self._text
 
-    def pretty_text(self, indent=4):
+    @property
+    def pretty_text(self):
+
+        indent = 4
 
         def _indent(s_, num_spaces):
             s = s_.split('\n')

--- a/tests/data/config/l.py
+++ b/tests/data/config/l.py
@@ -1,3 +1,3 @@
-_base_ = ['./l1.py', './l2.yaml', './l3.json']
+_base_ = ['./l1.py', './l2.yaml', './l3.json', './l4.py']
 item3 = False
 item4 = 'test'

--- a/tests/data/config/l4.py
+++ b/tests/data/config/l4.py
@@ -1,0 +1,2 @@
+item5 = dict(a=0, b=1)
+item6 = [dict(a=0), dict(b=1)]

--- a/tests/data/config/l4.py
+++ b/tests/data/config/l4.py
@@ -1,2 +1,3 @@
 item5 = dict(a=0, b=1)
 item6 = [dict(a=0), dict(b=1)]
+item7 = dict(a=[0, 1, 2], b=dict(c=[3.1, 4.2, 5.3]))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@
 import json
 import os.path as osp
 import sys
+import tempfile
 
 import pytest
 
@@ -78,6 +79,8 @@ def test_merge_from_multiple_bases():
     assert cfg.item2.a == 0
     assert cfg.item3 is False
     assert cfg.item4 == 'test'
+    assert cfg.item5 == dict(a=0, b=1)
+    assert cfg.item6 == [dict(a=0), dict(b=1)]
 
     with pytest.raises(KeyError):
         Config.fromfile(osp.join(osp.dirname(__file__), 'data/config/m.py'))
@@ -171,3 +174,14 @@ def test_setattr():
     assert cfg.item2.a == 0
     assert cfg._cfg_dict['item5'] == {'a': {'b': None}}
     assert cfg.item5.a.b is None
+
+
+def test_pretty_text():
+    cfg_file = osp.join(osp.dirname(__file__), 'data/config/l.py')
+    cfg = Config.fromfile(cfg_file)
+    with tempfile.TemporaryDirectory() as temp_config_dir:
+        text_cfg_filename = osp.join(temp_config_dir, '_text_config.py')
+        with open(text_cfg_filename, 'w') as f:
+            f.write(cfg.pretty_text)
+        text_cfg = Config.fromfile(text_cfg_filename)
+    assert text_cfg._cfg_dict == cfg._cfg_dict

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,6 +182,6 @@ def test_pretty_text():
     with tempfile.TemporaryDirectory() as temp_config_dir:
         text_cfg_filename = osp.join(temp_config_dir, '_text_config.py')
         with open(text_cfg_filename, 'w') as f:
-            f.write(cfg.pretty_text())
+            f.write(cfg.pretty_text)
         text_cfg = Config.fromfile(text_cfg_filename)
     assert text_cfg._cfg_dict == cfg._cfg_dict

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,6 +182,6 @@ def test_pretty_text():
     with tempfile.TemporaryDirectory() as temp_config_dir:
         text_cfg_filename = osp.join(temp_config_dir, '_text_config.py')
         with open(text_cfg_filename, 'w') as f:
-            f.write(cfg.pretty_text)
+            f.write(cfg.pretty_text())
         text_cfg = Config.fromfile(text_cfg_filename)
     assert text_cfg._cfg_dict == cfg._cfg_dict

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,6 +81,7 @@ def test_merge_from_multiple_bases():
     assert cfg.item4 == 'test'
     assert cfg.item5 == dict(a=0, b=1)
     assert cfg.item6 == [dict(a=0), dict(b=1)]
+    assert cfg.item7 == dict(a=[0, 1, 2], b=dict(c=[3.1, 4.2, 5.3]))
 
     with pytest.raises(KeyError):
         Config.fromfile(osp.join(osp.dirname(__file__), 'data/config/m.py'))


### PR DESCRIPTION
This PR added pretty_text in Config, which could print formated cfg. 
Note: pretty_text could be directly loaded with Config and result is the same as original cfg. 
For example,  in [mask_rcnn_r50_fpn_1x_coco.py](https://github.com/open-mmlab/mmdetection/blob/v2.0), 
```
cfg = Config.fromfile('configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py')
cfg.pretty_text
```
the output would be 
```
model=dict(
    type='MaskRCNN',
    pretrained='torchvision://resnet50',
    backbone=dict(
        type='ResNet',
        depth=50,
        num_stages=4,
        out_indices=(0, 1, 2, 3),
        frozen_stages=1,
        norm_cfg=dict(
            type='BN',
            requires_grad=True),
        norm_eval=True,
        style='pytorch'),
    neck=dict(
        type='FPN',
        in_channels=[256, 512, 1024, 2048],
        out_channels=256,
        num_outs=5),
    rpn_head=dict(
        type='RPNHead',
        in_channels=256,
        feat_channels=256,
        anchor_scales=[8],
        anchor_ratios=[0.5, 1.0, 2.0],
        anchor_strides=[4, 8, 16, 32, 64],
        target_means=[0.0, 0.0, 0.0, 0.0],
        target_stds=[1.0, 1.0, 1.0, 1.0],
        loss_cls=dict(
            type='CrossEntropyLoss',
            use_sigmoid=True,
            loss_weight=1.0),
        loss_bbox=dict(
            type='SmoothL1Loss',
            beta=0.1111111111111111,
            loss_weight=1.0)),
    roi_head=dict(
        type='StandardRoIHead',
        bbox_roi_extractor=dict(
            type='SingleRoIExtractor',
            roi_layer=dict(
                type='RoIAlign',
                out_size=7,
                sample_num=2),
            out_channels=256,
            featmap_strides=[4, 8, 16, 32]),
        bbox_head=dict(
            type='Shared2FCBBoxHead',
            in_channels=256,
            fc_out_channels=1024,
            roi_feat_size=7,
            num_classes=81,
            target_means=[0.0, 0.0, 0.0, 0.0],
            target_stds=[0.1, 0.1, 0.2, 0.2],
            reg_class_agnostic=False,
            loss_cls=dict(
                type='CrossEntropyLoss',
                use_sigmoid=False,
                loss_weight=1.0),
            loss_bbox=dict(
                type='SmoothL1Loss',
                beta=1.0,
                loss_weight=1.0)),
        mask_roi_extractor=dict(
            type='SingleRoIExtractor',
            roi_layer=dict(
                type='RoIAlign',
                out_size=14,
                sample_num=2),
            out_channels=256,
            featmap_strides=[4, 8, 16, 32]),
        mask_head=dict(
            type='FCNMaskHead',
            num_convs=4,
            in_channels=256,
            conv_out_channels=256,
            num_classes=81,
            loss_mask=dict(
                type='CrossEntropyLoss',
                use_mask=True,
                loss_weight=1.0))))
train_cfg=dict(
    rpn=dict(
        assigner=dict(
            type='MaxIoUAssigner',
            pos_iou_thr=0.7,
            neg_iou_thr=0.3,
            min_pos_iou=0.3,
            match_low_quality=True,
            ignore_iof_thr=-1),
        sampler=dict(
            type='RandomSampler',
            num=256,
            pos_fraction=0.5,
            neg_pos_ub=-1,
            add_gt_as_proposals=False),
        allowed_border=0,
        pos_weight=-1,
        debug=False),
    rpn_proposal=dict(
        nms_across_levels=False,
        nms_pre=2000,
        nms_post=2000,
        max_num=2000,
        nms_thr=0.7,
        min_bbox_size=0),
    rcnn=dict(
        assigner=dict(
            type='MaxIoUAssigner',
            pos_iou_thr=0.5,
            neg_iou_thr=0.5,
            min_pos_iou=0.5,
            match_low_quality=False,
            ignore_iof_thr=-1),
        sampler=dict(
            type='RandomSampler',
            num=512,
            pos_fraction=0.25,
            neg_pos_ub=-1,
            add_gt_as_proposals=True),
        mask_size=28,
        pos_weight=-1,
        debug=False))
test_cfg=dict(
    rpn=dict(
        nms_across_levels=False,
        nms_pre=1000,
        nms_post=1000,
        max_num=1000,
        nms_thr=0.7,
        min_bbox_size=0),
    rcnn=dict(
        score_thr=0.05,
        nms=dict(
            type='nms',
            iou_thr=0.5),
        max_per_img=100,
        mask_thr_binary=0.5))
dataset_type='CocoDataset'
data_root='data/coco/'
img_norm_cfg=dict(
    mean=[123.675, 116.28, 103.53],
    std=[58.395, 57.12, 57.375],
    to_rgb=True)
train_pipeline=[
    dict(type='LoadImageFromFile'),
    dict(type='LoadAnnotations',
        with_bbox=True,
        with_mask=True),
    dict(type='Resize',
        img_scale=(1333, 800),
        keep_ratio=True),
    dict(type='RandomFlip',
        flip_ratio=0.5),
    dict(type='Normalize',
        mean=[123.675, 116.28, 103.53],
        std=[58.395, 57.12, 57.375],
        to_rgb=True),
    dict(type='Pad',
        size_divisor=32),
    dict(type='DefaultFormatBundle'),
    dict(type='Collect',
        keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks'])]
test_pipeline=[
    dict(type='LoadImageFromFile'),
    dict(type='MultiScaleFlipAug',
        img_scale=(1333, 800),
        flip=False,
        transforms=[
            dict(type='Resize',
                keep_ratio=True),
            dict(type='RandomFlip'),
            dict(type='Normalize',
                mean=[123.675, 116.28, 103.53],
                std=[58.395, 57.12, 57.375],
                to_rgb=True),
            dict(type='Pad',
                size_divisor=32),
            dict(type='ImageToTensor',
                keys=['img']),
            dict(type='Collect',
                keys=['img'])])]
data=dict(
    imgs_per_gpu=2,
    workers_per_gpu=2,
    train=dict(
        type='CocoDataset',
        ann_file='data/coco/annotations/instances_train2017.json',
        img_prefix='data/coco/train2017/',
        pipeline=[
            dict(type='LoadImageFromFile'),
            dict(type='LoadAnnotations',
                with_bbox=True,
                with_mask=True),
            dict(type='Resize',
                img_scale=(1333, 800),
                keep_ratio=True),
            dict(type='RandomFlip',
                flip_ratio=0.5),
            dict(type='Normalize',
                mean=[123.675, 116.28, 103.53],
                std=[58.395, 57.12, 57.375],
                to_rgb=True),
            dict(type='Pad',
                size_divisor=32),
            dict(type='DefaultFormatBundle'),
            dict(type='Collect',
                keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks'])]),
    val=dict(
        type='CocoDataset',
        ann_file='data/coco/annotations/instances_val2017.json',
        img_prefix='data/coco/val2017/',
        pipeline=[
            dict(type='LoadImageFromFile'),
            dict(type='MultiScaleFlipAug',
                img_scale=(1333, 800),
                flip=False,
                transforms=[
                    dict(type='Resize',
                        keep_ratio=True),
                    dict(type='RandomFlip'),
                    dict(type='Normalize',
                        mean=[123.675, 116.28, 103.53],
                        std=[58.395, 57.12, 57.375],
                        to_rgb=True),
                    dict(type='Pad',
                        size_divisor=32),
                    dict(type='ImageToTensor',
                        keys=['img']),
                    dict(type='Collect',
                        keys=['img'])])]),
    test=dict(
        type='CocoDataset',
        ann_file='data/coco/annotations/instances_val2017.json',
        img_prefix='data/coco/val2017/',
        pipeline=[
            dict(type='LoadImageFromFile'),
            dict(type='MultiScaleFlipAug',
                img_scale=(1333, 800),
                flip=False,
                transforms=[
                    dict(type='Resize',
                        keep_ratio=True),
                    dict(type='RandomFlip'),
                    dict(type='Normalize',
                        mean=[123.675, 116.28, 103.53],
                        std=[58.395, 57.12, 57.375],
                        to_rgb=True),
                    dict(type='Pad',
                        size_divisor=32),
                    dict(type='ImageToTensor',
                        keys=['img']),
                    dict(type='Collect',
                        keys=['img'])])]))
evaluation=dict(
    interval=1,
    metric=['bbox', 'segm'])
optimizer=dict(
    type='SGD',
    lr=0.02,
    momentum=0.9,
    weight_decay=0.0001)
optimizer_config=dict(
    grad_clip=dict(
        max_norm=35,
        norm_type=2))
lr_config=dict(
    policy='step',
    warmup='linear',
    warmup_iters=500,
    warmup_ratio=0.3333333333333333,
    step=[8, 11])
total_epochs=12
checkpoint_config=dict(
    interval=1)
log_config=dict(
    interval=50,
    hooks=[
        dict(type='TextLoggerHook')])
dist_params=dict(
    backend='nccl')
log_level='INFO'
load_from=None
resume_from=None
workflow=[('train', 1)]
```