### PR TITLE
Add MlflowLoggerHook

### DIFF
--- a/mmcv/runner/hooks/__init__.py
+++ b/mmcv/runner/hooks/__init__.py
@@ -3,8 +3,8 @@ from .checkpoint import CheckpointHook
 from .closure import ClosureHook
 from .hook import HOOKS, Hook
 from .iter_timer import IterTimerHook
-from .logger import (LoggerHook, PaviLoggerHook, TensorboardLoggerHook,
-                     TextLoggerHook, WandbLoggerHook)
+from .logger import (LoggerHook, MlflowLoggerHook, PaviLoggerHook,
+                     TensorboardLoggerHook, TextLoggerHook, WandbLoggerHook)
 from .lr_updater import LrUpdaterHook
 from .memory import EmptyCacheHook
 from .optimizer import OptimizerHook
@@ -13,6 +13,6 @@ from .sampler_seed import DistSamplerSeedHook
 __all__ = [
     'HOOKS', 'Hook', 'CheckpointHook', 'ClosureHook', 'LrUpdaterHook',
     'OptimizerHook', 'IterTimerHook', 'DistSamplerSeedHook', 'EmptyCacheHook',
-    'LoggerHook', 'PaviLoggerHook', 'TextLoggerHook', 'TensorboardLoggerHook',
-    'WandbLoggerHook'
+    'LoggerHook', 'MlflowLoggerHook', 'PaviLoggerHook', 'TextLoggerHook',
+    'TensorboardLoggerHook', 'WandbLoggerHook'
 ]

--- a/mmcv/runner/hooks/logger/__init__.py
+++ b/mmcv/runner/hooks/logger/__init__.py
@@ -7,6 +7,6 @@ from .text import TextLoggerHook
 from .wandb import WandbLoggerHook
 
 __all__ = [
-    'LoggerHook', 'MlflowLoggerHook', 'PaviLoggerHook', 'TensorboardLoggerHook', 'TextLoggerHook',
-    'WandbLoggerHook'
+    'LoggerHook', 'MlflowLoggerHook', 'PaviLoggerHook',
+    'TensorboardLoggerHook', 'TextLoggerHook', 'WandbLoggerHook'
 ]

--- a/mmcv/runner/hooks/logger/__init__.py
+++ b/mmcv/runner/hooks/logger/__init__.py
@@ -1,12 +1,12 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 from .base import LoggerHook
-from .mlflow import MLflowLoggerHook
+from .mlflow import MlflowLoggerHook
 from .pavi import PaviLoggerHook
 from .tensorboard import TensorboardLoggerHook
 from .text import TextLoggerHook
 from .wandb import WandbLoggerHook
 
 __all__ = [
-    'LoggerHook', 'MLflowLoggerHook', 'PaviLoggerHook', 'TensorboardLoggerHook', 'TextLoggerHook',
+    'LoggerHook', 'MlflowLoggerHook', 'PaviLoggerHook', 'TensorboardLoggerHook', 'TextLoggerHook',
     'WandbLoggerHook'
 ]

--- a/mmcv/runner/hooks/logger/__init__.py
+++ b/mmcv/runner/hooks/logger/__init__.py
@@ -1,11 +1,12 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 from .base import LoggerHook
+from .mlflow import MLflowLoggerHook
 from .pavi import PaviLoggerHook
 from .tensorboard import TensorboardLoggerHook
 from .text import TextLoggerHook
 from .wandb import WandbLoggerHook
 
 __all__ = [
-    'LoggerHook', 'PaviLoggerHook', 'TensorboardLoggerHook', 'TextLoggerHook',
+    'LoggerHook', 'MLflowLoggerHook', 'PaviLoggerHook', 'TensorboardLoggerHook', 'TextLoggerHook',
     'WandbLoggerHook'
 ]

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -7,7 +7,7 @@ from .base import LoggerHook
 
 
 @HOOKS.register_module
-class MLflowLoggerHook(LoggerHook):
+class MlflowLoggerHook(LoggerHook):
 
     def __init__(self,
                  experiment_name,
@@ -17,10 +17,10 @@ class MLflowLoggerHook(LoggerHook):
                  interval=10,
                  ignore_last=True,
                  reset_flag=True):
-        super(MLflowLoggerHook, self).__init__(interval, ignore_last,
+        super(MlflowLoggerHook, self).__init__(interval, ignore_last,
                                               reset_flag)
         self.import_mlflow()
-        self._mlflow_client  = self.mlflow.MLflowClient(tracking_uri)
+        self._mlflow_client  = self.mlflow.MlflowClient(tracking_uri)
         self.experiment_name = experiment_name
         self.tags = tags
         self.log_model = log_model

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -20,7 +20,7 @@ class MlflowLoggerHook(LoggerHook):
         super(MlflowLoggerHook, self).__init__(interval, ignore_last,
                                               reset_flag)
         self.import_mlflow()
-        self._mlflow_client  = self.mlflow.MlflowClient(tracking_uri)
+        self._mlflow_client = self.mlflow.tracking.MlflowClient(tracking_uri)
         self.experiment_name = experiment_name
         self.tags = tags
         self.log_model = log_model

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -48,13 +48,11 @@ class MlflowLoggerHook(LoggerHook):
 
     @master_only
     def log(self, runner):
-        metrics = {}
         for var, val in runner.log_buffer.output.items():
             if var in ['time', 'data_time']:
                 continue
             tag = '{}/{}'.format(var, runner.mode)
-            metrics[tag] = val
-            self._mlflow_client.log_metric(self._run_id, step=runner.iter)
+            self._mlflow_client.log_metric(self._run_id, tag, val, step=runner.iter)
 
     @master_only
     def after_run(self, runner):

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -1,6 +1,4 @@
 # Copyright (c) Open-MMLab. All rights reserved.
-import numbers
-
 from mmcv.runner import master_only
 from ..hook import HOOKS
 from .base import LoggerHook
@@ -11,13 +9,34 @@ class MlflowLoggerHook(LoggerHook):
 
     def __init__(self,
                  experiment_name=None,
-                 tags = None,
+                 tags=None,
                  log_model=True,
                  interval=10,
                  ignore_last=True,
                  reset_flag=True):
+        """Class to log metrics and (optionally) a trained model to MLflow.
+
+        It requires `MLflow`_ to be installed.
+
+        Args:
+            experiment_name (str, optional): Name of the experiment to be used.
+                Default None.
+                If not None, set the active experiment.
+                If experiment does not exist, an experiment with provided name
+                will be created.
+            tags (dict of str: str, optional): Tags for the current run.
+                Default None.
+                If not None, set tags for the current run.
+            log_model (bool, optional): Wheter to log an MLflow artifact.
+                Default True.
+                If True, log runner.model as an MLflow artifact
+                for the current run.
+
+        .. _MLflow:
+            https://www.mlflow.org/docs/latest/index.html
+        """
         super(MlflowLoggerHook, self).__init__(interval, ignore_last,
-                                              reset_flag)
+                                               reset_flag)
         self.import_mlflow()
         self.experiment_name = experiment_name
         self.tags = tags
@@ -37,6 +56,8 @@ class MlflowLoggerHook(LoggerHook):
     def before_run(self, runner):
         if self.experiment_name is not None:
             self.mlflow.set_experiment(self.experiment_name)
+        if self.tags is not None:
+            self.mlflow.set_tags(self.tags)
 
     @master_only
     def log(self, runner):
@@ -51,4 +72,4 @@ class MlflowLoggerHook(LoggerHook):
     @master_only
     def after_run(self, runner):
         if self.log_model:
-            self.mlflow_pytorch.log_model(runner.model, "models")
+            self.mlflow_pytorch.log_model(runner.model, 'models')

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -1,0 +1,63 @@
+# Copyright (c) Open-MMLab. All rights reserved.
+import numbers
+
+from mmcv.runner import master_only
+from ..hook import HOOKS
+from .base import LoggerHook
+
+
+@HOOKS.register_module
+class MLflowLoggerHook(LoggerHook):
+
+    def __init__(self,
+                 experiment_name,
+                 tracking_uri = None,
+                 tags = None,
+                 log_model=True,
+                 interval=10,
+                 ignore_last=True,
+                 reset_flag=True):
+        super(MLflowLoggerHook, self).__init__(interval, ignore_last,
+                                              reset_flag)
+        self.import_mlflow()
+        self._mlflow_client  = self.mlflow.MLflowClient(tracking_uri)
+        self.experiment_name = experiment_name
+        self.tags = tags
+        self.log_model = log_model
+
+    def import_mlflow(self):
+        try:
+            import mlflow
+        except ImportError:
+            raise ImportError(
+                'Please run "pip install mlflow" to install mlflow')
+        self.mlflow = mlflow
+
+    @master_only
+    def before_run(self, runner):
+        experiment = self._mlflow_client.get_experiment_by_name(self.experiment_name)
+        if experiment:
+            self._experiment_id = experiment.experiment_id
+        else:
+            runner.logger.warning(f'Experiment with name {self.experiment_name} not found. Creating it.')
+            self._experiment_id = self._mlflow_client.create_experiment(name=self.experiment_name)
+        
+        run = self._mlflow_client.create_run(experiment_id=self._experiment_id, tags=self.tags)
+        
+        self._run_id = run.info.run_id
+
+    @master_only
+    def log(self, runner):
+        metrics = {}
+        for var, val in runner.log_buffer.output.items():
+            if var in ['time', 'data_time']:
+                continue
+            tag = '{}/{}'.format(var, runner.mode)
+            metrics[tag] = val
+            self._mlflow_client.log_metric(self._run_id, step=runner.iter)
+
+    @master_only
+    def after_run(self, runner):
+        if self.log_model:
+            self.mlflow.pytorch.log_model(runner.model, "models")
+        self._mlflow_client.set_terminated(self._run_id)

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -44,8 +44,8 @@ class MlflowLoggerHook(LoggerHook):
             runner.logger.warning(f'Experiment with name {self.experiment_name} not found. Creating it.')
             self._experiment_id = self._mlflow_client.create_experiment(name=self.experiment_name)
 
-        if mlflow.active_run():
-            run = self._mlflow_client.get_run(mlflow.active_run())
+        if self.mlflow.active_run():
+            run = self._mlflow_client.get_run(self.mlflow.active_run())
         else:
             run = self._mlflow_client.create_run(experiment_id=self._experiment_id, tags=self.tags)
         

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -36,7 +36,7 @@ class MlflowLoggerHook(LoggerHook):
     @master_only
     def before_run(self, runner):
         if self.experiment_name is not None:
-            self.mlflow.set_experiment(experiment_name)
+            self.mlflow.set_experiment(self.experiment_name)
 
     @master_only
     def log(self, runner):

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -10,7 +10,7 @@ from .base import LoggerHook
 class MlflowLoggerHook(LoggerHook):
 
     def __init__(self,
-                 experiment_name=None,
+                 exp_name=None,
                  tags=None,
                  log_model=True,
                  interval=10,
@@ -21,7 +21,7 @@ class MlflowLoggerHook(LoggerHook):
         It requires `MLflow`_ to be installed.
 
         Args:
-            experiment_name (str, optional): Name of the experiment to be used.
+            exp_name (str, optional): Name of the experiment to be used.
                 Default None.
                 If not None, set the active experiment.
                 If experiment does not exist, an experiment with provided name
@@ -40,7 +40,7 @@ class MlflowLoggerHook(LoggerHook):
         super(MlflowLoggerHook, self).__init__(interval, ignore_last,
                                                reset_flag)
         self.import_mlflow()
-        self.experiment_name = experiment_name
+        self.exp_name = exp_name
         self.tags = tags
         self.log_model = log_model
 
@@ -56,8 +56,8 @@ class MlflowLoggerHook(LoggerHook):
 
     @master_only
     def before_run(self, runner):
-        if self.experiment_name is not None:
-            self.mlflow.set_experiment(self.experiment_name)
+        if self.exp_name is not None:
+            self.mlflow.set_experiment(self.exp_name)
         if self.tags is not None:
             self.mlflow.set_tags(self.tags)
 

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -10,8 +10,7 @@ from .base import LoggerHook
 class MlflowLoggerHook(LoggerHook):
 
     def __init__(self,
-                 experiment_name,
-                 tracking_uri = None,
+                 experiment_name=None,
                  tags = None,
                  log_model=True,
                  interval=10,
@@ -20,7 +19,6 @@ class MlflowLoggerHook(LoggerHook):
         super(MlflowLoggerHook, self).__init__(interval, ignore_last,
                                               reset_flag)
         self.import_mlflow()
-        self._mlflow_client = self.mlflow.tracking.MlflowClient(tracking_uri)
         self.experiment_name = experiment_name
         self.tags = tags
         self.log_model = log_model
@@ -37,30 +35,20 @@ class MlflowLoggerHook(LoggerHook):
 
     @master_only
     def before_run(self, runner):
-        experiment = self._mlflow_client.get_experiment_by_name(self.experiment_name)
-        if experiment:
-            self._experiment_id = experiment.experiment_id
-        else:
-            runner.logger.warning(f'Experiment with name {self.experiment_name} not found. Creating it.')
-            self._experiment_id = self._mlflow_client.create_experiment(name=self.experiment_name)
-
-        if self.mlflow.active_run():
-            run = self._mlflow_client.get_run(self.mlflow.active_run())
-        else:
-            run = self._mlflow_client.create_run(experiment_id=self._experiment_id, tags=self.tags)
-        
-        self._run_id = run.info.run_id
+        if self.experiment_name is not None:
+            self.mlflow.set_experiment(experiment_name)
 
     @master_only
     def log(self, runner):
+        metrics = {}
         for var, val in runner.log_buffer.output.items():
             if var in ['time', 'data_time']:
                 continue
             tag = '{}/{}'.format(var, runner.mode)
-            self._mlflow_client.log_metric(self._run_id, tag, val, step=runner.iter)
+            metrics[tag] = val
+        self.mlflow.log_metrics(metrics, step=runner.iter)
 
     @master_only
     def after_run(self, runner):
         if self.log_model:
             self.mlflow_pytorch.log_model(runner.model, "models")
-        self._mlflow_client.set_terminated(self._run_id)

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -28,10 +28,12 @@ class MlflowLoggerHook(LoggerHook):
     def import_mlflow(self):
         try:
             import mlflow
+            import mlflow.pytorch as mlflow_pytorch
         except ImportError:
             raise ImportError(
                 'Please run "pip install mlflow" to install mlflow')
         self.mlflow = mlflow
+        self.mlflow_pytorch = mlflow_pytorch
 
     @master_only
     def before_run(self, runner):
@@ -57,5 +59,5 @@ class MlflowLoggerHook(LoggerHook):
     @master_only
     def after_run(self, runner):
         if self.log_model:
-            self.mlflow.pytorch.log_model(runner.model, "models")
+            self.mlflow_pytorch.log_model(runner.model, "models")
         self._mlflow_client.set_terminated(self._run_id)

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -1,4 +1,6 @@
 # Copyright (c) Open-MMLab. All rights reserved.
+import numbers
+
 from mmcv.runner import master_only
 from ..hook import HOOKS
 from .base import LoggerHook
@@ -66,7 +68,8 @@ class MlflowLoggerHook(LoggerHook):
             if var in ['time', 'data_time']:
                 continue
             tag = '{}/{}'.format(var, runner.mode)
-            metrics[tag] = val
+            if isinstance(val, numbers.Number):
+                metrics[tag] = val
         self.mlflow.log_metrics(metrics, step=runner.iter)
 
     @master_only

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -43,8 +43,11 @@ class MlflowLoggerHook(LoggerHook):
         else:
             runner.logger.warning(f'Experiment with name {self.experiment_name} not found. Creating it.')
             self._experiment_id = self._mlflow_client.create_experiment(name=self.experiment_name)
-        
-        run = self._mlflow_client.create_run(experiment_id=self._experiment_id, tags=self.tags)
+
+        if mlflow.active_run():
+            run = self._mlflow_client.get_run(mlflow.active_run())
+        else:
+            run = self._mlflow_client.create_run(experiment_id=self._experiment_id, tags=self.tags)
         
         self._run_id = run.info.run_id
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -50,7 +50,7 @@ def test_pavi_hook():
 
 
 @only_if_torch_available
-@pytest.mark.parametrize('log_model')
+@pytest.mark.parametrize('log_model', (True, False))
 def test_mlflow_hook(log_model):
     sys.modules['mlflow'] = MagicMock()
     sys.modules['mlflow.pytorch'] = MagicMock()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -84,6 +84,8 @@ def test_mlflow_hook(log_model):
 
 @only_if_torch_available
 def test_wandb_hook():
+    sys.modules['wandb'] = MagicMock()
+
     hook = mmcv.runner.hooks.WandbLoggerHook()
     loader = DataLoader(torch.ones((5, 5)))
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -63,8 +63,7 @@ def test_mlflow_hook(log_model):
         work_dir=work_dir,
         batch_processor=lambda model, x, **kwargs: {
             'log_vars': {
-                'accuracy': 0.98,
-                'NotLoggable': 'FOO BAR'
+                'accuracy': 0.98
             },
             'num_samples': 5
         })

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -52,6 +52,7 @@ def test_pavi_hook():
 @only_if_torch_available
 def test_mlflow_hook():
     sys.modules['mlflow'] = MagicMock()
+    sys.modules['mlflow.pytorch'] = MagicMock()
 
     model = nn.Linear(1, 1)
     loader = DataLoader(torch.ones((5, 5)))

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -11,13 +11,12 @@ try:
     import torch
     import torch.nn as nn
     from torch.utils.data import DataLoader
-    torch_available = True
 except ImportError:
     warnings.warn('torch is not available')
-    torch_available = False
+    torch = None
 
 only_if_torch_available = pytest.mark.skipif(
-    torch_available, reason='torch is not available')
+    torch is None, reason='torch is not available')
 
 
 @only_if_torch_available

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -63,7 +63,8 @@ def test_mlflow_hook(log_model):
         work_dir=work_dir,
         batch_processor=lambda model, x, **kwargs: {
             'log_vars': {
-                'accuracy': 0.98
+                'accuracy': 0.98,
+                'NotLoggable': 'FOO BAR'
             },
             'num_samples': 5
         })

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,25 +1,15 @@
 import os.path as osp
 import sys
-import warnings
 from unittest.mock import MagicMock
 
 import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
 
 import mmcv.runner
 
-try:
-    import torch
-    import torch.nn as nn
-    from torch.utils.data import DataLoader
-except ImportError:
-    warnings.warn('torch is not available')
-    torch = None
 
-only_if_torch_available = pytest.mark.skipif(
-    torch is None, reason='torch is not available')
-
-
-@only_if_torch_available
 def test_pavi_hook():
     sys.modules['pavi'] = MagicMock()
 
@@ -49,7 +39,6 @@ def test_pavi_hook():
         iteration=5)
 
 
-@only_if_torch_available
 @pytest.mark.parametrize('log_model', (True, False))
 def test_mlflow_hook(log_model):
     sys.modules['mlflow'] = MagicMock()
@@ -69,7 +58,7 @@ def test_mlflow_hook(log_model):
         })
 
     hook = mmcv.runner.hooks.MlflowLoggerHook(
-        experiment_name='test', log_model=log_model)
+        exp_name='test', log_model=log_model)
     runner.register_hook(hook)
     runner.run([loader, loader], [('train', 1), ('val', 1)], 1)
 
@@ -82,7 +71,6 @@ def test_mlflow_hook(log_model):
         assert not hook.mlflow_pytorch.log_model.called
 
 
-@only_if_torch_available
 def test_wandb_hook():
     sys.modules['wandb'] = MagicMock()
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,11 +1,7 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 import os.path as osp
-import sys
 import tempfile
 import warnings
-from unittest.mock import MagicMock
-
-sys.modules['wandb'] = MagicMock()
 
 
 def test_save_checkpoint():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -32,32 +32,3 @@ def test_save_checkpoint():
         assert osp.realpath(latest_path) == osp.realpath(epoch1_path)
 
         torch.load(latest_path)
-
-
-def test_wandb_hook():
-    try:
-        import torch
-        import torch.nn as nn
-        from torch.utils.data import DataLoader
-    except ImportError:
-        warnings.warn('Skipping test_save_checkpoint in the absense of torch')
-        return
-
-    import mmcv.runner
-    hook = mmcv.runner.hooks.WandbLoggerHook()
-    loader = DataLoader(torch.ones((5, 5)))
-
-    model = nn.Linear(1, 1)
-    runner = mmcv.runner.Runner(
-        model=model,
-        batch_processor=lambda model, x, **kwargs: {
-            'log_vars': {
-                'accuracy': 0.98
-            },
-            'num_samples': 5
-        })
-    runner.register_hook(hook)
-    runner.run([loader, loader], [('train', 1), ('val', 1)], 1)
-    hook.wandb.init.assert_called_with()
-    hook.wandb.log.assert_called_with({'accuracy/val': 0.98}, step=5)
-    hook.wandb.join.assert_called_with()


### PR DESCRIPTION
This P.R. adds a new class to `mmcv.runner.hooks.logger` for logging metrics and (optionally) a trained model to [MLflow](https://www.mlflow.org/docs/latest/index.html); similar to existing options for pavi, wandb or tensorboard.

An unit test following the existing ones is included.

The `wandb` unit test has been moved from `test_runner `to `test_hooks`.