### PR TITLE
Support specifying names for registry.register_module()

### DIFF
--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -1,4 +1,5 @@
 import inspect
+import warnings
 from functools import partial
 
 from .misc import is_str
@@ -24,7 +25,7 @@ class Registry(object):
     def __repr__(self):
         format_str = self.__class__.__name__ + \
                      f'(name={self._name}, ' \
-                     f'items={list(self._module_dict.keys())})'
+                     f'items={self._module_dict})'
         return format_str
 
     @property
@@ -46,44 +47,81 @@ class Registry(object):
         """
         return self._module_dict.get(key, None)
 
-    def _register_module(self, module_class, force=False):
+    def _register_module(self, module_class, module_name=None, force=False):
         if not inspect.isclass(module_class):
             raise TypeError('module must be a class, '
                             f'but got {type(module_class)}')
-        module_name = module_class.__name__
+        if not (module_name is None or isinstance(module_name, str)):
+            raise TypeError('module_name must be a str, '
+                            f'but got {type(module_name)}')
+        if module_name is None:
+            module_name = module_class.__name__
         if not force and module_name in self._module_dict:
             raise KeyError(f'{module_name} is already registered '
                            f'in {self.name}')
         self._module_dict[module_name] = module_class
 
-    def register_module(self, cls=None, force=False):
+    def deprecated_register_module(self, cls=None, force=False):
+        warnings.warn(
+            'The old API of register_module(module, force=False) '
+            'is deprecated and will be removed, please use the new API '
+            'register_module(name=None, force=False, module=None) instead.',
+            DeprecationWarning)
+        if cls is None:
+            return partial(self.deprecated_register_module, force=force)
+        self._register_module(cls, force=force)
+        return cls
+
+    def register_module(self, name=None, force=False, module=None):
         """Register a module.
 
         A record will be added to `self._module_dict`, whose key is the class
-        name and value is the class itself.
+        name or the specified name, and value is the class itself.
         It can be used as a decorator or a normal function.
 
         Example:
             >>> backbones = Registry('backbone')
-            >>> @backbones.register_module
-            >>> class ResNet(object):
+            >>> @backbones.register_module()
+            >>> class ResNet:
             >>>     pass
 
-        Example:
             >>> backbones = Registry('backbone')
-            >>> class ResNet(object):
+            >>> @backbones.register_module(name='mnet')
+            >>> class MobileNet:
+            >>>     pass
+
+            >>> backbones = Registry('backbone')
+            >>> class ResNet:
             >>>     pass
             >>> backbones.register_module(ResNet)
 
         Args:
-            module (:obj:`nn.Module`): Module to be registered.
+            cls (type): Module class to be registered.
+            name (str | None): The module name to be registered. If not
+                specified, the class name will be used.
             force (bool, optional): Whether to override an existing class with
                 the same name. Default: False.
         """
-        if cls is None:
-            return partial(self.register_module, force=force)
-        self._register_module(cls, force=force)
-        return cls
+        # NOTE: This is a walkaround to be compatible with the old api,
+        # while it may introduce unexpected bugs.
+        if isinstance(name, type):
+            return self.deprecated_register_module(name, force=force)
+
+        # use it as a normal method: x.register_module(module=SomeClass)
+        if module is not None:
+            self._register_module(module, name, force=force)
+            return
+
+        # raise the error ahead of time
+        if not (name is None or isinstance(name, str)):
+            raise TypeError(f'name must be a str, but got {type(name)}')
+
+        # use it as a decorator: @x.register_module()
+        def _register(cls):
+            self._register_module(
+                module_class=cls, module_name=name, force=force)
+
+        return _register
 
 
 def build_from_cfg(cfg, registry, default_args=None):

--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -109,7 +109,8 @@ class Registry(object):
 
         # use it as a normal method: x.register_module(module=SomeClass)
         if module is not None:
-            self._register_module(module, name, force=force)
+            self._register_module(
+                module_class=module, module_name=name, force=force)
             return
 
         # raise the error ahead of time

--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -51,9 +51,7 @@ class Registry(object):
         if not inspect.isclass(module_class):
             raise TypeError('module must be a class, '
                             f'but got {type(module_class)}')
-        if not (module_name is None or isinstance(module_name, str)):
-            raise TypeError('module_name must be a str, '
-                            f'but got {type(module_name)}')
+
         if module_name is None:
             module_name = module_class.__name__
         if not force and module_name in self._module_dict:
@@ -96,11 +94,11 @@ class Registry(object):
             >>> backbones.register_module(ResNet)
 
         Args:
-            cls (type): Module class to be registered.
             name (str | None): The module name to be registered. If not
                 specified, the class name will be used.
             force (bool, optional): Whether to override an existing class with
                 the same name. Default: False.
+            module (type): Module class to be registered.
         """
         # NOTE: This is a walkaround to be compatible with the old api,
         # while it may introduce unexpected bugs.

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -73,6 +73,7 @@ def test_registry():
     with pytest.raises(TypeError):
         CATS.register_module(0)
 
+    # test old APIs
     with pytest.warns(DeprecationWarning):
         CATS.register_module(SphynxCat)
 


### PR DESCRIPTION
Old API:
```python
CATS = mmcv.Registry('cat')

@CATS.register_module
class BritishShorthair:
    pass
```

New API:
```python
CATS = mmcv.Registry('cat')

@CATS.register_module()
class BritishShorthair:
    pass

@CATS.register_module(name='CuteCat')
class Munchkin:
    pass
```