### PR TITLE
Fix deadlock if processes have different log_buffer.output

### DIFF
--- a/mmcv/runner/hooks/logger/text.py
+++ b/mmcv/runner/hooks/logger/text.py
@@ -98,13 +98,16 @@ class TextLoggerHook(LoggerHook):
         log_dict['iter'] = runner.inner_iter + 1
         # only record lr of the first param group
         log_dict['lr'] = runner.current_lr()[0]
+        memory = None
+        if torch.cuda.is_available():
+            memory = self._get_max_memory(runner)
         if mode == 'train':
             log_dict['time'] = runner.log_buffer.output['time']
             log_dict['data_time'] = runner.log_buffer.output['data_time']
 
             # statistic memory
-            if torch.cuda.is_available():
-                log_dict['memory'] = self._get_max_memory(runner)
+            if memory is not None:
+                log_dict['memory'] = memory
         for name, val in runner.log_buffer.output.items():
             if name in ['time', 'data_time']:
                 continue


### PR DESCRIPTION
This pull request fixes the deadlock issue if processes have different `log_buffer.output` when using `TextLoggerHook` in distributed mode. More specifically, if process 0 has called log_buffer.clear() while other processes have not, the process 0 will not call `_get_max_memory()` (which calls `torch.distributed.reduce()`) in `TextLoggerHook` while others will call. Thus, the synchronization between processes will be broken.