### PR TITLE
Save/load hooks meta

### DIFF
--- a/mmcv/runner/hooks/checkpoint.py
+++ b/mmcv/runner/hooks/checkpoint.py
@@ -21,7 +21,7 @@ class CheckpointHook(Hook):
         self.args = kwargs
 
     @master_only
-    def after_train_epoch(self, runner):
+    def after_epoch(self, runner):
         if not self.every_n_epochs(runner, self.interval):
             return
 

--- a/mmcv/runner/runner.py
+++ b/mmcv/runner/runner.py
@@ -260,6 +260,11 @@ class Runner(object):
         else:
             meta.update(epoch=self.epoch + 1, iter=self.iter)
 
+        for hook in self.hooks:
+            hook_meta = getattr(hook, 'meta', None)
+            if hook_meta:
+                meta['hooks'][hook.__class__.__name__] = hook_meta
+
         filename = filename_tmpl.format(self.epoch + 1)
         filepath = osp.join(out_dir, filename)
         optimizer = self.optimizer if save_optimizer else None
@@ -329,6 +334,13 @@ class Runner(object):
 
         self._epoch = checkpoint['meta']['epoch']
         self._iter = checkpoint['meta']['iter']
+
+        hooks_meta = checkpoint['meta'].get('hooks', {})
+        for hook in self.hooks:
+            name = hook.__class__.__name__
+            if name in hooks_meta:
+                hook.meta = hooks_meta[name]
+
         if 'optimizer' in checkpoint and resume_optimizer:
             self.optimizer.load_state_dict(checkpoint['optimizer'])
 


### PR DESCRIPTION
This PR is not final and just illustrates one possible way to resolve the issue and probably isn't generic enough.

Right now we can save meta information to the checkpoint, but we cannot extract it because of `Runner` discards it immediately after loading, this requires overriding the default `Runner` with a custom class to handle this situation.
Saving meta information is crucial in some situations (eg. when you want to save the best checkpoint and you want to resume training without saving hook information outside the checkpoint)

Here is example from current code. We have no way to get `checkoint['meta']` without overriding methods in `Runner` or we have to do double loading of checkpoint:

```python
    def resume(self,
               checkpoint,
               resume_optimizer=True,
               map_location='default'):
        if map_location == 'default':
            device_id = torch.cuda.current_device()
            checkpoint = self.load_checkpoint(
                checkpoint,
                map_location=lambda storage, loc: storage.cuda(device_id))
        else:
            checkpoint = self.load_checkpoint(
                checkpoint, map_location=map_location)

        self._epoch = checkpoint['meta']['epoch']
        self._iter = checkpoint['meta']['iter']
        if 'optimizer' in checkpoint and resume_optimizer:
            self.optimizer.load_state_dict(checkpoint['optimizer'])

        self.logger.info('resumed epoch %d, iter %d', self.epoch, self.iter)
```