### PR TITLE
Make Config.dump() output in original file

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -298,15 +298,13 @@ class Config(object):
             else:
                 with open(file, 'w') as f:
                     f.write(self.pretty_text)
-        elif self.filename.endswith(('.yml', '.yaml', '.json')):
+        else:
             import mmcv
             if file is None:
                 file_format = self.filename.split('.')[-1]
                 return mmcv.dump(cfg_dict, file_format=file_format)
             else:
                 mmcv.dump(cfg_dict, file)
-        else:
-            raise IOError('Only py/yml/yaml/json type are supported now!')
 
     def merge_from_dict(self, options):
         """Merge list into cfg_dict

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -1,5 +1,4 @@
 # Copyright (c) Open-MMLab. All rights reserved.
-import json
 import os.path as osp
 import shutil
 import sys
@@ -291,10 +290,23 @@ class Config(object):
     def __iter__(self):
         return iter(self._cfg_dict)
 
-    def dump(self):
-        cfg_dict = super(Config, self).__getattribute__('_cfg_dict')
-        format_text = json.dumps(cfg_dict, indent=2)
-        return format_text
+    def dump(self, file=None):
+        cfg_dict = super(Config, self).__getattribute__('_cfg_dict').to_dict()
+        if self.filename.endswith('.py'):
+            if file is None:
+                return self.pretty_text
+            else:
+                with open(file, 'w') as f:
+                    f.write(self.pretty_text)
+        elif self.filename.endswith(('.yml', '.yaml', '.json')):
+            import mmcv
+            if file is None:
+                file_format = self.filename.split('.')[-1]
+                return mmcv.dump(cfg_dict, file_format=file_format)
+            else:
+                mmcv.dump(cfg_dict, file)
+        else:
+            raise IOError('Only py/yml/yaml/json type are supported now!')
 
     def merge_from_dict(self, options):
         """Merge list into cfg_dict

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,10 +2,10 @@
 import argparse
 import json
 import os.path as osp
-import sys
 import tempfile
 
 import pytest
+import yaml
 
 from mmcv import Config, DictAction
 
@@ -21,18 +21,44 @@ def test_construct():
         Config([0, 1])
 
     cfg_dict = dict(item1=[1, 2], item2=dict(a=0), item3=True, item4='test')
-    format_text = json.dumps(cfg_dict, indent=2)
-    for filename in ['a.py', 'b.json', 'c.yaml']:
-        cfg_file = osp.join(osp.dirname(__file__), 'data/config', filename)
-        cfg = Config(cfg_dict, filename=cfg_file)
-        assert isinstance(cfg, Config)
-        assert cfg.filename == cfg_file
-        assert cfg.text == open(cfg_file, 'r').read()
-        if sys.version_info >= (3, 6):
-            assert cfg.dump() == format_text
-        else:
-            loaded = json.loads(cfg.dump())
-            assert set(loaded.keys()) == set(cfg_dict)
+    # test a.py
+    cfg_file = osp.join(osp.dirname(__file__), 'data/config/a.py')
+    cfg = Config(cfg_dict, filename=cfg_file)
+    assert isinstance(cfg, Config)
+    assert cfg.filename == cfg_file
+    assert cfg.text == open(cfg_file, 'r').read()
+    assert cfg.dump() == cfg.pretty_text
+    with tempfile.TemporaryDirectory() as temp_config_dir:
+        dump_file = osp.join(temp_config_dir, 'a.py')
+        cfg.dump(dump_file)
+        assert cfg.dump() == open(dump_file, 'r').read()
+        assert Config.fromfile(dump_file)
+
+    # test b.json
+    cfg_file = osp.join(osp.dirname(__file__), 'data/config/b.json')
+    cfg = Config(cfg_dict, filename=cfg_file)
+    assert isinstance(cfg, Config)
+    assert cfg.filename == cfg_file
+    assert cfg.text == open(cfg_file, 'r').read()
+    assert cfg.dump() == json.dumps(cfg_dict)
+    with tempfile.TemporaryDirectory() as temp_config_dir:
+        dump_file = osp.join(temp_config_dir, 'b.json')
+        cfg.dump(dump_file)
+        assert cfg.dump() == open(dump_file, 'r').read()
+        assert Config.fromfile(dump_file)
+
+    # test c.yaml
+    cfg_file = osp.join(osp.dirname(__file__), 'data/config/c.yaml')
+    cfg = Config(cfg_dict, filename=cfg_file)
+    assert isinstance(cfg, Config)
+    assert cfg.filename == cfg_file
+    assert cfg.text == open(cfg_file, 'r').read()
+    assert cfg.dump() == yaml.dump(cfg_dict)
+    with tempfile.TemporaryDirectory() as temp_config_dir:
+        dump_file = osp.join(temp_config_dir, 'c.yaml')
+        cfg.dump(dump_file)
+        assert cfg.dump() == open(dump_file, 'r').read()
+        assert Config.fromfile(dump_file)
 
 
 def test_fromfile():


### PR DESCRIPTION
This PR made `Config.dump()` output in original file format for different config type.  