### PR TITLE
Runner: add global before and after epoch hook callbacks

### DIFF
--- a/mmcv/runner/hooks/hook.py
+++ b/mmcv/runner/hooks/hook.py
@@ -24,6 +24,12 @@ class Hook(object):
     def after_iter(self, runner):
         pass
 
+    def true_before_epoch(self, runner):
+        pass
+
+    def true_after_epoch(self, runner):
+        pass
+
     def before_train_epoch(self, runner):
         self.before_epoch(runner)
 

--- a/mmcv/runner/runner.py
+++ b/mmcv/runner/runner.py
@@ -364,6 +364,7 @@ class Runner(object):
         self.call_hook('before_run')
 
         while self.epoch < max_epochs:
+            self.call_hook('true_before_epoch')
             for i, flow in enumerate(workflow):
                 mode, epochs = flow
                 if isinstance(mode, str):  # self.train()
@@ -381,6 +382,7 @@ class Runner(object):
                     if mode == 'train' and self.epoch >= max_epochs:
                         return
                     epoch_runner(data_loaders[i], **kwargs)
+            self.call_hook('true_after_epoch')
 
         time.sleep(1)  # wait for some hooks like loggers to finish
         self.call_hook('after_run')


### PR DESCRIPTION
Right now there are no **global** hook callbacks that run after and before an epoch.

`after_epoch` just callback that called after `after_train_epoch` and `after_val_epoch`.
Working on #271 I've realized that I want to implement two hooks: Checkpointer > BestCheckpointer

And get such order of hooks:
1. `BestCheckpointer.after_val_epoch` - compares current loss vs best loss across training and save flag for future + add meta information
2. `Checkpointer.after_epoch` - saves checkpoint with new meta information
3. `BestCheckpointer.after_epoch` - creates a symlink to file from step 2

I didn't find any ways to implement this behavior without introducing new hook's callbacks. 

Any thoughts on this?

PS. Probably we need to use a different name than `true_after_epoch` so I'm open for suggestions