### PR TITLE
fix building ConvModule with Tanh activation

### DIFF
--- a/mmcv/cnn/bricks/conv_module.py
+++ b/mmcv/cnn/bricks/conv_module.py
@@ -139,7 +139,9 @@ class ConvModule(nn.Module):
         # build activation layer
         if self.with_activation:
             act_cfg_ = act_cfg.copy()
-            act_cfg_.setdefault('inplace', inplace)
+            # nn.Tanh has no 'inplace' argument
+            if act_cfg_['type'] != 'Tanh':
+                act_cfg_.setdefault('inplace', inplace)
             self.activate = build_activation_layer(act_cfg_)
 
         # Use msra init by default

--- a/tests/test_cnn/test_conv_module.py
+++ b/tests/test_cnn/test_conv_module.py
@@ -117,6 +117,12 @@ def test_conv_module():
     output = conv(x)
     assert output.shape == (1, 8, 256, 256)
 
+    # tanh
+    conv = ConvModule(3, 8, 3, padding=1, act_cfg=dict(type='Tanh'))
+    assert isinstance(conv.activate, nn.Tanh)
+    output = conv(x)
+    assert output.shape == (1, 8, 256, 256)
+
 
 def test_bias():
     # bias: auto, without norm


### PR DESCRIPTION
When building `ConvModule` with activation function `nn.Tanh`, `inplace=True` is automatically added to `act_cfg`. However, `nn.Tanh` does not accept `inplace` argument.

This pull request fixes this by adding keyword `inplace` to `act_cfg` only when activation type is not `nn.Tanh`.