### PR TITLE
Fix deprecation warning collections.abc

### DIFF
--- a/mmcv/parallel/collate.py
+++ b/mmcv/parallel/collate.py
@@ -1,5 +1,6 @@
 # Copyright (c) Open-MMLab. All rights reserved.
-from collections.abc import Sequence, Mapping
+from collections.abc import Mapping, Sequence
+
 import torch
 import torch.nn.functional as F
 from torch.utils.data.dataloader import default_collate

--- a/mmcv/parallel/collate.py
+++ b/mmcv/parallel/collate.py
@@ -1,6 +1,5 @@
 # Copyright (c) Open-MMLab. All rights reserved.
-import collections
-
+from collections.abc import Sequence, Mapping
 import torch
 import torch.nn.functional as F
 from torch.utils.data.dataloader import default_collate
@@ -20,7 +19,7 @@ def collate(batch, samples_per_gpu=1):
     3. cpu_only = False, stack = False, e.g., gt bboxes
     """
 
-    if not isinstance(batch, collections.Sequence):
+    if not isinstance(batch, Sequence):
         raise TypeError(f'{batch.dtype} is not supported.')
 
     if isinstance(batch[0], DataContainer):
@@ -73,10 +72,10 @@ def collate(batch, samples_per_gpu=1):
                 stacked.append(
                     [sample.data for sample in batch[i:i + samples_per_gpu]])
         return DataContainer(stacked, batch[0].stack, batch[0].padding_value)
-    elif isinstance(batch[0], collections.Sequence):
+    elif isinstance(batch[0], Sequence):
         transposed = zip(*batch)
         return [collate(samples, samples_per_gpu) for samples in transposed]
-    elif isinstance(batch[0], collections.Mapping):
+    elif isinstance(batch[0], Mapping):
         return {
             key: collate([d[key] for d in batch], samples_per_gpu)
             for key in batch[0]


### PR DESCRIPTION
## Description
You are probably aware, but when training I am getting a few deprecation warnings:
`mmcv/mmcv/parallel/collate.py:23: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working`

These imports should be updated:
https://docs.python.org/3.8/library/collections.abc.html#collections.abc.Sequence

The note in 3.7 docs:

> Changed in version 3.3: Moved Collections Abstract Base Classes to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.7. Subsequently, they will be removed entirely.