### PR TITLE
Use parrots wrapper in optimizer constructor

### DIFF
--- a/mmcv/runner/optimizer/default_constructor.py
+++ b/mmcv/runner/optimizer/default_constructor.py
@@ -2,10 +2,8 @@ import warnings
 
 import torch
 from torch.nn import GroupNorm, LayerNorm
-from torch.nn.modules.batchnorm import _BatchNorm
-from torch.nn.modules.instancenorm import _InstanceNorm
 
-from mmcv.utils import build_from_cfg, is_list_of
+from mmcv.utils import _BatchNorm, _InstanceNorm, build_from_cfg, is_list_of
 from .builder import OPTIMIZER_BUILDERS, OPTIMIZERS
 
 


### PR DESCRIPTION
This pull request changes the import source of `_BatchNorm` and `_InstanceNorm` in default_constructor.py from torch to mmcv.utils.parrots_wrapper.py.