### PR TITLE
Add grad norm to the logger

### DIFF
--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -14,11 +14,15 @@ class OptimizerHook(Hook):
         params = list(
             filter(lambda p: p.requires_grad and p.grad is not None, params))
         if len(params) > 0:
-            clip_grad.clip_grad_norm_(params, **self.grad_clip)
+            return clip_grad.clip_grad_norm_(params, **self.grad_clip)
 
     def after_train_iter(self, runner):
         runner.optimizer.zero_grad()
         runner.outputs['loss'].backward()
         if self.grad_clip is not None:
-            self.clip_grads(runner.model.parameters())
+            grad_norm = self.clip_grads(runner.model.parameters())
+            if grad_norm is not None:
+                # Add grad norm to the logger
+                runner.log_buffer.update({'grad_norm': grad_norm},
+                                         runner.outputs['num_samples'])
         runner.optimizer.step()


### PR DESCRIPTION
If the users specify grad_clip in the config, it's better to monitor the grad_norm so that one can judge if the training is stable or not from the grad_norm. 