### PR TITLE
Remove more unused things

### DIFF
--- a/mmcv/cnn/resnet.py
+++ b/mmcv/cnn/resnet.py
@@ -32,6 +32,7 @@ class BasicBlock(nn.Module):
                  style='pytorch',
                  with_cp=False):
         super(BasicBlock, self).__init__()
+        assert style in ['pytorch', 'caffe']
         self.conv1 = conv3x3(inplanes, planes, stride, dilation)
         self.bn1 = nn.BatchNorm2d(planes)
         self.relu = nn.ReLU(inplace=True)
@@ -171,7 +172,7 @@ def make_res_layer(block,
             style=style,
             with_cp=with_cp))
     inplanes = planes * block.expansion
-    for i in range(1, blocks):
+    for _ in range(1, blocks):
         layers.append(
             block(inplanes, planes, 1, dilation, style=style, with_cp=with_cp))
 

--- a/mmcv/cnn/vgg.py
+++ b/mmcv/cnn/vgg.py
@@ -141,7 +141,7 @@ class VGG(nn.Module):
     def forward(self, x):
         outs = []
         vgg_layers = getattr(self, self.module_name)
-        for i, num_blocks in enumerate(self.stage_blocks):
+        for i in range(len(self.stage_blocks)):
             for j in range(*self.range_sub_modules[i]):
                 vgg_layer = vgg_layers[j]
                 x = vgg_layer(x)

--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -33,7 +33,7 @@ def _init_dist_mpi(backend, **kwargs):
     raise NotImplementedError
 
 
-def _init_dist_slurm(backend, port=29500, **kwargs):
+def _init_dist_slurm(backend, port=29500):
     proc_id = int(os.environ['SLURM_PROCID'])
     ntasks = int(os.environ['SLURM_NTASKS'])
     node_list = os.environ['SLURM_NODELIST']

--- a/mmcv/runner/hooks/momentum_updater.py
+++ b/mmcv/runner/hooks/momentum_updater.py
@@ -8,8 +8,7 @@ class MomentumUpdaterHook(Hook):
                  by_epoch=True,
                  warmup=None,
                  warmup_iters=0,
-                 warmup_ratio=0.9,
-                 **kwargs):
+                 warmup_ratio=0.9):
         # validate the "warmup" argument
         if warmup is not None:
             if warmup not in ['constant', 'linear', 'exp']:

--- a/mmcv/utils/progressbar.py
+++ b/mmcv/utils/progressbar.py
@@ -175,7 +175,7 @@ def track_parallel_progress(func,
     return results
 
 
-def track_iter_progress(tasks, bar_width=50, file=sys.stdout, **kwargs):
+def track_iter_progress(tasks, bar_width=50, file=sys.stdout):
     """Track the progress of tasks iteration or enumeration with a progress bar.
 
     Tasks are yielded with a simple for-loop.

--- a/mmcv/video/processing.py
+++ b/mmcv/video/processing.py
@@ -58,8 +58,7 @@ def resize_video(in_file,
                  ratio=None,
                  keep_ar=False,
                  log_level='info',
-                 print_cmd=False,
-                 **kwargs):
+                 print_cmd=False):
     """Resize a video.
 
     Args:
@@ -98,8 +97,7 @@ def cut_video(in_file,
               vcodec=None,
               acodec=None,
               log_level='info',
-              print_cmd=False,
-              **kwargs):
+              print_cmd=False):
     """Cut a clip from a video.
 
     Args:
@@ -132,8 +130,7 @@ def concat_video(video_list,
                  vcodec=None,
                  acodec=None,
                  log_level='info',
-                 print_cmd=False,
-                 **kwargs):
+                 print_cmd=False):
     """Concatenate multiple videos into a single one.
 
     Args:

--- a/tests/test_video/test_processing.py
+++ b/tests/test_video/test_processing.py
@@ -33,7 +33,8 @@ class TestVideoEditor:
 
     def test_resize_video(self):
         out_file = osp.join(tempfile.gettempdir(), '.mmcv_test.mp4')
-        mmcv.resize_video(self.video_path, out_file, (200, 100), quiet=True)
+        mmcv.resize_video(
+            self.video_path, out_file, (200, 100), log_level='panic')
         v = mmcv.VideoReader(out_file)
         assert v.resolution == (200, 100)
         os.remove(out_file)


### PR DESCRIPTION
```bash
$ pylint mmcv | grep unused
mmcv/video/processing.py:55:0: W0613: Unused argument 'kwargs' (unused-argument)
mmcv/video/processing.py:94:0: W0613: Unused argument 'kwargs' (unused-argument)
mmcv/video/processing.py:130:0: W0613: Unused argument 'kwargs' (unused-argument)
mmcv/cnn/weight_init.py:52:31: W0613: Unused argument 'bias' (unused-argument)
mmcv/cnn/resnet.py:32:17: W0613: Unused argument 'style' (unused-argument)
mmcv/cnn/resnet.py:174:8: W0612: Unused variable 'i' (unused-variable)
mmcv/cnn/vgg.py:144:15: W0612: Unused variable 'num_blocks' (unused-variable)
mmcv/utils/progressbar.py:178:0: W0613: Unused argument 'kwargs' (unused-argument)
mmcv/runner/dist_utils.py:36:0: W0613: Unused argument 'kwargs' (unused-argument)
mmcv/runner/hooks/momentum_updater.py:7:0: W0613: Unused argument 'kwargs' (unused-argument)
```