### PR TITLE
fix possible bugs brought by dumping grad_norm to the logger

### DIFF
--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -23,6 +23,6 @@ class OptimizerHook(Hook):
             grad_norm = self.clip_grads(runner.model.parameters())
             if grad_norm is not None:
                 # Add grad norm to the logger
-                runner.log_buffer.update({'grad_norm': grad_norm},
+                runner.log_buffer.update({'grad_norm': float(grad_norm)},
                                          runner.outputs['num_samples'])
         runner.optimizer.step()


### PR DESCRIPTION
In pytorch-1.4&pytorch-1.5 the returning value of `clip_grad_norm` is torch.Tensor (https://github.com/pytorch/pytorch/blob/4ff3872a2099993bf7e8c588f7182f3df777205b/torch/nn/utils/clip_grad.py#L30), whereas in previous versions the returning value is a itemized float value https://github.com/pytorch/pytorch/blob/6590ecf1c9d30c2cfa5dbc762ce03672275ac8af/torch/nn/utils/clip_grad.py#L33. This  PR helps fix this bug. 