### PR TITLE
Fix potential bug in DefaultOptimizerConstructor

### DIFF
--- a/mmcv/runner/optimizer/default_constructor.py
+++ b/mmcv/runner/optimizer/default_constructor.py
@@ -87,11 +87,15 @@ class DefaultOptimizerConstructor:
             raise TypeError('paramwise_cfg should be None or a dict, '
                             f'but got {type(self.paramwise_cfg)}')
 
-        if ('custom_keys' in self.paramwise_cfg
-                and not isinstance(self.paramwise_cfg['custom_keys'], dict)):
-            raise TypeError(
-                'If specified, custom_keys must be a dict, '
-                f'but got {type(self.paramwise_cfg["custom_keys"])}')
+        if 'custom_keys' in self.paramwise_cfg:
+            if not isinstance(self.paramwise_cfg['custom_keys'], dict):
+                raise TypeError(
+                    'If specified, custom_keys must be a dict, '
+                    f'but got {type(self.paramwise_cfg["custom_keys"])}')
+            for key in self.paramwise_cfg['custom_keys']:
+                if ('decay_mult' in self.paramwise_cfg['custom_keys'][key]
+                        and self.base_wd is None):
+                    raise ValueError('base_wd should not be None')
 
         # get base lr and weight decay
         # weight_decay must be explicitly specified if mult is specified

--- a/mmcv/runner/optimizer/default_constructor.py
+++ b/mmcv/runner/optimizer/default_constructor.py
@@ -154,11 +154,11 @@ class DefaultOptimizerConstructor:
             for key in sorted_keys:
                 if key in f'{prefix}.{name}':
                     is_custom = True
-                    param_group['lr'] = self.base_lr * custom_keys[key].get(
-                        'lr_mult', 1.)
-                    param_group[
-                        'weight_decay'] = self.base_wd * custom_keys[key].get(
-                            'decay_mult', 1.)
+                    lr_mult = custom_keys[key].get('lr_mult', 1.)
+                    param_group['lr'] = self.base_lr * lr_mult
+                    if self.base_wd is not None:
+                        decay_mult = custom_keys[key].get('decay_mult', 1.)
+                        param_group['weight_decay'] = self.base_wd * decay_mult
                     break
             if not is_custom:
                 # bias_lr_mult affects all bias parameters except for norm.bias

--- a/mmcv/runner/optimizer/default_constructor.py
+++ b/mmcv/runner/optimizer/default_constructor.py
@@ -92,10 +92,10 @@ class DefaultOptimizerConstructor:
                 raise TypeError(
                     'If specified, custom_keys must be a dict, '
                     f'but got {type(self.paramwise_cfg["custom_keys"])}')
-            for key in self.paramwise_cfg['custom_keys']:
-                if ('decay_mult' in self.paramwise_cfg['custom_keys'][key]
-                        and self.base_wd is None):
-                    raise ValueError('base_wd should not be None')
+            if self.base_wd is None:
+                for key in self.paramwise_cfg['custom_keys']:
+                    if 'decay_mult' in self.paramwise_cfg['custom_keys'][key]:
+                        raise ValueError('base_wd should not be None')
 
         # get base lr and weight decay
         # weight_decay must be explicitly specified if mult is specified

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -372,7 +372,16 @@ def test_default_optimizer_constructor():
         # custom_keys should be a dict
         paramwise_cfg_ = dict(custom_keys=[0.1, 0.0001])
         optim_constructor = DefaultOptimizerConstructor(
-            optim_constructor, paramwise_cfg_)
+            optimizer_cfg, paramwise_cfg_)
+        optimizer = optim_constructor(model)
+
+    with pytest.raises(ValueError):
+        # if 'decay_mult' is specified in custom_keys, weight_decay should be
+        # specified
+        optimizer_cfg_ = dict(type='SGD', lr=0.01)
+        paramwise_cfg_ = dict(custom_keys={'.backbone': dict(decay_mult=0.5)})
+        optim_constructor = DefaultOptimizerConstructor(
+            optimizer_cfg_, paramwise_cfg_)
         optimizer = optim_constructor(model)
 
     optim_constructor = DefaultOptimizerConstructor(optimizer_cfg,

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -455,7 +455,6 @@ def test_default_optimizer_constructor():
     groups = []
     group_settings = []
     # group 1, matches of 'param1'
-    # 'param1' is the longest match for 'sub.param1'
     groups.append(['param1', 'sub.param1'])
     group_settings.append({
         'lr': base_lr * 10,


### PR DESCRIPTION
It would throws a `TypeError` when `weight_decay` is not specified but `custom_keys` are specified in `paramwise_cfg`.