### PR TITLE
Remove all module wrapper's module when saving checkpoint

### DIFF
--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -257,7 +257,7 @@ def weights_to_cpu(state_dict):
 def _save_to_state_dict(module, destination, prefix, keep_vars):
     """Saves module state to `destination` dictionary.
 
-    This method is the same as :meth:`torch.nn.Module._save_to_state_dict`.
+    This method is modified from :meth:`torch.nn.Module._save_to_state_dict`.
 
     Args:
         module (nn.Module): The module to generate state_dict.
@@ -269,6 +269,7 @@ def _save_to_state_dict(module, destination, prefix, keep_vars):
         if param is not None:
             destination[prefix + name] = param if keep_vars else param.detach()
     for name, buf in module._buffers.items():
+        # remove check of _non_persistent_buffers_set to allow nn.BatchNorm2d
         if buf is not None:
             destination[prefix + name] = buf if keep_vars else buf.detach()
 

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -265,6 +265,7 @@ def state_dict(module, destination=None, prefix='', keep_vars=False):
         MMDistributedDataParallel or other registered module wrappers.
 
     Args:
+        module (nn.Module): The module to generate state_dict.
         destination (OrderedDict): Returned dict for the state of the
             module.
         prefix (str): Prefix of the key.

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -255,9 +255,7 @@ def weights_to_cpu(state_dict):
 
 
 def _save_to_state_dict(module, destination, prefix, keep_vars):
-    """Saves module state to `destination` dictionary, containing a state of
-    the module, but not its descendants. This is called on every submodule in
-    :meth:`~torch.nn.Module.state_dict`.
+    """Saves module state to `destination` dictionary.
 
     This method is modified from :meth:`torch.nn.Module._save_to_state_dict`.
 

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -261,15 +261,15 @@ def _save_to_state_dict(module, destination, prefix, keep_vars):
 
     Args:
         module (nn.Module): The module to generate state_dict.
-        destination (dict): a dict where state will be stored
-        prefix (str): the prefix for parameters and buffers used in this
-            module
+        destination (dict): A dict where state will be stored.
+        prefix (str): The prefix for parameters and buffers used in this
+            module.
     """
     for name, param in module._parameters.items():
         if param is not None:
             destination[prefix + name] = param if keep_vars else param.detach()
     for name, buf in module._buffers.items():
-        if buf is not None and name not in module._non_persistent_buffers_set:
+        if buf is not None:
             destination[prefix + name] = buf if keep_vars else buf.detach()
 
 

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -259,7 +259,7 @@ def _save_to_state_dict(module, destination, prefix, keep_vars):
 
     This method is modified from :meth:`torch.nn.Module._save_to_state_dict`.
 
-    Arguments:
+    Args:
         module (nn.Module): The module to generate state_dict.
         destination (dict): a dict where state will be stored
         prefix (str): the prefix for parameters and buffers used in this
@@ -279,9 +279,9 @@ def state_dict(module, destination=None, prefix='', keep_vars=False):
     Both parameters and persistent buffers (e.g. running averages) are
     included. Keys are corresponding parameter and buffer names.
 
-    This method is modified from :meth:`torch.nn.Module.state_dict`:
-    1. Support getting sub-module for MMDataParallel,
-        MMDistributedDataParallel or other registered module wrappers.
+    This method is modified from :meth:`torch.nn.Module.state_dict` to
+    recursively check parallel module in case that the model has a complicated
+    structure, e.g., nn.Module(nn.Module(DDP))
 
     Args:
         module (nn.Module): The module to generate state_dict.
@@ -294,7 +294,6 @@ def state_dict(module, destination=None, prefix='', keep_vars=False):
     Returns:
         dict: a dictionary containing a whole state of the module.
     """
-    # this is what we modified:
     # recursively check parallel module in case that the model has a
     # complicated structure, e.g., nn.Module(nn.Module(DDP))
     if is_module_wrapper(module):

--- a/tests/test_runner/test_checkpoint.py
+++ b/tests/test_runner/test_checkpoint.py
@@ -19,6 +19,7 @@ class Block(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv = nn.Conv2d(3, 3, 1)
+        self.norm = nn.BatchNorm2d(3)
 
 
 class Model(nn.Module):
@@ -34,46 +35,78 @@ def assert_tensor_equal(tensor_a, tensor_b):
 
 
 def test_get_state_dict():
+    state_dict_keys = set([
+        'block.conv.weight', 'block.conv.bias', 'block.norm.weight',
+        'block.norm.bias', 'block.norm.running_mean', 'block.norm.running_var',
+        'block.norm.num_batches_tracked', 'conv.weight', 'conv.bias'
+    ])
+
     model = Model()
     state_dict = get_state_dict(model)
     assert isinstance(state_dict, OrderedDict)
-    assert set(state_dict.keys()) == set(
-        ['block.conv.weight', 'block.conv.bias', 'conv.weight', 'conv.bias'])
+    assert set(state_dict.keys()) == state_dict_keys
 
     assert_tensor_equal(state_dict['block.conv.weight'],
-                        model.block.conv.weight.data)
-    assert_tensor_equal(state_dict['block.conv.bias'],
-                        model.block.conv.bias.data)
-    assert_tensor_equal(state_dict['conv.weight'], model.conv.weight.data)
-    assert_tensor_equal(state_dict['conv.bias'], model.conv.bias.data)
+                        model.block.conv.weight)
+    assert_tensor_equal(state_dict['block.conv.bias'], model.block.conv.bias)
+    assert_tensor_equal(state_dict['block.norm.weight'],
+                        model.block.norm.weight)
+    assert_tensor_equal(state_dict['block.norm.bias'], model.block.norm.bias)
+    assert_tensor_equal(state_dict['block.norm.running_mean'],
+                        model.block.norm.running_mean)
+    assert_tensor_equal(state_dict['block.norm.running_var'],
+                        model.block.norm.running_var)
+    assert_tensor_equal(state_dict['block.norm.num_batches_tracked'],
+                        model.block.norm.num_batches_tracked)
+    assert_tensor_equal(state_dict['conv.weight'], model.conv.weight)
+    assert_tensor_equal(state_dict['conv.bias'], model.conv.bias)
 
-    ddp_wrapped_model = DDPWrapper(model)
-    state_dict = get_state_dict(ddp_wrapped_model)
+    wrapped_model = DDPWrapper(model)
+    state_dict = get_state_dict(wrapped_model)
     assert isinstance(state_dict, OrderedDict)
-    assert set(state_dict.keys()) == set(
-        ['block.conv.weight', 'block.conv.bias', 'conv.weight', 'conv.bias'])
+    assert set(state_dict.keys()) == state_dict_keys
     assert_tensor_equal(state_dict['block.conv.weight'],
-                        ddp_wrapped_model.module.block.conv.weight.data)
+                        wrapped_model.module.block.conv.weight)
     assert_tensor_equal(state_dict['block.conv.bias'],
-                        ddp_wrapped_model.module.block.conv.bias.data)
+                        wrapped_model.module.block.conv.bias)
+    assert_tensor_equal(state_dict['block.norm.weight'],
+                        wrapped_model.module.block.norm.weight)
+    assert_tensor_equal(state_dict['block.norm.bias'],
+                        wrapped_model.module.block.norm.bias)
+    assert_tensor_equal(state_dict['block.norm.running_mean'],
+                        wrapped_model.module.block.norm.running_mean)
+    assert_tensor_equal(state_dict['block.norm.running_var'],
+                        wrapped_model.module.block.norm.running_var)
+    assert_tensor_equal(state_dict['block.norm.num_batches_tracked'],
+                        wrapped_model.module.block.norm.num_batches_tracked)
     assert_tensor_equal(state_dict['conv.weight'],
-                        ddp_wrapped_model.module.conv.weight.data)
+                        wrapped_model.module.conv.weight)
     assert_tensor_equal(state_dict['conv.bias'],
-                        ddp_wrapped_model.module.conv.bias.data)
+                        wrapped_model.module.conv.bias)
 
     # wrapped inner module
-    for name, module in ddp_wrapped_model.module._modules.items():
+    for name, module in wrapped_model.module._modules.items():
         module = DataParallel(module)
-        ddp_wrapped_model.module._modules[name] = module
-    state_dict = get_state_dict(ddp_wrapped_model)
+        wrapped_model.module._modules[name] = module
+    state_dict = get_state_dict(wrapped_model)
     assert isinstance(state_dict, OrderedDict)
-    assert set(state_dict.keys()) == set(
-        ['block.conv.weight', 'block.conv.bias', 'conv.weight', 'conv.bias'])
+    assert set(state_dict.keys()) == state_dict_keys
     assert_tensor_equal(state_dict['block.conv.weight'],
-                        ddp_wrapped_model.module.block.module.conv.weight.data)
+                        wrapped_model.module.block.module.conv.weight)
     assert_tensor_equal(state_dict['block.conv.bias'],
-                        ddp_wrapped_model.module.block.module.conv.bias.data)
+                        wrapped_model.module.block.module.conv.bias)
+    assert_tensor_equal(state_dict['block.norm.weight'],
+                        wrapped_model.module.block.module.norm.weight)
+    assert_tensor_equal(state_dict['block.norm.bias'],
+                        wrapped_model.module.block.module.norm.bias)
+    assert_tensor_equal(state_dict['block.norm.running_mean'],
+                        wrapped_model.module.block.module.norm.running_mean)
+    assert_tensor_equal(state_dict['block.norm.running_var'],
+                        wrapped_model.module.block.module.norm.running_var)
+    assert_tensor_equal(
+        state_dict['block.norm.num_batches_tracked'],
+        wrapped_model.module.block.module.norm.num_batches_tracked)
     assert_tensor_equal(state_dict['conv.weight'],
-                        ddp_wrapped_model.module.conv.module.weight.data)
+                        wrapped_model.module.conv.module.weight)
     assert_tensor_equal(state_dict['conv.bias'],
-                        ddp_wrapped_model.module.conv.module.bias.data)
+                        wrapped_model.module.conv.module.bias)

--- a/tests/test_runner/test_checkpoint.py
+++ b/tests/test_runner/test_checkpoint.py
@@ -1,0 +1,78 @@
+from collections import OrderedDict
+
+import torch.nn as nn
+
+from mmcv.parallel.registry import MODULE_WRAPPERS
+from mmcv.runner.checkpoint import get_state_dict
+
+
+@MODULE_WRAPPERS.register_module()
+class DDPWrapper(object):
+
+    def __init__(self, module):
+        self.module = module
+
+
+class Block(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 3, 1)
+
+
+class Model(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.block = Block()
+        self.conv = nn.Conv2d(3, 3, 1)
+
+
+def assert_tensor_equal(tensor_a, tensor_b):
+    assert tensor_a.eq(tensor_b).all()
+
+
+def test_get_state_dict():
+    model = Model()
+    state_dict = get_state_dict(model)
+    assert isinstance(state_dict, OrderedDict)
+    assert set(state_dict.keys()) == set(
+        ['block.conv.weight', 'block.conv.bias', 'conv.weight', 'conv.bias'])
+
+    assert_tensor_equal(state_dict['block.conv.weight'],
+                        model.block.conv.weight.data)
+    assert_tensor_equal(state_dict['block.conv.bias'],
+                        model.block.conv.bias.data)
+    assert_tensor_equal(state_dict['conv.weight'], model.conv.weight.data)
+    assert_tensor_equal(state_dict['conv.bias'], model.conv.bias.data)
+
+    ddp_wrapped_model = DDPWrapper(model)
+    state_dict = get_state_dict(ddp_wrapped_model)
+    assert isinstance(state_dict, OrderedDict)
+    assert set(state_dict.keys()) == set(
+        ['block.conv.weight', 'block.conv.bias', 'conv.weight', 'conv.bias'])
+    assert_tensor_equal(state_dict['block.conv.weight'],
+                        ddp_wrapped_model.module.block.conv.weight.data)
+    assert_tensor_equal(state_dict['block.conv.bias'],
+                        ddp_wrapped_model.module.block.conv.bias.data)
+    assert_tensor_equal(state_dict['conv.weight'],
+                        ddp_wrapped_model.module.conv.weight.data)
+    assert_tensor_equal(state_dict['conv.bias'],
+                        ddp_wrapped_model.module.conv.bias.data)
+
+    # wrapped inner module
+    for name, module in ddp_wrapped_model.module._modules.items():
+        module = DDPWrapper(module)
+        ddp_wrapped_model.module._modules[name] = module
+    state_dict = get_state_dict(ddp_wrapped_model)
+    assert isinstance(state_dict, OrderedDict)
+    assert set(state_dict.keys()) == set(
+        ['block.conv.weight', 'block.conv.bias', 'conv.weight', 'conv.bias'])
+    assert_tensor_equal(state_dict['block.conv.weight'],
+                        ddp_wrapped_model.module.block.module.conv.weight.data)
+    assert_tensor_equal(state_dict['block.conv.bias'],
+                        ddp_wrapped_model.module.block.module.conv.bias.data)
+    assert_tensor_equal(state_dict['conv.weight'],
+                        ddp_wrapped_model.module.conv.module.weight.data)
+    assert_tensor_equal(state_dict['conv.bias'],
+                        ddp_wrapped_model.module.conv.module.bias.data)

--- a/tests/test_runner/test_checkpoint.py
+++ b/tests/test_runner/test_checkpoint.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import torch.nn as nn
+from torch.nn.parallel import DataParallel
 
 from mmcv.parallel.registry import MODULE_WRAPPERS
 from mmcv.runner.checkpoint import get_state_dict
@@ -62,7 +63,7 @@ def test_get_state_dict():
 
     # wrapped inner module
     for name, module in ddp_wrapped_model.module._modules.items():
-        module = DDPWrapper(module)
+        module = DataParallel(module)
         ddp_wrapped_model.module._modules[name] = module
     state_dict = get_state_dict(ddp_wrapped_model)
     assert isinstance(state_dict, OrderedDict)


### PR DESCRIPTION
This merge request modifies the `mmcv.runner.checkpoint.save_checkpoint()`. Originally, the function only remove `module` of state_dict keys from the outer module wrapper. We modify the function to remove all the `module` of state_dict keys generated by module wrappers (even module wrapper is embedded within the model).