### PR TITLE
fix a bug in some opencv version

### DIFF
--- a/mmcv/visualization/image.py
+++ b/mmcv/visualization/image.py
@@ -122,7 +122,7 @@ def imshow_det_bboxes(img,
 
     bbox_color = color_val(bbox_color)
     text_color = color_val(text_color)
-
+    img = np.ascontiguousarray(img)
     for bbox, label in zip(bboxes, labels):
         bbox_int = bbox.astype(np.int32)
         left_top = (bbox_int[0], bbox_int[1])


### PR DESCRIPTION
in some version of opencv,
https://github.com/open-mmlab/mmcv/blob/2b876bc7a7066ca5941bda9e5841147dfcc5904a/mmcv/visualization/image.py#L130
will raise a error
`imshow_det_bboxes(
    img, left_top, right_bottom, bbox_color, thickness=thickness)
TypeError: an integer is required (got type tuple)`