### PR TITLE
[feat]add error log in config validate check

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -87,9 +87,9 @@ class Config:
             content = f.read()
         try:
             ast.parse(content)
-        except SyntaxError:
+        except SyntaxError as e:
             raise SyntaxError('There are syntax errors in config '
-                              f'file {filename}')
+                              f'file {filename}: {e}')
 
     @staticmethod
     def _substitute_predefined_vars(filename, temp_config_name):


### PR DESCRIPTION
modied mmcv/utils/config.py use print the error log when validate the syntax of config file, otherwise it is hard to debug for users.