### PR TITLE
Fix 'has no attribute' error when model is not wrapped by DDP

### DIFF
--- a/mmcv/runner/hooks/logger/text.py
+++ b/mmcv/runner/hooks/logger/text.py
@@ -50,7 +50,7 @@ class TextLoggerHook(LoggerHook):
             self._dump_log(runner.meta, runner)
 
     def _get_max_memory(self, runner):
-        device = runner.model.output_device
+        device = getattr(runner.model, 'output_device', None)
         mem = torch.cuda.max_memory_allocated(device=device)
         mem_mb = torch.tensor([mem / (1024 * 1024)],
                               dtype=torch.int,


### PR DESCRIPTION
This pull request fix `_get_max_memory` throw `has no attribute 'output_device'` error when model has no attribute `output_device`.

`output_device` is an attribute from DDP (DistributedDataParallel) module. If model passed to mmcv runners is not wrapped by DDP, it does not have 'output_device'. This  PR fix this by returning None if model has no attribute 'output_device'.