### PR TITLE
fix: close temp_config_file after creating it on windows.

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -4,6 +4,7 @@ import os.path as osp
 import re
 import shutil
 import sys
+import platform
 import tempfile
 from argparse import Action, ArgumentParser
 from collections import abc
@@ -120,6 +121,8 @@ class Config:
         with tempfile.TemporaryDirectory() as temp_config_dir:
             temp_config_file = tempfile.NamedTemporaryFile(
                 dir=temp_config_dir, suffix=fileExtname)
+            if platform.system() == "Windows":
+                temp_config_file.close()
             temp_config_name = osp.basename(temp_config_file.name)
             # Substitute predefined variables
             if use_predefined_variables:


### PR DESCRIPTION
`Traceback (most recent call last):
  File "D:/projects/mmsegmentation/tools/get_flops.py", line 56, in <module>
    main()
  File "D:/projects/mmsegmentation/tools/get_flops.py", line 33, in main
    cfg = Config.fromfile(args.config)
  File "d:\projects\mmcv\mmcv\utils\config.py", line 207, in fromfile
    use_predefined_variables)
  File "d:\projects\mmcv\mmcv\utils\config.py", line 130, in _file2dict
    temp_config_file.name)
  File "d:\projects\mmcv\mmcv\utils\config.py", line 110, in _substitute_predefined_vars
    with open(temp_config_name, 'w') as tmp_config_file:
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\xxxxxxxxxx\\AppData\\Local\\Temp\\tmpkzk7pd02\\tmpc7aaepmu.py'
`

**The solution** is to immediately close the temp config file after creating it on windows as in PR.
**The reason** is `tempfile.NamedTemporaryFile()` opened a temp file with `_io.open()` but actually not using it immediately. The later access to this temp file creates a permission problem on the Windows platform.
details in: https://www.jianshu.com/p/7fe2a663c29a
**To reproduce**: 
`python mmsegmentation\tools\get_flops.py mmsegmentation\configs\fcn\fcn_r50-d8_512x512_20k_voc12aug.py` (on windows)
