### PR TITLE
Add runner.meta to checkpoint in save_checkpoint()

### DIFF
--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -147,8 +147,13 @@ class EpochBasedRunner(BaseRunner):
         """
         if meta is None:
             meta = dict(epoch=self.epoch + 1, iter=self.iter)
-        else:
+        elif isinstance(meta, dict):
             meta.update(epoch=self.epoch + 1, iter=self.iter)
+        else:
+            raise TypeError(
+                f'meta should be a dict or None, but got {type(meta)}')
+        if self.meta is not None:
+            meta.update(self.meta)
 
         filename = filename_tmpl.format(self.epoch + 1)
         filepath = osp.join(out_dir, filename)

--- a/mmcv/runner/iter_based_runner.py
+++ b/mmcv/runner/iter_based_runner.py
@@ -183,7 +183,8 @@ class IterBasedRunner(BaseRunner):
         else:
             raise TypeError(
                 f'meta should be a dict or None, but got {type(meta)}')
-        meta.update(self.meta)
+        if self.meta is not None:
+            meta.update(self.meta)
 
         filename = filename_tmpl.format(self.iter + 1)
         filepath = osp.join(out_dir, filename)

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -131,6 +131,10 @@ def test_save_checkpoint():
     model = Model()
     runner = EpochBasedRunner(model=model, logger=logging.getLogger())
 
+    with pytest.raises(TypeError):
+        # meta should be None or dict
+        runner.save_checkpoint('.', meta=list())
+
     with tempfile.TemporaryDirectory() as root:
         runner.save_checkpoint(root)
 


### PR DESCRIPTION
This PR modifies:
* In `EpochBasedRunner`, if `runner.meta` is not None, add the meta to checkpoint's meta.
* In `IterBasedRunner`, fix `runner.save_checkpoint()` when `runner.meta is None`.