### PR TITLE
Assign `self.warmup_iters` in `before_run` function

### DIFF
--- a/mmcv/runner/hooks/lr_updater.py
+++ b/mmcv/runner/hooks/lr_updater.py
@@ -110,12 +110,13 @@ class LrUpdaterHook(Hook):
                 group['initial_lr'] for group in runner.optimizer.param_groups
             ]
 
-    def before_train_epoch(self, runner):
-        if not self.by_epoch:
-            return
         if self.warmup_by_epoch:
             epoch_len = len(runner.data_loader)
             self.warmup_iters = self.warmup_epochs * epoch_len
+
+    def before_train_epoch(self, runner):
+        if not self.by_epoch:
+            return
 
         self.regular_lr = self.get_regular_lr(runner)
         self._set_lr(runner, self.regular_lr)


### PR DESCRIPTION
This PR changes the code to make `self.warmup_iters` assigned in `before_run` function in class `LrUpdaterHook`. The original code can not run when `self.warmup_by_epoch = True` and `self.by_epoch=False`.