### PR TITLE
Fix bug for `self.warmup_iters` when warmup_by_epoch

### DIFF
--- a/mmcv/runner/hooks/lr_updater.py
+++ b/mmcv/runner/hooks/lr_updater.py
@@ -110,11 +110,11 @@ class LrUpdaterHook(Hook):
                 group['initial_lr'] for group in runner.optimizer.param_groups
             ]
 
-        if self.warmup_by_epoch:
+    def before_train_epoch(self, runner):
+        if self.warmup_iters is None:
             epoch_len = len(runner.data_loader)
             self.warmup_iters = self.warmup_epochs * epoch_len
 
-    def before_train_epoch(self, runner):
         if not self.by_epoch:
             return
 


### PR DESCRIPTION
This PR fixes bug for `self.warmup_iters` when `self.warmup_by_epoch` in `before_run`, since at the stage `before_run`, the runner could not get the `data_loader`. So, This PR moves it to `before_train_epoch` and uses `if self.warmup_iters is None:` to make the `self.warmup_iters` assigned only Once.