### PR TITLE
Fix mmcv-dataparallel

### DIFF
--- a/mmcv/parallel/_functions.py
+++ b/mmcv/parallel/_functions.py
@@ -19,8 +19,11 @@ def scatter(input, devices, streams=None):
         output = input.contiguous()
         # TODO: copy to a pinned buffer first (if copying from CPU)
         stream = streams[0] if output.numel() > 0 else None
-        with torch.cuda.device(devices[0]), torch.cuda.stream(stream):
-            output = output.cuda(devices[0], non_blocking=True)
+        if devices != [-1]:
+            with torch.cuda.device(devices[0]), torch.cuda.stream(stream):
+                output = output.cuda(devices[0], non_blocking=True)
+        # This is a workaround
+        output = output.unsqueeze(0)
         return output
     else:
         raise Exception(f'Unknown type {type(input)}.')
@@ -62,7 +65,7 @@ class Scatter:
     def forward(target_gpus, input):
         input_device = get_input_device(input)
         streams = None
-        if input_device == -1:
+        if input_device == -1 and target_gpus != [-1]:
             # Perform CPU to GPU copies in a background stream
             streams = [_get_stream(device) for device in target_gpus]
 

--- a/mmcv/parallel/_functions.py
+++ b/mmcv/parallel/_functions.py
@@ -22,8 +22,10 @@ def scatter(input, devices, streams=None):
         if devices != [-1]:
             with torch.cuda.device(devices[0]), torch.cuda.stream(stream):
                 output = output.cuda(devices[0], non_blocking=True)
-        # This is a workaround
-        output = output.unsqueeze(0)
+        else:
+            # unsquzee the first dimension thus the tensor's shape is the
+            # same as those scattered with GPU.
+            output = output.unsqueeze(0)
         return output
     else:
         raise Exception(f'Unknown type {type(input)}.')

--- a/mmcv/parallel/data_parallel.py
+++ b/mmcv/parallel/data_parallel.py
@@ -85,7 +85,9 @@ class MMDataParallel(DataParallel):
 
     def train_step(self, *inputs, **kwargs):
         if not self.device_ids:
-            inputs, kwargs = self.scatter(inputs, kwargs, -1)
+            # We add the following line thus the module could gather and
+            # convert data containers as those in GPU inference
+            inputs, kwargs = self.scatter(inputs, kwargs, [-1])
             return self.module.train_step(*inputs, **kwargs)
 
         assert len(self.device_ids) == 1, \
@@ -105,7 +107,9 @@ class MMDataParallel(DataParallel):
 
     def val_step(self, *inputs, **kwargs):
         if not self.device_ids:
-            inputs, kwargs = self.scatter(inputs, kwargs, -1)
+            # We add the following line thus the module could gather and
+            # convert data containers as those in GPU inference
+            inputs, kwargs = self.scatter(inputs, kwargs, [-1])
             return self.module.val_step(*inputs, **kwargs)
 
         assert len(self.device_ids) == 1, \

--- a/mmcv/parallel/data_parallel.py
+++ b/mmcv/parallel/data_parallel.py
@@ -1,12 +1,42 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 from itertools import chain
 
+import torch
+from torch.cuda._utils import _get_device_index
 from torch.nn.parallel import DataParallel
+from torch.nn.parallel.data_parallel import _check_balance
 
 from .scatter_gather import scatter_kwargs
 
 
 class MMDataParallel(DataParallel):
+
+    def __init__(self, module, device_ids=None, output_device=None, dim=0):
+        super(DataParallel, self).__init__()
+
+        if not torch.cuda.is_available():
+            self.module = module
+            self.device_ids = []
+            self.dim = dim
+            return
+
+        if device_ids is None:
+            device_ids = list(range(torch.cuda.device_count()))
+        if output_device is None:
+            output_device = device_ids[0]
+
+        self.dim = dim
+        self.module = module
+        self.device_ids = list(
+            map(lambda x: _get_device_index(x, True), device_ids))
+        self.output_device = _get_device_index(output_device, True)
+        self.src_device_obj = torch.device('cuda:{}'.format(
+            self.device_ids[0]))
+
+        _check_balance(self.device_ids)
+
+        if len(self.device_ids) == 1:
+            self.module.cuda(device_ids[0])
 
     def forward(self, *inputs, **kwargs):
         """Override the original forward function.
@@ -14,8 +44,8 @@ class MMDataParallel(DataParallel):
         The main difference lies in the CPU inference
         """
         if not self.device_ids:
-            inputs, kwargs = self.scatter(inputs, kwargs, -1)
-            return self.module(*inputs, **kwargs)
+            inputs, kwargs = self.scatter(inputs, kwargs, [-1])
+            return self.module(*inputs[0], **kwargs[0])
 
         for t in chain(self.module.parameters(), self.module.buffers()):
             if t.device != self.src_device_obj:

--- a/mmcv/parallel/data_parallel.py
+++ b/mmcv/parallel/data_parallel.py
@@ -39,7 +39,7 @@ class MMDataParallel(DataParallel):
             inputs, kwargs = self.scatter(inputs, kwargs, [-1])
             return self.module(*inputs[0], **kwargs[0])
         else:
-            super().forward(*inputs, **kwargs)
+            return super().forward(*inputs, **kwargs)
 
     def scatter(self, inputs, kwargs, device_ids):
         return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)

--- a/mmcv/parallel/data_parallel.py
+++ b/mmcv/parallel/data_parallel.py
@@ -8,11 +8,35 @@ from .scatter_gather import scatter_kwargs
 
 class MMDataParallel(DataParallel):
 
+    def forward(self, *inputs, **kwargs):
+        """Override the original forward function.
+
+        The main difference lies in the CPU inference
+        """
+        if not self.device_ids:
+            inputs, kwargs = self.scatter(inputs, kwargs, -1)
+            return self.module(*inputs, **kwargs)
+
+        for t in chain(self.module.parameters(), self.module.buffers()):
+            if t.device != self.src_device_obj:
+                raise RuntimeError(
+                    'module must have its parameters and buffers '
+                    f'on device {self.src_device_obj} (device_ids[0]) but '
+                    f'found one of them on device: {t.device}')
+
+        inputs, kwargs = self.scatter(inputs, kwargs, self.device_ids)
+        if len(self.device_ids) == 1:
+            return self.module(*inputs[0], **kwargs[0])
+        replicas = self.replicate(self.module, self.device_ids[:len(inputs)])
+        outputs = self.parallel_apply(replicas, inputs, kwargs)
+        return self.gather(outputs, self.output_device)
+
     def scatter(self, inputs, kwargs, device_ids):
         return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
 
     def train_step(self, *inputs, **kwargs):
         if not self.device_ids:
+            inputs, kwargs = self.scatter(inputs, kwargs, -1)
             return self.module.train_step(*inputs, **kwargs)
 
         assert len(self.device_ids) == 1, \
@@ -32,6 +56,7 @@ class MMDataParallel(DataParallel):
 
     def val_step(self, *inputs, **kwargs):
         if not self.device_ids:
+            inputs, kwargs = self.scatter(inputs, kwargs, -1)
             return self.module.val_step(*inputs, **kwargs)
 
         assert len(self.device_ids) == 1, \

--- a/mmcv/parallel/data_parallel.py
+++ b/mmcv/parallel/data_parallel.py
@@ -21,8 +21,9 @@ class MMDataParallel(DataParallel):
     Args:
         module (:class:`nn.Module`): Module to be encapsulated.
         device_ids (list[int]): Device IDS of modules to be scattered to.
-        output_device (str | int): Device ID for output
-        dim (int): Dimension used to scatter the data.
+            Defaults to None when GPU is not available.
+        output_device (str | int): Device ID for output. Defaults to None.
+        dim (int): Dimension used to scatter the data. Defaults to 0.
     """
 
     def __init__(self, module, device_ids=None, output_device=None, dim=0):

--- a/mmcv/parallel/scatter_gather.py
+++ b/mmcv/parallel/scatter_gather.py
@@ -19,7 +19,7 @@ def scatter(inputs, target_gpus, dim=0):
                 return OrigScatter.apply(target_gpus, None, dim, obj)
             else:
                 # for CPU inference we use self-implemented scatter
-                return Scatter.forward(target_gpus, obj.data)
+                return Scatter.forward(target_gpus, obj)
         if isinstance(obj, DataContainer):
             if obj.cpu_only:
                 return obj.data

--- a/mmcv/parallel/scatter_gather.py
+++ b/mmcv/parallel/scatter_gather.py
@@ -15,7 +15,11 @@ def scatter(inputs, target_gpus, dim=0):
 
     def scatter_map(obj):
         if isinstance(obj, torch.Tensor):
-            return OrigScatter.apply(target_gpus, None, dim, obj)
+            if target_gpus != [-1]:
+                return OrigScatter.apply(target_gpus, None, dim, obj)
+            else:
+                # for CPU inference we use self-implemented scatter
+                return Scatter.forward(target_gpus, obj.data)
         if isinstance(obj, DataContainer):
             if obj.cpu_only:
                 return obj.data


### PR DESCRIPTION
Fix https://github.com/open-mmlab/mmdetection/issues/1501
Fix https://github.com/open-mmlab/mmdetection/issues/3048

A RetinaNet is tested with three modes: multi-GPU distributed testing, single-GPU testing with MMDataParallel, and CPU testing with MMDataParallel. The model achieves similar AP under these three modes.