### PR TITLE
Fix inconsistent return types in pybind11 function prototypes

### DIFF
--- a/mmcv/ops/csrc/pytorch/carafe_naive_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/carafe_naive_cuda.cu
@@ -1,11 +1,11 @@
 #include "carafe_naive_cuda_kernel.cuh"
 #include "pytorch_cuda_helper.hpp"
 
-int CARAFENAIVEForwardCUDAKernelLauncher(const Tensor features,
-                                         const Tensor masks, Tensor output,
-                                         const int kernel_size,
-                                         const int group_size,
-                                         const int scale_factor) {
+void CARAFENAIVEForwardCUDAKernelLauncher(const Tensor features,
+                                          const Tensor masks, Tensor output,
+                                          const int kernel_size,
+                                          const int group_size,
+                                          const int scale_factor) {
   int output_size = output.numel();
   int channels = output.size(1);
   int height = output.size(2);
@@ -23,10 +23,9 @@ int CARAFENAIVEForwardCUDAKernelLauncher(const Tensor features,
       }));
 
   AT_CUDA_CHECK(cudaGetLastError());
-  return 0;
 }
 
-int CARAFENAIVEBackwardCUDAKernelLauncher(
+void CARAFENAIVEBackwardCUDAKernelLauncher(
     const Tensor top_grad, const Tensor features, const Tensor masks,
     Tensor bottom_grad, Tensor mask_grad, const int kernel_size,
     const int group_size, const int scale_factor) {
@@ -49,5 +48,4 @@ int CARAFENAIVEBackwardCUDAKernelLauncher(
       }));
 
   AT_CUDA_CHECK(cudaGetLastError());
-  return 0;
 }

--- a/mmcv/ops/csrc/pytorch/pybind.cpp
+++ b/mmcv/ops/csrc/pytorch/pybind.cpp
@@ -3,43 +3,43 @@
 std::string get_compiler_version();
 std::string get_compiling_cuda_version();
 
-int carafe_naive_forward(Tensor features, Tensor masks, Tensor output,
-                         int kernel_size, int group_size, int scale_factor);
+void carafe_naive_forward(Tensor features, Tensor masks, Tensor output,
+                          int kernel_size, int group_size, int scale_factor);
 
-int carafe_naive_backward(Tensor top_grad, Tensor features, Tensor masks,
-                          Tensor bottom_grad, Tensor mask_grad, int kernel_size,
-                          int group_size, int scale_factor);
+void carafe_naive_backward(Tensor top_grad, Tensor features, Tensor masks,
+                           Tensor bottom_grad, Tensor mask_grad,
+                           int kernel_size, int group_size, int scale_factor);
 
-int carafe_forward(Tensor features, Tensor masks, Tensor rfeatures,
-                   Tensor routput, Tensor rmasks, Tensor output,
-                   int kernel_size, int group_size, int scale_factor);
+void carafe_forward(Tensor features, Tensor masks, Tensor rfeatures,
+                    Tensor routput, Tensor rmasks, Tensor output,
+                    int kernel_size, int group_size, int scale_factor);
 
-int carafe_backward(Tensor top_grad, Tensor rfeatures, Tensor masks,
-                    Tensor rtop_grad, Tensor rbottom_grad_hs,
-                    Tensor rbottom_grad, Tensor rmask_grad, Tensor bottom_grad,
-                    Tensor mask_grad, int kernel_size, int group_size,
-                    int scale_factor);
+void carafe_backward(Tensor top_grad, Tensor rfeatures, Tensor masks,
+                     Tensor rtop_grad, Tensor rbottom_grad_hs,
+                     Tensor rbottom_grad, Tensor rmask_grad, Tensor bottom_grad,
+                     Tensor mask_grad, int kernel_size, int group_size,
+                     int scale_factor);
 
-int deform_conv_forward(Tensor input, Tensor weight, Tensor offset,
-                        Tensor output, Tensor columns, Tensor ones, int kW,
-                        int kH, int dW, int dH, int padW, int padH,
-                        int dilationW, int dilationH, int group,
-                        int deformable_group, int im2col_step);
+void deform_conv_forward(Tensor input, Tensor weight, Tensor offset,
+                         Tensor output, Tensor columns, Tensor ones, int kW,
+                         int kH, int dW, int dH, int padW, int padH,
+                         int dilationW, int dilationH, int group,
+                         int deformable_group, int im2col_step);
 
-int deform_conv_backward_input(Tensor input, Tensor offset, Tensor gradOutput,
-                               Tensor gradInput, Tensor gradOffset,
-                               Tensor weight, Tensor columns, int kW, int kH,
-                               int dW, int dH, int padW, int padH,
-                               int dilationW, int dilationH, int group,
-                               int deformable_group, int im2col_step);
+void deform_conv_backward_input(Tensor input, Tensor offset, Tensor gradOutput,
+                                Tensor gradInput, Tensor gradOffset,
+                                Tensor weight, Tensor columns, int kW, int kH,
+                                int dW, int dH, int padW, int padH,
+                                int dilationW, int dilationH, int group,
+                                int deformable_group, int im2col_step);
 
-int deform_conv_backward_parameters(Tensor input, Tensor offset,
-                                    Tensor gradOutput, Tensor gradWeight,
-                                    Tensor columns, Tensor ones, int kW, int kH,
-                                    int dW, int dH, int padW, int padH,
-                                    int dilationW, int dilationH, int group,
-                                    int deformable_group, float scale,
-                                    int im2col_step);
+void deform_conv_backward_parameters(Tensor input, Tensor offset,
+                                     Tensor gradOutput, Tensor gradWeight,
+                                     Tensor columns, Tensor ones, int kW,
+                                     int kH, int dW, int dH, int padW, int padH,
+                                     int dilationW, int dilationH, int group,
+                                     int deformable_group, float scale,
+                                     int im2col_step);
 
 void deform_roi_pool_forward(Tensor input, Tensor rois, Tensor offset,
                              Tensor output, int pooled_height, int pooled_width,
@@ -52,39 +52,39 @@ void deform_roi_pool_backward(Tensor grad_output, Tensor input, Tensor rois,
                               int pooled_width, float spatial_scale,
                               int sampling_ratio, float gamma);
 
-int sigmoid_focal_loss_forward(Tensor input, Tensor target, Tensor weight,
-                               Tensor output, float gamma, float alpha);
+void sigmoid_focal_loss_forward(Tensor input, Tensor target, Tensor weight,
+                                Tensor output, float gamma, float alpha);
 
-int sigmoid_focal_loss_backward(Tensor input, Tensor target, Tensor weight,
-                                Tensor grad_input, float gamma, float alpha);
+void sigmoid_focal_loss_backward(Tensor input, Tensor target, Tensor weight,
+                                 Tensor grad_input, float gamma, float alpha);
 
-int softmax_focal_loss_forward(Tensor input, Tensor target, Tensor weight,
-                               Tensor output, float gamma, float alpha);
+void softmax_focal_loss_forward(Tensor input, Tensor target, Tensor weight,
+                                Tensor output, float gamma, float alpha);
 
-int softmax_focal_loss_backward(Tensor input, Tensor target, Tensor weight,
-                                Tensor buff, Tensor grad_input, float gamma,
-                                float alpha);
+void softmax_focal_loss_backward(Tensor input, Tensor target, Tensor weight,
+                                 Tensor buff, Tensor grad_input, float gamma,
+                                 float alpha);
 
 void bbox_overlaps(const Tensor bboxes1, const Tensor bboxes2, Tensor ious,
                    const int mode, const bool aligned, const int offset);
 
-int masked_im2col_forward(const Tensor im, const Tensor mask_h_idx,
-                          const Tensor mask_w_idx, Tensor col,
-                          const int kernel_h, const int kernel_w,
-                          const int pad_h, const int pad_w);
+void masked_im2col_forward(const Tensor im, const Tensor mask_h_idx,
+                           const Tensor mask_w_idx, Tensor col,
+                           const int kernel_h, const int kernel_w,
+                           const int pad_h, const int pad_w);
 
-int masked_col2im_forward(const Tensor col, const Tensor mask_h_idx,
-                          const Tensor mask_w_idx, Tensor im, int height,
-                          int width, int channels);
+void masked_col2im_forward(const Tensor col, const Tensor mask_h_idx,
+                           const Tensor mask_w_idx, Tensor im, int height,
+                           int width, int channels);
 
-int modulated_deform_conv_forward(
+void modulated_deform_conv_forward(
     Tensor input, Tensor weight, Tensor bias, Tensor ones, Tensor offset,
     Tensor mask, Tensor output, Tensor columns, int kernel_h, int kernel_w,
     const int stride_h, const int stride_w, const int pad_h, const int pad_w,
     const int dilation_h, const int dilation_w, const int group,
     const int deformable_group, const bool with_bias);
 
-int modulated_deform_conv_backward(
+void modulated_deform_conv_backward(
     Tensor input, Tensor weight, Tensor bias, Tensor ones, Tensor offset,
     Tensor mask, Tensor columns, Tensor grad_input, Tensor grad_weight,
     Tensor grad_bias, Tensor grad_offset, Tensor grad_mask, Tensor grad_output,
@@ -99,22 +99,22 @@ Tensor softnms(Tensor boxes, Tensor scores, Tensor dets, float iou_threshold,
 
 std::vector<std::vector<int> > nms_match(Tensor dets, float iou_threshold);
 
-int roi_align_forward(Tensor input, Tensor rois, Tensor output, Tensor argmax_y,
-                      Tensor argmax_x, int aligned_height, int aligned_width,
-                      float spatial_scale, int sampling_ratio, int pool_mode,
-                      bool aligned);
-
-int roi_align_backward(Tensor grad_output, Tensor rois, Tensor argmax_y,
-                       Tensor argmax_x, Tensor grad_input, int aligned_height,
+void roi_align_forward(Tensor input, Tensor rois, Tensor output,
+                       Tensor argmax_y, Tensor argmax_x, int aligned_height,
                        int aligned_width, float spatial_scale,
                        int sampling_ratio, int pool_mode, bool aligned);
 
-int roi_pool_forward(Tensor input, Tensor rois, Tensor output, Tensor argmax,
-                     int pooled_height, int pooled_width, float spatial_scale);
+void roi_align_backward(Tensor grad_output, Tensor rois, Tensor argmax_y,
+                        Tensor argmax_x, Tensor grad_input, int aligned_height,
+                        int aligned_width, float spatial_scale,
+                        int sampling_ratio, int pool_mode, bool aligned);
 
-int roi_pool_backward(Tensor grad_output, Tensor rois, Tensor argmax,
-                      Tensor grad_input, int pooled_height, int pooled_width,
-                      float spatial_scale);
+void roi_pool_forward(Tensor input, Tensor rois, Tensor output, Tensor argmax,
+                      int pooled_height, int pooled_width, float spatial_scale);
+
+void roi_pool_backward(Tensor grad_output, Tensor rois, Tensor argmax,
+                       Tensor grad_input, int pooled_height, int pooled_width,
+                       float spatial_scale);
 
 void sync_bn_forward_mean(const Tensor input, Tensor mean);
 

--- a/mmcv/ops/csrc/pytorch/pybind.cpp
+++ b/mmcv/ops/csrc/pytorch/pybind.cpp
@@ -155,10 +155,9 @@ void psamask_backward(Tensor grad_output, const Tensor grad_input,
                       const int w_feature, const int h_mask, const int w_mask,
                       const int half_h_mask, const int half_w_mask);
 
-void tin_shift_forward(const Tensor input, const Tensor shift, Tensor output);
+void tin_shift_forward(Tensor input, Tensor shift, Tensor output);
 
-void tin_shift_backward(Tensor grad_output, const Tensor shift,
-                        const Tensor grad_input);
+void tin_shift_backward(Tensor grad_output, Tensor shift, Tensor grad_input);
 
 Tensor bottom_pool_forward(Tensor input);
 


### PR DESCRIPTION
This was required for me to build on windows on VS17/19, but several function prototypes in the pybind11 file did not match those in neighboring files due to differences in returning ints vs voids, and one const inconsistency on recent code