### PR TITLE
[feature] Use cu92 & ubuntu1604 for torch 1.3.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,13 @@ jobs:
           wget https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/7fa2af80.pub
           sudo apt-key add 7fa2af80.pub
           sudo apt update -qq
-          sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-} libcublas10=10.1.0.105-1
+          sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
+          export CUBLAS_INSTALLER=libcublas10_10.1.0.105-1_amd64.deb
+          export CUBLASDEV_INSTALLER=libcublas-dev_10.1.0.105-1_amd64.deb
+          wget http://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/${CUBLAS_INSTALLER}
+          wget http://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/${CUBLASDEV_INSTALLER}
+          sudo dpkg -i ${CUBLAS_INSTALLER}
+          sudo dpkg -i ${CUBLASDEV_INSTALLER}
           sudo apt clean
           /usr/local/cuda/bin/nvcc -V
           export CUDA_ROOT=/usr/local/cuda-${CUDA_SHORT}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,18 +217,13 @@ jobs:
           sudo apt-key add 7fa2af80.pub
           sudo apt update -qq
           sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
-          export CUBLAS_INSTALLER=libcublas10_10.1.0.105-1_amd64.deb
-          export CUBLASDEV_INSTALLER=libcublas-dev_10.1.0.105-1_amd64.deb
-          wget http://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/${CUBLAS_INSTALLER}
-          wget http://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/${CUBLASDEV_INSTALLER}
-          sudo dpkg -i ${CUBLAS_INSTALLER}
-          sudo dpkg -i ${CUBLASDEV_INSTALLER}
           sudo apt clean
           /usr/local/cuda/bin/nvcc -V
-          export CUDA_ROOT=/usr/local/cuda-${CUDA_SHORT}
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
           find /usr/local/ -name cublas_v2.h
-          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/include/
+          find /usr/include/ -name cublas_v2.h
+          tree /usr/local/cuda-10.2
+          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/local/cuda-10.2/include:/usr/local/cuda-10.2/lib64:/usr/include/
           echo ${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}
           sudo apt-get install -y ninja-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
           wget https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/7fa2af80.pub
           sudo apt-key add 7fa2af80.pub
           sudo apt update -qq
-          sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
+          sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-} libcublas10=10.1.0.105-1
           sudo apt clean
           /usr/local/cuda/bin/nvcc -V
           export CUDA_ROOT=/usr/local/cuda-${CUDA_SHORT}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,7 +224,7 @@ jobs:
           find /usr/include/ -name cublas_v2.h
           sudo apt install -y tree
           tree /usr/local/cuda-10.2
-          tree /usr/local/cuda
+          ls -l /usr/local/cuda
           sudo cp /usr/local/cuda-10.2/include/* /usr/local/cuda/include
           sudo cp /usr/local/cuda-10.2/lib64/* /usr/local/cuda/include/lib64/
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/local/cuda-10.2/include:/usr/local/cuda-10.2/lib64:/usr/include/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
           sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
           sudo apt clean
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
-          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:${LD_LIBRARY_PATH}
+          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/include/:${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}
           sudo apt-get install -y ninja-build
       - name: Install Pillow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,6 +222,7 @@ jobs:
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
           find /usr/local/ -name cublas_v2.h
           find /usr/include/ -name cublas_v2.h
+          sudo apt install -y tree
           tree /usr/local/cuda-10.2
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/local/cuda-10.2/include:/usr/local/cuda-10.2/lib64:/usr/include/
           echo ${LD_LIBRARY_PATH}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Run unittests and generate coverage report
         run: |
           pytest tests/ --ignore=tests/test_runner --ignore=tests/test_optimizer.py --ignore=tests/test_cnn --ignore=tests/test_parallel.py --ignore=tests/test_ops --ignore=tests/test_load_model_zoo.py --ignore=tests/test_utils/test_logging.py --ignore=tests/test_image/test_io.py --ignore=tests/test_utils/test_registry.py
+
   build_without_ops:
     runs-on: ubuntu-latest
     env:
@@ -122,6 +123,7 @@ jobs:
           coverage run --branch --source=mmcv -m pytest tests/
           coverage xml
           coverage report -m
+
   build_cuda:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
           sudo apt clean
           /usr/local/cuda/bin/nvcc -V
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
-          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/include/:${LD_LIBRARY_PATH}
+          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/include/
           export PATH=${CUDA_HOME}/bin:${PATH}
           sudo apt-get install -y ninja-build
       - name: Install Pillow
@@ -220,7 +220,7 @@ jobs:
           sudo apt clean
           /usr/local/cuda/bin/nvcc -V
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
-          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/include/:${LD_LIBRARY_PATH}
+          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/include/
           echo ${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}
           sudo apt-get install -y ninja-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,6 +221,7 @@ jobs:
           /usr/local/cuda/bin/nvcc -V
           export CUDA_ROOT=/usr/local/cuda-${CUDA_SHORT}
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
+          find /usr/local/ -name cublas_v2.h
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/include/
           echo ${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,6 +157,7 @@ jobs:
           sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
           sudo apt clean
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
+          ln -s /usr/local/cuda-${CUDA_SHORT} /usr/local/cuda
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}
           sudo apt-get install -y ninja-build
@@ -218,6 +219,7 @@ jobs:
           sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
           sudo apt clean
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
+          ln -s /usr/local/cuda-${CUDA_SHORT} /usr/local/cuda
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}
           sudo apt-get install -y ninja-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
           tree /usr/local/cuda-10.2
           ls -l /usr/local/cuda
           sudo cp /usr/local/cuda-10.2/include/* /usr/local/cuda/include
-          sudo cp /usr/local/cuda-10.2/lib64/* /usr/local/cuda/lib64/
+          sudo cp -r /usr/local/cuda-10.2/lib64/* /usr/local/cuda/lib64/
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/local/cuda-10.2/include:/usr/local/cuda-10.2/lib64:/usr/include/
           echo ${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,6 @@ jobs:
           sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
           sudo apt clean
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
-          ln -s /usr/local/cuda-${CUDA_SHORT} /usr/local/cuda
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}
           sudo apt-get install -y ninja-build
@@ -219,8 +218,8 @@ jobs:
           sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
           sudo apt clean
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
-          ln -s /usr/local/cuda-${CUDA_SHORT} /usr/local/cuda
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:${LD_LIBRARY_PATH}
+          echo ${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}
           sudo apt-get install -y ninja-build
       - name: Install Pillow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -219,6 +219,7 @@ jobs:
           sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
           sudo apt clean
           /usr/local/cuda/bin/nvcc -V
+          export CUDA_ROOT=/usr/local/cuda-${CUDA_SHORT}
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/include/
           echo ${LD_LIBRARY_PATH}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
           coverage report -m
 
   build_cuda92:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     env:
       CUDA: 9.2.148-1
       CUDA_SHORT: 9.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,6 +224,9 @@ jobs:
           find /usr/include/ -name cublas_v2.h
           sudo apt install -y tree
           tree /usr/local/cuda-10.2
+          sudo cp /usr/local/cuda-10.2/include/* /usr/local/cuda/include
+          sudo cp /usr/local/cuda-10.2/lib/* /usr/local/cuda/include/lib64/
+          sudo cp /usr/local/cuda-10.2/lib/* /usr/local/cuda/include/lib/
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/local/cuda-10.2/include:/usr/local/cuda-10.2/lib64:/usr/include/
           echo ${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,60 @@ jobs:
           coverage xml
           coverage report -m
 
-  build_cuda:
+  build_cuda92:
+    runs-on: ubuntu-latest
+    env:
+      CUDA: 9.2.148-1
+      CUDA_SHORT: 9.2
+      UBUNTU_VERSION: ubuntu1604
+      FORCE_CUDA: 1
+      MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
+    strategy:
+      matrix:
+        python-version: [3.7]
+        torch: [1.3.1]
+        include:
+          - torch: 1.3.1
+            torchvision: 0.4.2
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install CUDA
+        run: |
+          export INSTALLER=cuda-repo-${UBUNTU_VERSION}_${CUDA}_amd64.deb
+          wget http://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/${INSTALLER}
+          sudo dpkg -i ${INSTALLER}
+          wget https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/7fa2af80.pub
+          sudo apt-key add 7fa2af80.pub
+          sudo apt update -qq
+          sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
+          sudo apt clean
+          export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
+          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:${LD_LIBRARY_PATH}
+          export PATH=${CUDA_HOME}/bin:${PATH}
+          sudo apt-get install -y ninja-build
+      - name: Install Pillow
+        run: pip install Pillow==6.2.2
+        if: ${{matrix.torchvision == '0.4.2'}}
+      - name: Install PyTorch
+        run: pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
+      - name: Install unittest dependencies
+        run: pip install pytest coverage lmdb PyTurboJPEG
+      - name: Build and install
+        run: rm -rf .eggs && pip install -e .
+      - name: Run unittests and generate coverage report
+        run: |
+          coverage run --branch --source=mmcv -m pytest tests/
+          coverage xml
+          coverage report -m
+
+  build_cuda101:
     runs-on: ubuntu-latest
     env:
       CUDA: 10.1.105-1
@@ -135,10 +188,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-        torch: [1.3.1, 1.5.1+cu101, 1.6.0+cu101]
+        torch: [1.5.1+cu101, 1.6.0+cu101]
         include:
-          - torch: 1.3.1
-            torchvision: 0.4.2
           - torch: 1.5.1+cu101
             torchvision: 0.6.1+cu101
           - torch: 1.6.0+cu101

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,6 +156,7 @@ jobs:
           sudo apt update -qq
           sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
           sudo apt clean
+          /usr/local/cuda/bin/nvcc -V
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/include/:${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}
@@ -217,8 +218,9 @@ jobs:
           sudo apt update -qq
           sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
           sudo apt clean
+          /usr/local/cuda/bin/nvcc -V
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
-          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:${LD_LIBRARY_PATH}
+          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/include/:${LD_LIBRARY_PATH}
           echo ${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}
           sudo apt-get install -y ninja-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,9 +224,9 @@ jobs:
           find /usr/include/ -name cublas_v2.h
           sudo apt install -y tree
           tree /usr/local/cuda-10.2
+          tree /usr/local/cuda
           sudo cp /usr/local/cuda-10.2/include/* /usr/local/cuda/include
-          sudo cp /usr/local/cuda-10.2/lib/* /usr/local/cuda/include/lib64/
-          sudo cp /usr/local/cuda-10.2/lib/* /usr/local/cuda/include/lib/
+          sudo cp /usr/local/cuda-10.2/lib64/* /usr/local/cuda/include/lib64/
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/local/cuda-10.2/include:/usr/local/cuda-10.2/lib64:/usr/include/
           echo ${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
           tree /usr/local/cuda-10.2
           ls -l /usr/local/cuda
           sudo cp /usr/local/cuda-10.2/include/* /usr/local/cuda/include
-          sudo cp /usr/local/cuda-10.2/lib64/* /usr/local/cuda/include/lib64/
+          sudo cp /usr/local/cuda-10.2/lib64/* /usr/local/cuda/lib64/
           export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/local/cuda-10.2/include:/usr/local/cuda-10.2/lib64:/usr/include/
           echo ${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,6 @@ jobs:
       - name: Run unittests and generate coverage report
         run: |
           pytest tests/ --ignore=tests/test_runner --ignore=tests/test_optimizer.py --ignore=tests/test_cnn --ignore=tests/test_parallel.py --ignore=tests/test_ops --ignore=tests/test_load_model_zoo.py --ignore=tests/test_utils/test_logging.py --ignore=tests/test_image/test_io.py --ignore=tests/test_utils/test_registry.py
-
   build_without_ops:
     runs-on: ubuntu-latest
     env:
@@ -123,62 +122,7 @@ jobs:
           coverage run --branch --source=mmcv -m pytest tests/
           coverage xml
           coverage report -m
-
-  build_cuda92:
-    runs-on: ubuntu-16.04
-    env:
-      CUDA: 9.2.148-1
-      CUDA_SHORT: 9.2
-      UBUNTU_VERSION: ubuntu1604
-      FORCE_CUDA: 1
-      MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
-    strategy:
-      matrix:
-        python-version: [3.7]
-        torch: [1.3.1]
-        include:
-          - torch: 1.3.1
-            torchvision: 0.4.2
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install CUDA
-        run: |
-          export INSTALLER=cuda-repo-${UBUNTU_VERSION}_${CUDA}_amd64.deb
-          wget http://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/${INSTALLER}
-          sudo dpkg -i ${INSTALLER}
-          wget https://developer.download.nvidia.com/compute/cuda/repos/${UBUNTU_VERSION}/x86_64/7fa2af80.pub
-          sudo apt-key add 7fa2af80.pub
-          sudo apt update -qq
-          sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
-          sudo apt clean
-          /usr/local/cuda/bin/nvcc -V
-          export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
-          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/include/
-          export PATH=${CUDA_HOME}/bin:${PATH}
-          sudo apt-get install -y ninja-build
-      - name: Install Pillow
-        run: pip install Pillow==6.2.2
-        if: ${{matrix.torchvision == '0.4.2'}}
-      - name: Install PyTorch
-        run: pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
-      - name: Install unittest dependencies
-        run: pip install pytest coverage lmdb PyTurboJPEG
-      - name: Build and install
-        run: rm -rf .eggs && pip install -e .
-      - name: Run unittests and generate coverage report
-        run: |
-          coverage run --branch --source=mmcv -m pytest tests/
-          coverage xml
-          coverage report -m
-
-  build_cuda101:
+  build_cuda:
     runs-on: ubuntu-latest
     env:
       CUDA: 10.1.105-1
@@ -189,8 +133,10 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-        torch: [1.5.1+cu101, 1.6.0+cu101]
+        torch: [1.3.1, 1.5.1+cu101, 1.6.0+cu101]
         include:
+          - torch: 1.3.1
+            torchvision: 0.4.2
           - torch: 1.5.1+cu101
             torchvision: 0.6.1+cu101
           - torch: 1.6.0+cu101
@@ -218,17 +164,10 @@ jobs:
           sudo apt update -qq
           sudo apt install -y cuda-${CUDA_SHORT/./-} cuda-cufft-dev-${CUDA_SHORT/./-}
           sudo apt clean
-          /usr/local/cuda/bin/nvcc -V
           export CUDA_HOME=/usr/local/cuda-${CUDA_SHORT}
-          find /usr/local/ -name cublas_v2.h
-          find /usr/include/ -name cublas_v2.h
-          sudo apt install -y tree
-          tree /usr/local/cuda-10.2
-          ls -l /usr/local/cuda
           sudo cp /usr/local/cuda-10.2/include/* /usr/local/cuda/include
           sudo cp -r /usr/local/cuda-10.2/lib64/* /usr/local/cuda/lib64/
-          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:/usr/local/cuda-10.2/include:/usr/local/cuda-10.2/lib64:/usr/include/
-          echo ${LD_LIBRARY_PATH}
+          export LD_LIBRARY_PATH=${CUDA_HOME}/lib64:${CUDA_HOME}/include:${LD_LIBRARY_PATH}
           export PATH=${CUDA_HOME}/bin:${PATH}
           sudo apt-get install -y ninja-build
       - name: Install Pillow


### PR DESCRIPTION
This PR fixes the bug in github action caused by the weird cublas installation path. When installing CUDA, `libcublas10_10.2.2.214-1_amd64.deb` and  `libcublas-dev_10.2.2.214-1_amd64.deb`will be automatically installed due to compatibility issues. However, these two libraries will be installed in `/usr/local/cuda-10.2` rather than the expected `/usr/local/cuda-10.1`, although we install CUDA-10.1. Thus, when compiling the CUDA extensions, it will raise `cublas_v2.h is not found` error. This is fixed by simply copying the files from `/usr/local/cuda-10.2` to `/usr/local/cuda-10.1`.