### PR TITLE
Remove assertion

### DIFF
--- a/mmcv/parallel/collate.py
+++ b/mmcv/parallel/collate.py
@@ -24,7 +24,6 @@ def collate(batch, samples_per_gpu=1):
         raise TypeError(f'{batch.dtype} is not supported.')
 
     if isinstance(batch[0], DataContainer):
-        assert len(batch) % samples_per_gpu == 0
         stacked = []
         if batch[0].cpu_only:
             for i in range(0, len(batch), samples_per_gpu):


### PR DESCRIPTION
When single GPU testing with batch size > 1 and the length of the dataset can't be divisible by the batch size, this assertion will report an error. It seems it can be safely removed to yield the correct result.