### PR TITLE
remove the set of _max_iter in epoch based runner

### DIFF
--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -90,11 +90,6 @@ class EpochBasedRunner(BaseRunner):
         assert len(data_loaders) == len(workflow)
 
         self._max_epochs = max_epochs
-        for i, flow in enumerate(workflow):
-            mode, epochs = flow
-            if mode == 'train':
-                self._max_iters = self._max_epochs * len(data_loaders[i])
-                break
 
         work_dir = self.work_dir if self.work_dir is not None else 'NONE'
         self.logger.info('Start running, host: %s, work_dir: %s',


### PR DESCRIPTION
`EpochBasedRunner._max_iter` should be set in line 24, `train()` of `epoch_based_runner.py`, and the setting between 93-97 is redundant and unnecessary. 