### PR TITLE
Allow type to be default arg

### DIFF
--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -139,7 +139,7 @@ def build_from_cfg(cfg, registry, default_args=None):
     if not isinstance(cfg, dict):
         raise TypeError(f'cfg must be a dict, but got {type(cfg)}')
     if 'type' not in cfg:
-        if default_args is not None and 'type' not in default_args:
+        if default_args is None or 'type' not in default_args:
             raise KeyError(
                 '`cfg` or `default_args` must contain the key "type", '
                 f'but got {cfg}\n{default_args}')

--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -149,6 +149,11 @@ def build_from_cfg(cfg, registry, default_args=None):
                         f'but got {type(default_args)}')
 
     args = cfg.copy()
+
+    if default_args is not None:
+        for name, value in default_args.items():
+            args.setdefault(name, value)
+
     obj_type = args.pop('type')
     if is_str(obj_type):
         obj_cls = registry.get(obj_type)
@@ -161,7 +166,4 @@ def build_from_cfg(cfg, registry, default_args=None):
         raise TypeError(
             f'type must be a str or valid type, but got {type(obj_type)}')
 
-    if default_args is not None:
-        for name, value in default_args.items():
-            args.setdefault(name, value)
     return obj_cls(**args)

--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -138,9 +138,9 @@ def build_from_cfg(cfg, registry, default_args=None):
     """
     if not isinstance(cfg, dict):
         raise TypeError(f'cfg must be a dict, but got {type(cfg)}')
-    if 'type' not in cfg:
+    if 'type' not in cfg and 'type' not in default_args:
         raise KeyError(
-            f'the cfg dict must contain the key "type", but got {cfg}')
+            f'`cfg` or `default_args` must contain the key "type", but got {cfg}\n{default_args}')
     if not isinstance(registry, Registry):
         raise TypeError('registry must be an mmcv.Registry object, '
                         f'but got {type(registry)}')

--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -139,8 +139,8 @@ def build_from_cfg(cfg, registry, default_args=None):
     if not isinstance(cfg, dict):
         raise TypeError(f'cfg must be a dict, but got {type(cfg)}')
     if 'type' not in cfg and 'type' not in default_args:
-        raise KeyError(
-            f'`cfg` or `default_args` must contain the key "type", but got {cfg}\n{default_args}')
+        raise KeyError('`cfg` or `default_args` must contain the key "type", '
+                       f'but got {cfg}\n{default_args}')
     if not isinstance(registry, Registry):
         raise TypeError('registry must be an mmcv.Registry object, '
                         f'but got {type(registry)}')

--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -138,9 +138,10 @@ def build_from_cfg(cfg, registry, default_args=None):
     """
     if not isinstance(cfg, dict):
         raise TypeError(f'cfg must be a dict, but got {type(cfg)}')
-    if 'type' not in cfg and 'type' not in default_args:
-        raise KeyError('`cfg` or `default_args` must contain the key "type", '
-                       f'but got {cfg}\n{default_args}')
+    if 'type' not in cfg:
+        if default_args is not None and 'type' not in default_args:
+            raise KeyError('`cfg` or `default_args` must contain the key "type", '
+                           f'but got {cfg}\n{default_args}')
     if not isinstance(registry, Registry):
         raise TypeError('registry must be an mmcv.Registry object, '
                         f'but got {type(registry)}')

--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -140,8 +140,9 @@ def build_from_cfg(cfg, registry, default_args=None):
         raise TypeError(f'cfg must be a dict, but got {type(cfg)}')
     if 'type' not in cfg:
         if default_args is not None and 'type' not in default_args:
-            raise KeyError('`cfg` or `default_args` must contain the key "type", '
-                           f'but got {cfg}\n{default_args}')
+            raise KeyError(
+                '`cfg` or `default_args` must contain the key "type", '
+                f'but got {cfg}\n{default_args}')
     if not isinstance(registry, Registry):
         raise TypeError('registry must be an mmcv.Registry object, '
                         f'but got {type(registry)}')

--- a/tests/test_utils/test_registry.py
+++ b/tests/test_utils/test_registry.py
@@ -190,6 +190,11 @@ def test_build_from_cfg():
         cfg = dict(type=1000)
         model = mmcv.build_from_cfg(cfg, BACKBONES)
 
+    # cfg should contain the key "type"
+    with pytest.raises(KeyError):
+        cfg = dict(depth=50, stages=4)
+        model = mmcv.build_from_cfg(cfg, BACKBONES)
+
     # incorrect registry type
     with pytest.raises(TypeError):
         cfg = dict(type='ResNet', depth=50)

--- a/tests/test_utils/test_registry.py
+++ b/tests/test_utils/test_registry.py
@@ -158,6 +158,17 @@ def test_build_from_cfg():
     assert isinstance(model, ResNet)
     assert model.depth == 50 and model.stages == 4
 
+    # type defined using default_args
+    cfg = dict(depth=50)
+    model = mmcv.build_from_cfg(cfg, BACKBONES, default_args=dict(type="ResNet"))
+    assert isinstance(model, ResNet)
+    assert model.depth == 50 and model.stages == 4
+
+    cfg = dict(depth=50)
+    model = mmcv.build_from_cfg(cfg, BACKBONES, default_args=dict(type=ResNet))
+    assert isinstance(model, ResNet)
+    assert model.depth == 50 and model.stages == 4
+
     # not a registry
     with pytest.raises(TypeError):
         cfg = dict(type='VGG')

--- a/tests/test_utils/test_registry.py
+++ b/tests/test_utils/test_registry.py
@@ -160,7 +160,8 @@ def test_build_from_cfg():
 
     # type defined using default_args
     cfg = dict(depth=50)
-    model = mmcv.build_from_cfg(cfg, BACKBONES, default_args=dict(type="ResNet"))
+    model = mmcv.build_from_cfg(
+        cfg, BACKBONES, default_args=dict(type='ResNet'))
     assert isinstance(model, ResNet)
     assert model.depth == 50 and model.stages == 4
 

--- a/tests/test_utils/test_registry.py
+++ b/tests/test_utils/test_registry.py
@@ -189,11 +189,6 @@ def test_build_from_cfg():
         cfg = dict(type=1000)
         model = mmcv.build_from_cfg(cfg, BACKBONES)
 
-    # cfg should contain the key "type"
-    with pytest.raises(KeyError):
-        cfg = dict(depth=50, stages=4)
-        model = mmcv.build_from_cfg(cfg, BACKBONES)
-
     # incorrect registry type
     with pytest.raises(TypeError):
         cfg = dict(type='ResNet', depth=50)

--- a/tests/test_utils/test_registry.py
+++ b/tests/test_utils/test_registry.py
@@ -191,9 +191,15 @@ def test_build_from_cfg():
         model = mmcv.build_from_cfg(cfg, BACKBONES)
 
     # cfg should contain the key "type"
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match='must contain the key "type"'):
         cfg = dict(depth=50, stages=4)
         model = mmcv.build_from_cfg(cfg, BACKBONES)
+
+    # cfg or default_args should contain the key "type"
+    with pytest.raises(KeyError, match='must contain the key "type"'):
+        cfg = dict(depth=50)
+        model = mmcv.build_from_cfg(
+            cfg, BACKBONES, default_args=dict(stages=4))
 
     # incorrect registry type
     with pytest.raises(TypeError):


### PR DESCRIPTION
This P.R. updates `build_from_cfg` in order to allow `type` being set with `default_args`