### PR TITLE
fix deprecated wrappers exiting bug

### DIFF
--- a/mmcv/ops/deprecated_wrappers.py
+++ b/mmcv/ops/deprecated_wrappers.py
@@ -7,7 +7,7 @@ from ..cnn.bricks.wrappers import Conv2d, ConvTranspose2d, Linear, MaxPool2d
 
 class Conv2d_deprecated(Conv2d):
 
-    def __init__(*args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         warnings.warn(
             'Importing Conv2d wrapper from "mmcv.ops" will be deprecated in'
@@ -16,7 +16,7 @@ class Conv2d_deprecated(Conv2d):
 
 class ConvTranspose2d_deprecated(ConvTranspose2d):
 
-    def __init__(*args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         warnings.warn(
             'Importing ConvTranspose2d wrapper from "mmcv.ops" will be '
@@ -26,7 +26,7 @@ class ConvTranspose2d_deprecated(ConvTranspose2d):
 
 class MaxPool2d_deprecated(MaxPool2d):
 
-    def __init__(*args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         warnings.warn(
             'Importing MaxPool2d wrapper from "mmcv.ops" will be deprecated in'
@@ -35,7 +35,7 @@ class MaxPool2d_deprecated(MaxPool2d):
 
 class Linear_deprecated(Linear):
 
-    def __init__(*args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         warnings.warn(
             'Importing Linear wrapper from "mmcv.ops" will be deprecated in'


### PR DESCRIPTION
Added missing `self` in deprecated wrappers to solve mmdetection [#3785](https://github.com/open-mmlab/mmdetection/issues/3785).