### PR TITLE
Bump version to 1.1.3

### DIFF
--- a/mmcv/version.py
+++ b/mmcv/version.py
@@ -1,6 +1,6 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'
 
 
 def parse_version_info(version_str):


### PR DESCRIPTION
## New Features

- Implement `Conv2dAdaptivePadding`, which is the same op as 2D convolution in tensorflow with `padding` set to "same". (#529)
- Support reading video from url (#531)
- Add `imtranslate`, `imequalize`, `adjust_color`, `adjust_brightness`, `adjust_contrast` augmentation. (#538, #542, #543, #546)

## Improvements

- Add switch for onnx exporter. (#564)
- Allow `type` to be `default_args` in `build_from_cfg`. (#558)
- Expose `wrap_fp16_model` to mmcv.runner.  (#555)
- Move op wrappers into bricks and use wrappers in registry (#550)
- Support multiple interpolation modes for `imrotate` (#545)

## Bug Fixes

- Fix the init method of deprecated wrappers. (#567)
- Fix DCN bug in parrots. (#562, #563, #565)
- Use copy instead of symlink on windows. (#557)
- Remove assertion for batch size and samples_per_gpu. (#549)
- Fix compilation bug in windows and add instruction for windows. (#540)
- Fix missing pad_val in impad_to_multiple. (#539)