### PR TITLE
Add runner builder

### DIFF
--- a/mmcv/runner/__init__.py
+++ b/mmcv/runner/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 from .base_runner import BaseRunner
+from .builder import RUNNERS, build_runner
 from .checkpoint import (_load_checkpoint, load_checkpoint, load_state_dict,
                          save_checkpoint, weights_to_cpu)
 from .dist_utils import get_dist_info, init_dist, master_only
@@ -30,5 +31,6 @@ __all__ = [
     'OPTIMIZER_BUILDERS', 'OPTIMIZERS', 'DefaultOptimizerConstructor',
     'build_optimizer', 'build_optimizer_constructor', 'IterLoader',
     'set_random_seed', 'auto_fp16', 'force_fp32', 'wrap_fp16_model',
-    'Fp16OptimizerHook', 'SyncBuffersHook', 'EMAHook'
+    'Fp16OptimizerHook', 'SyncBuffersHook', 'EMAHook', 'build_runner',
+    'RUNNERS'
 ]

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -43,6 +43,8 @@ class BaseRunner(metaclass=ABCMeta):
         meta (dict | None): A dict records some import information such as
             environment info and seed, which will be logged in logger hook.
             Defaults to None.
+        max_epochs (int, optional): Total training epochs.
+        max_iters (int, optional): Total training iterations.
     """
 
     def __init__(self,
@@ -51,7 +53,9 @@ class BaseRunner(metaclass=ABCMeta):
                  optimizer=None,
                  work_dir=None,
                  logger=None,
-                 meta=None):
+                 meta=None,
+                 max_iters=None,
+                 max_epochs=None):
         if batch_processor is not None:
             if not callable(batch_processor):
                 raise TypeError('batch_processor must be callable, '
@@ -121,8 +125,8 @@ class BaseRunner(metaclass=ABCMeta):
         self._epoch = 0
         self._iter = 0
         self._inner_iter = 0
-        self._max_epochs = 0
-        self._max_iters = 0
+        self._max_epochs = max_epochs
+        self._max_iters = max_iters
         # TODO: Redesign LogBuffer, it is not flexible and elegant enough
         self.log_buffer = LogBuffer()
 

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -125,6 +125,11 @@ class BaseRunner(metaclass=ABCMeta):
         self._epoch = 0
         self._iter = 0
         self._inner_iter = 0
+
+        if max_epochs is not None and max_iters is not None:
+            raise ValueError(
+                'Only one of `max_epochs` or `max_iters` can be set.')
+
         self._max_epochs = max_epochs
         self._max_iters = max_iters
         # TODO: Redesign LogBuffer, it is not flexible and elegant enough

--- a/mmcv/runner/builder.py
+++ b/mmcv/runner/builder.py
@@ -1,0 +1,7 @@
+from ..utils import Registry, build_from_cfg
+
+RUNNERS = Registry('runner')
+
+
+def build_runner(cfg, default_args=None):
+    return build_from_cfg(cfg, RUNNERS, default_args=default_args)

--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -7,10 +7,12 @@ import torch
 
 import mmcv
 from .base_runner import BaseRunner
+from .builder import RUNNERS
 from .checkpoint import save_checkpoint
 from .utils import get_host_info
 
 
+@RUNNERS.register_module()
 class EpochBasedRunner(BaseRunner):
     """Epoch-based Runner.
 
@@ -165,7 +167,7 @@ class EpochBasedRunner(BaseRunner):
         if create_symlink:
             mmcv.symlink(filename, osp.join(out_dir, 'latest.pth'))
 
-
+@RUNNERS.register_module()
 class Runner(EpochBasedRunner):
     """Deprecated name of EpochBasedRunner."""
 

--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -77,7 +77,7 @@ class EpochBasedRunner(BaseRunner):
 
         self.call_hook('after_val_epoch')
 
-    def run(self, data_loaders, workflow, **kwargs):
+    def run(self, data_loaders, workflow, max_epochs=None, **kwargs):
         """Start running.
 
         Args:
@@ -91,6 +91,12 @@ class EpochBasedRunner(BaseRunner):
         assert isinstance(data_loaders, list)
         assert mmcv.is_list_of(workflow, tuple)
         assert len(data_loaders) == len(workflow)
+        if max_epochs is not None:
+            warnings.warn(
+                'setting max_epochs in run is deprecated, '
+                'please set max_epochs in runner_config', DeprecationWarning)
+            self._max_epochs = max_epochs
+
         assert self._max_epochs is not None, (
             'max_epochs must be specified during instantiation')
 

--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -77,7 +77,7 @@ class EpochBasedRunner(BaseRunner):
 
         self.call_hook('after_val_epoch')
 
-    def run(self, data_loaders, workflow, max_epochs, **kwargs):
+    def run(self, data_loaders, workflow, **kwargs):
         """Start running.
 
         Args:
@@ -87,13 +87,12 @@ class EpochBasedRunner(BaseRunner):
                 running order and epochs. E.g, [('train', 2), ('val', 1)] means
                 running 2 epochs for training and 1 epoch for validation,
                 iteratively.
-            max_epochs (int): Total training epochs.
         """
         assert isinstance(data_loaders, list)
         assert mmcv.is_list_of(workflow, tuple)
         assert len(data_loaders) == len(workflow)
+        assert self._max_epochs is not None
 
-        self._max_epochs = max_epochs
         for i, flow in enumerate(workflow):
             mode, epochs = flow
             if mode == 'train':
@@ -172,6 +171,7 @@ class EpochBasedRunner(BaseRunner):
                 mmcv.symlink(filename, dst_file)
             else:
                 shutil.copy(filename, dst_file)
+
 
 @RUNNERS.register_module()
 class Runner(EpochBasedRunner):

--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -91,7 +91,8 @@ class EpochBasedRunner(BaseRunner):
         assert isinstance(data_loaders, list)
         assert mmcv.is_list_of(workflow, tuple)
         assert len(data_loaders) == len(workflow)
-        assert self._max_epochs is not None
+        assert self._max_epochs is not None, (
+            'max_epochs must be specified during instantiation')
 
         for i, flow in enumerate(workflow):
             mode, epochs = flow

--- a/mmcv/runner/iter_based_runner.py
+++ b/mmcv/runner/iter_based_runner.py
@@ -3,6 +3,7 @@ import os.path as osp
 import platform
 import shutil
 import time
+import warnings
 
 import torch
 from torch.optim import Optimizer
@@ -81,7 +82,7 @@ class IterBasedRunner(BaseRunner):
         self.call_hook('after_val_iter')
         self._inner_iter += 1
 
-    def run(self, data_loaders, workflow, **kwargs):
+    def run(self, data_loaders, workflow, max_iters=None, **kwargs):
         """Start running.
 
         Args:
@@ -95,6 +96,11 @@ class IterBasedRunner(BaseRunner):
         assert isinstance(data_loaders, list)
         assert mmcv.is_list_of(workflow, tuple)
         assert len(data_loaders) == len(workflow)
+        if max_iters is not None:
+            warnings.warn(
+                'setting max_iters in run is deprecated, '
+                'please set max_iters in runner_config', DeprecationWarning)
+            self._max_iters = max_iters
         assert self._max_iters is not None, (
             'max_iters must be specified during instantiation')
 

--- a/mmcv/runner/iter_based_runner.py
+++ b/mmcv/runner/iter_based_runner.py
@@ -95,7 +95,8 @@ class IterBasedRunner(BaseRunner):
         assert isinstance(data_loaders, list)
         assert mmcv.is_list_of(workflow, tuple)
         assert len(data_loaders) == len(workflow)
-        assert self._max_iters is not None
+        assert self._max_iters is not None, (
+            'max_iters must be specified during instantiation')
 
         work_dir = self.work_dir if self.work_dir is not None else 'NONE'
         self.logger.info('Start running, host: %s, work_dir: %s',

--- a/mmcv/runner/iter_based_runner.py
+++ b/mmcv/runner/iter_based_runner.py
@@ -7,6 +7,7 @@ from torch.optim import Optimizer
 
 import mmcv
 from .base_runner import BaseRunner
+from .builder import RUNNERS
 from .checkpoint import save_checkpoint
 from .hooks import IterTimerHook
 from .utils import get_host_info
@@ -39,6 +40,7 @@ class IterLoader:
         return len(self._dataloader)
 
 
+@RUNNERS.register_module()
 class IterBasedRunner(BaseRunner):
     """Iteration-based Runner.
 

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 
 from mmcv.parallel import MMDataParallel
-from mmcv.runner import EpochBasedRunner
+from mmcv.runner import RUNNERS, EpochBasedRunner, IterBasedRunner
 
 
 class OldStyleModel(nn.Module):
@@ -30,7 +30,8 @@ class Model(OldStyleModel):
         pass
 
 
-def test_epoch_based_runner():
+@pytest.mark.parametrize('runner_class', RUNNERS.module_dict.values())
+def test_epoch_based_runner(runner_class):
 
     with pytest.warns(UserWarning):
         # batch_processor is deprecated
@@ -39,48 +40,46 @@ def test_epoch_based_runner():
         def batch_processor():
             pass
 
-        _ = EpochBasedRunner(
-            model, batch_processor, logger=logging.getLogger())
+        _ = runner_class(model, batch_processor, logger=logging.getLogger())
 
     with pytest.raises(TypeError):
         # batch_processor must be callable
         model = OldStyleModel()
-        _ = EpochBasedRunner(
-            model, batch_processor=0, logger=logging.getLogger())
+        _ = runner_class(model, batch_processor=0, logger=logging.getLogger())
 
     with pytest.raises(TypeError):
         # optimizer must be a optimizer or a dict of optimizers
         model = Model()
         optimizer = 'NotAOptimizer'
-        _ = EpochBasedRunner(
+        _ = runner_class(
             model, optimizer=optimizer, logger=logging.getLogger())
 
     with pytest.raises(TypeError):
         # optimizer must be a optimizer or a dict of optimizers
         model = Model()
         optimizers = dict(optim1=torch.optim.Adam(), optim2='NotAOptimizer')
-        _ = EpochBasedRunner(
+        _ = runner_class(
             model, optimizer=optimizers, logger=logging.getLogger())
 
     with pytest.raises(TypeError):
         # logger must be a logging.Logger
         model = Model()
-        _ = EpochBasedRunner(model, logger=None)
+        _ = runner_class(model, logger=None)
 
     with pytest.raises(TypeError):
         # meta must be a dict or None
         model = Model()
-        _ = EpochBasedRunner(model, logger=logging.getLogger(), meta=['list'])
+        _ = runner_class(model, logger=logging.getLogger(), meta=['list'])
 
     with pytest.raises(AssertionError):
         # model must implement the method train_step()
         model = OldStyleModel()
-        _ = EpochBasedRunner(model, logger=logging.getLogger())
+        _ = runner_class(model, logger=logging.getLogger())
 
     with pytest.raises(TypeError):
         # work_dir must be a str or None
         model = Model()
-        _ = EpochBasedRunner(model, work_dir=1, logger=logging.getLogger())
+        _ = runner_class(model, work_dir=1, logger=logging.getLogger())
 
     with pytest.raises(RuntimeError):
         # batch_processor and train_step() cannot be both set
@@ -89,8 +88,7 @@ def test_epoch_based_runner():
             pass
 
         model = Model()
-        _ = EpochBasedRunner(
-            model, batch_processor, logger=logging.getLogger())
+        _ = runner_class(model, batch_processor, logger=logging.getLogger())
 
     # test work_dir
     model = Model()
@@ -98,23 +96,24 @@ def test_epoch_based_runner():
     dir_name = ''.join(
         [random.choice(string.ascii_letters) for _ in range(10)])
     work_dir = osp.join(temp_root, dir_name)
-    _ = EpochBasedRunner(model, work_dir=work_dir, logger=logging.getLogger())
+    _ = runner_class(model, work_dir=work_dir, logger=logging.getLogger())
     assert osp.isdir(work_dir)
-    _ = EpochBasedRunner(model, work_dir=work_dir, logger=logging.getLogger())
+    _ = runner_class(model, work_dir=work_dir, logger=logging.getLogger())
     assert osp.isdir(work_dir)
     os.removedirs(work_dir)
 
 
-def test_runner_with_parallel():
+@pytest.mark.parametrize('runner_class', RUNNERS.module_dict.values())
+def test_runner_with_parallel(runner_class):
 
     def batch_processor():
         pass
 
     model = MMDataParallel(OldStyleModel())
-    _ = EpochBasedRunner(model, batch_processor, logger=logging.getLogger())
+    _ = runner_class(model, batch_processor, logger=logging.getLogger())
 
     model = MMDataParallel(Model())
-    _ = EpochBasedRunner(model, logger=logging.getLogger())
+    _ = runner_class(model, logger=logging.getLogger())
 
     with pytest.raises(RuntimeError):
         # batch_processor and train_step() cannot be both set
@@ -123,13 +122,13 @@ def test_runner_with_parallel():
             pass
 
         model = MMDataParallel(Model())
-        _ = EpochBasedRunner(
-            model, batch_processor, logger=logging.getLogger())
+        _ = runner_class(model, batch_processor, logger=logging.getLogger())
 
 
-def test_save_checkpoint():
+@pytest.mark.parametrize('runner_class', RUNNERS.module_dict.values())
+def test_save_checkpoint(runner_class):
     model = Model()
-    runner = EpochBasedRunner(model=model, logger=logging.getLogger())
+    runner = runner_class(model=model, logger=logging.getLogger())
 
     with pytest.raises(TypeError):
         # meta should be None or dict
@@ -139,18 +138,23 @@ def test_save_checkpoint():
         runner.save_checkpoint(root)
 
         latest_path = osp.join(root, 'latest.pth')
-        epoch1_path = osp.join(root, 'epoch_1.pth')
-
         assert osp.exists(latest_path)
-        assert osp.exists(epoch1_path)
-        assert osp.realpath(latest_path) == osp.realpath(epoch1_path)
+
+        if isinstance(runner, EpochBasedRunner):
+            first_ckp_path = osp.join(root, 'epoch_1.pth')
+        elif isinstance(runner, IterBasedRunner):
+            first_ckp_path = osp.join(root, 'iter_1.pth')
+
+        assert osp.exists(first_ckp_path)
+        assert osp.realpath(latest_path) == osp.realpath(first_ckp_path)
 
         torch.load(latest_path)
 
 
-def test_build_lr_momentum_hook():
+@pytest.mark.parametrize('runner_class', RUNNERS.module_dict.values())
+def test_build_lr_momentum_hook(runner_class):
     model = Model()
-    runner = EpochBasedRunner(model=model, logger=logging.getLogger())
+    runner = runner_class(model=model, logger=logging.getLogger())
 
     # test policy that is already title
     lr_config = dict(

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -11,7 +11,8 @@ import torch
 import torch.nn as nn
 
 from mmcv.parallel import MMDataParallel
-from mmcv.runner import RUNNERS, EpochBasedRunner, IterBasedRunner
+from mmcv.runner import (RUNNERS, EpochBasedRunner, IterBasedRunner,
+                         build_runner)
 
 
 class OldStyleModel(nn.Module):
@@ -28,6 +29,23 @@ class Model(OldStyleModel):
 
     def val_step(self):
         pass
+
+
+def test_build_runner():
+    temp_root = tempfile.gettempdir()
+    dir_name = ''.join(
+        [random.choice(string.ascii_letters) for _ in range(10)])
+
+    default_args = dict(
+        model=Model(),
+        work_dir=osp.join(temp_root, dir_name),
+        logger=logging.getLogger())
+    cfg = dict(type='EpochBasedRunner', max_epochs=1)
+    runner = build_runner(cfg, default_args=default_args)
+    assert runner._max_epochs == 1
+    cfg = dict(type='IterBasedRunner', max_iters=1)
+    runner = build_runner(cfg, default_args=default_args)
+    assert runner._max_iters == 1
 
 
 @pytest.mark.parametrize('runner_class', RUNNERS.module_dict.values())

--- a/tests/test_runner/test_runner.py
+++ b/tests/test_runner/test_runner.py
@@ -47,6 +47,10 @@ def test_build_runner():
     runner = build_runner(cfg, default_args=default_args)
     assert runner._max_iters == 1
 
+    with pytest.raises(ValueError, match='Only one of'):
+        cfg = dict(type='IterBasedRunner', max_epochs=1, max_iters=1)
+        runner = build_runner(cfg, default_args=default_args)
+
 
 @pytest.mark.parametrize('runner_class', RUNNERS.module_dict.values())
 def test_epoch_based_runner(runner_class):


### PR DESCRIPTION
This P.R. adds a new method `build_runner` and a new Registry object: `RUNNERS` for managing runner types.
This allows to specify runner type (and corresponding parameters) via configuration files.

The `max_iters` and `max_epochs` arguments have been moved from `run` to `__init__` (this change is backwards compatible with deprecation warning).
I don't know if there was a use case that needed to have them in `run` but in all downstream repos (mmdet, mmseg, etc) those args were parsed from config so i think it makes sense to set them during instantiation.

Discussed in https://github.com/open-mmlab/mmsegmentation/pull/118