### PR TITLE
Update lr_updater.py

### DIFF
--- a/mmcv/runner/hooks/lr_updater.py
+++ b/mmcv/runner/hooks/lr_updater.py
@@ -318,7 +318,7 @@ def get_position_from_periods(iteration, cumulative_periods):
         int: The position of the right-closest number in the period list.
     """
     for i, period in enumerate(cumulative_periods):
-        if iteration <= period:
+        if iteration < period:
             return i
     raise ValueError(f'Current iteration {iteration} exceeds '
                      f'cumulative_periods {cumulative_periods}')

--- a/mmcv/runner/hooks/lr_updater.py
+++ b/mmcv/runner/hooks/lr_updater.py
@@ -308,7 +308,7 @@ def get_position_from_periods(iteration, cumulative_periods):
     For example, the cumulative_periods = [100, 200, 300, 400],
     if iteration == 50, return 0;
     if iteration == 210, return 2;
-    if iteration == 300, return 2.
+    if iteration == 300, return 3.
 
     Args:
         iteration (int): Current iteration.

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -291,7 +291,7 @@ def test_cosine_restart_lr_update_hook():
             'momentum': 0.95
         }, 0),
         call('train', {
-            'learning_rate': 0.0,
+            'learning_rate': 0.01,
             'momentum': 0.95
         }, 5),
         call('train', {


### PR DESCRIPTION
since epoch/iteration in  runner starts with 0, we shouldn't leave the latter iteration to former (12th epoch for example, with first period equal to 12) period.