### PR TITLE
Fix a typo in warning message

### DIFF
--- a/mmcv/parallel/data_parallel.py
+++ b/mmcv/parallel/data_parallel.py
@@ -76,7 +76,7 @@ class MMDataParallel(DataParallel):
         assert len(self.device_ids) == 1, \
             ('MMDataParallel only supports single GPU training, if you need to'
              ' train with multiple GPUs, please use MMDistributedDataParallel'
-             'instead.')
+             ' instead.')
 
         for t in chain(self.module.parameters(), self.module.buffers()):
             if t.device != self.src_device_obj:


### PR DESCRIPTION
"please use MMDistributedDataParallelinstead." -> "please use MMDistributedDataParallel instead."