### PR TITLE
Fix some bug as well as unit test for nms_rotate

### DIFF
--- a/mmcv/ops/csrc/pytorch/pybind.cpp
+++ b/mmcv/ops/csrc/pytorch/pybind.cpp
@@ -178,8 +178,8 @@ Tensor top_pool_backward(Tensor input, Tensor grad_output);
 void box_iou_rotated(const Tensor boxes1, const Tensor boxes2, Tensor ious,
                      const bool aligned);
 
-Tensor nms_rotated(const Tensor dets, Tensor scores, Tensor order,
-                   Tensor dets_sorted, const float iou_threshold,
+Tensor nms_rotated(const Tensor dets, const Tensor scores, const Tensor order,
+                   const Tensor dets_sorted, const float iou_threshold,
                    const int multi_label);
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {

--- a/tests/test_ops/test_nms_rotated.py
+++ b/tests/test_ops/test_nms_rotated.py
@@ -1,12 +1,12 @@
 import numpy as np
 import torch
-
+import pytest
 
 class TestNmsRotated(object):
 
     def test_ml_nms_rotated(self):
         if not torch.cuda.is_available():
-            return
+            pytest.skip('test requires GPU')
         from mmcv.ops import nms_rotated
         np_boxes = np.array(
             [[6.0, 3.0, 8.0, 7.0, 0.5, 0.7], [3.0, 6.0, 9.0, 11.0, 0.6, 0.8],
@@ -31,7 +31,7 @@ class TestNmsRotated(object):
 
     def test_nms_rotated(self):
         if not torch.cuda.is_available():
-            return
+            pytest.skip('test requires GPU')
         from mmcv.ops import nms_rotated
         np_boxes = np.array(
             [[6.0, 3.0, 8.0, 7.0, 0.5, 0.7], [3.0, 6.0, 9.0, 11.0, 0.6, 0.8],

--- a/tests/test_ops/test_nms_rotated.py
+++ b/tests/test_ops/test_nms_rotated.py
@@ -3,11 +3,12 @@ import pytest
 import torch
 
 
-class TestNmsRotated(object):
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason='GPU is required to test NMSRotated op')
+class TestNmsRotated:
 
     def test_ml_nms_rotated(self):
-        if not torch.cuda.is_available():
-            pytest.skip('test requires GPU')
         from mmcv.ops import nms_rotated
         np_boxes = np.array(
             [[6.0, 3.0, 8.0, 7.0, 0.5, 0.7], [3.0, 6.0, 9.0, 11.0, 0.6, 0.8],
@@ -31,8 +32,6 @@ class TestNmsRotated(object):
         assert np.allclose(keep_inds.cpu().numpy(), np_expect_keep_inds)
 
     def test_nms_rotated(self):
-        if not torch.cuda.is_available():
-            pytest.skip('test requires GPU')
         from mmcv.ops import nms_rotated
         np_boxes = np.array(
             [[6.0, 3.0, 8.0, 7.0, 0.5, 0.7], [3.0, 6.0, 9.0, 11.0, 0.6, 0.8],

--- a/tests/test_ops/test_nms_rotated.py
+++ b/tests/test_ops/test_nms_rotated.py
@@ -1,6 +1,7 @@
 import numpy as np
-import torch
 import pytest
+import torch
+
 
 class TestNmsRotated(object):
 

--- a/tests/test_ops/test_nms_rotated.py
+++ b/tests/test_ops/test_nms_rotated.py
@@ -24,9 +24,9 @@ class TestNmsRotated(object):
         boxes = torch.from_numpy(np_boxes).cuda()
         labels = torch.from_numpy(np_labels).cuda()
 
-        dets, keep_inds = nms_rotated(boxes, 0.5, labels, True)
+        dets, keep_inds = nms_rotated(boxes[:, :5], boxes[:, -1], 0.5, labels)
 
-        assert np.allclose(dets.cpu().numpy(), np_expect_dets)
+        assert np.allclose(dets.cpu().numpy()[:, :5], np_expect_dets)
         assert np.allclose(keep_inds.cpu().numpy(), np_expect_keep_inds)
 
     def test_nms_rotated(self):
@@ -47,6 +47,6 @@ class TestNmsRotated(object):
 
         boxes = torch.from_numpy(np_boxes).cuda()
 
-        dets, keep_inds = nms_rotated(boxes, 0.5)
-        assert np.allclose(dets.cpu().numpy(), np_expect_dets)
+        dets, keep_inds = nms_rotated(boxes[:, :5], boxes[:, -1], 0.5)
+        assert np.allclose(dets.cpu().numpy()[:, :5], np_expect_dets)
         assert np.allclose(keep_inds.cpu().numpy(), np_expect_keep_inds)


### PR DESCRIPTION
Fixes #709 

Two problems for my view:

1. Argument type of `nms_rotate` mismatch in `pybind.cpp` and `nms_rorate.cpp`, the latter is with `const`  while the former isn't.
2. Argument in python unittest mismatch, seems `score` is merged into `box` as 6-th column.