### PR TITLE
fix grad_output uncontiguous

### DIFF
--- a/mmcv/ops/roi_align.py
+++ b/mmcv/ops/roi_align.py
@@ -94,7 +94,7 @@ class RoIAlignFunction(Function):
     def backward(ctx, grad_output):
         rois, argmax_y, argmax_x = ctx.saved_tensors
         grad_input = grad_output.new_zeros(ctx.input_shape)
-
+        grad_output = grad_output.contiguous()
         ext_module.roi_align_backward(
             grad_output,
             rois,

--- a/mmcv/ops/roi_align.py
+++ b/mmcv/ops/roi_align.py
@@ -94,6 +94,7 @@ class RoIAlignFunction(Function):
     def backward(ctx, grad_output):
         rois, argmax_y, argmax_x = ctx.saved_tensors
         grad_input = grad_output.new_zeros(ctx.input_shape)
+        # complex head architecture may cause grad_output uncontiguous.
         grad_output = grad_output.contiguous()
         ext_module.roi_align_backward(
             grad_output,


### PR DESCRIPTION
Some complex head architecture may cause grad_output uncontiguous, eg.dii head in sparsercnn