### PR TITLE
optimize `mmcv.image.geometric.bbox_scaling`

### DIFF
--- a/mmcv/image/geometric.py
+++ b/mmcv/image/geometric.py
@@ -302,14 +302,22 @@ def bbox_scaling(bboxes, scale, clip_shape=None):
     Returns:
         ndarray: Scaled bboxes.
     """
-    if float(scale) == 1.0:
-        scaled_bboxes = bboxes.copy()
-    else:
-        w = bboxes[..., 2] - bboxes[..., 0] + 1
-        h = bboxes[..., 3] - bboxes[..., 1] + 1
-        dw = (w * (scale - 1)) * 0.5
-        dh = (h * (scale - 1)) * 0.5
-        scaled_bboxes = bboxes + np.stack((-dw, -dh, dw, dh), axis=-1)
+    scaled_bboxes = bboxes.copy()
+    if float(scale) != 1.0:
+        factor = (scale - 1) * 0.5
+
+        x_deltas = bboxes[..., 2] - bboxes[..., 0]
+        y_deltas = bboxes[..., 3] - bboxes[..., 1]
+        x_deltas += 1
+        y_deltas += 1
+        x_deltas *= factor
+        y_deltas *= factor
+        
+        scaled_bboxes[..., 0] -= x_deltas
+        scaled_bboxes[..., 1] -= y_deltas
+        scaled_bboxes[..., 2] += x_deltas
+        scaled_bboxes[..., 3] += y_deltas
+
     if clip_shape is not None:
         return bbox_clip(scaled_bboxes, clip_shape)
     else:


### PR DESCRIPTION
Hi, this PR updates `mmcv.image.geometric.bbox_scaling` to make it faster. The following is the test code, FYI.

Note: `bbox_scaling` is adapted from `mmcv.image.geometric.bbox_scaling`, `bbox_scaling_v2` is the updated implementation. For simplicity, two functions don't include `clip_shape` argument here. 

```python
import time
import numpy as np


def bbox_scaling(bboxes, scale):
    """Scaling bboxes w.r.t the box center.

    Args:
        bboxes (ndarray): Shape(..., 4).
        scale (float): Scaling factor.

    Returns:
        ndarray: Scaled bboxes.
    """
    if float(scale) == 1.0:
        scaled_bboxes = bboxes.copy()
    else:
        w = bboxes[..., 2] - bboxes[..., 0] + 1
        h = bboxes[..., 3] - bboxes[..., 1] + 1
        dw = (w * (scale - 1)) * 0.5
        dh = (h * (scale - 1)) * 0.5
        scaled_bboxes = bboxes + np.stack((-dw, -dh, dw, dh), axis=-1)
    return scaled_bboxes


def bbox_scaling_v2(bboxes, scale):
    """Scaling bboxes w.r.t the box center.

    Args:
        bboxes (ndarray): Shape(..., 4).
        scale (float): Scaling factor.

    Returns:
        ndarray: Scaled bboxes.
    """
    scaled_bboxes = bboxes.copy()
    if float(scale) != 1.0:
        factor = (scale - 1) * 0.5

        x_deltas = bboxes[..., 2] - bboxes[..., 0]
        y_deltas = bboxes[..., 3] - bboxes[..., 1]
        x_deltas += 1
        y_deltas += 1
        x_deltas *= factor
        y_deltas *= factor
        
        scaled_bboxes[..., 0] -= x_deltas
        scaled_bboxes[..., 1] -= y_deltas
        scaled_bboxes[..., 2] += x_deltas
        scaled_bboxes[..., 3] += y_deltas

    return scaled_bboxes


def benchmark(func, num_repeats=100, num_repeats_burn_in=0, display_interval=None):
    assert isinstance(num_repeats, int) and (num_repeats > 0)
    assert isinstance(num_repeats_burn_in, int) and (num_repeats_burn_in >= 0)
    assert isinstance(display_interval, int) or (display_interval is None)
    # assert num_repeats > num_repeats_burn_in
    
    duration_list = []
    for i in range(num_repeats + num_repeats_burn_in):
        start_time = time.time()
        output = func()
        duration = time.time() - start_time
        if i >= num_repeats_burn_in:
            duration_list.append(duration)
            actual_repeat = i - num_repeats_burn_in + 1
            if (display_interval is not None) and (actual_repeat % display_interval == 0):
                print('repeat {}, duration = {:.3f}s'.format(actual_repeat, duration))
    time_summary = {
        'total': np.sum(duration_list),
        'mean': np.mean(duration_list),
        'stddev': np.std(duration_list),
        'max': np.max(duration_list),
        'min': np.min(duration_list),
    }
    return output, time_summary


if __name__ == '__main__':
    num_repeats = 1000
    bboxes = np.random.randn(200000, 4).astype(np.float32)
    ret_bboxes1, tm1 = benchmark(lambda: bbox_scaling(bboxes.copy(), 2.5), num_repeats=num_repeats)
    ret_bboxes2, tm2 = benchmark(lambda: bbox_scaling_v2(bboxes.copy(), 2.5), num_repeats=num_repeats)
    print(np.allclose(ret_bboxes1, ret_bboxes2))
    print(tm1)
    print(tm2)

```