### PR TITLE
Add 4 functions for initialization and their test units

### DIFF
--- a/mmcv/cnn/__init__.py
+++ b/mmcv/cnn/__init__.py
@@ -15,8 +15,9 @@ from .bricks import (ACTIVATION_LAYERS, CONV_LAYERS, NORM_LAYERS,
 from .resnet import ResNet, make_res_layer
 from .utils import (bias_init_with_prob, caffe2_xavier_init, constant_init,
                     fuse_conv_bn, get_model_complexity_info, initialize,
-                    kaiming_init, normal_init, pretrained_init, random_init,
-                    uniform_init, xavier_init)
+                    kaiming_init, normal_init, uniform_init, xavier_init,
+                    INITIALIZERS, ConstantInit, XavierInit, NormalInit,
+                    UniformInit, KaimingInit, BiasInitWithProb, PretrainedInit)
 from .vgg import VGG, make_vgg_layer
 
 __all__ = [
@@ -31,5 +32,7 @@ __all__ = [
     'PLUGIN_LAYERS', 'Scale', 'get_model_complexity_info', 'conv_ws_2d',
     'ConvAWS2d', 'ConvWS2d', 'fuse_conv_bn', 'DepthwiseSeparableConvModule',
     'Linear', 'Conv2d', 'ConvTranspose2d', 'MaxPool2d', 'ConvTranspose3d',
-    'MaxPool3d', 'Conv3d', 'pretrained_init', 'initialize', 'random_init'
+    'MaxPool3d', 'Conv3d', 'initialize', 'INITIALIZERS', 'ConstantInit',
+    'XavierInit', 'NormalInit', 'UniformInit', 'KaimingInit',
+    'BiasInitWithProb', 'PretrainedInit'
 ]

--- a/mmcv/cnn/__init__.py
+++ b/mmcv/cnn/__init__.py
@@ -14,8 +14,9 @@ from .bricks import (ACTIVATION_LAYERS, CONV_LAYERS, NORM_LAYERS,
 # yapf: enable
 from .resnet import ResNet, make_res_layer
 from .utils import (bias_init_with_prob, caffe2_xavier_init, constant_init,
-                    fuse_conv_bn, get_model_complexity_info, kaiming_init,
-                    normal_init, uniform_init, xavier_init)
+                    fuse_conv_bn, get_model_complexity_info, initialize,
+                    kaiming_init, normal_init, pretrained_init, random_init,
+                    uniform_init, xavier_init)
 from .vgg import VGG, make_vgg_layer
 
 __all__ = [
@@ -30,5 +31,5 @@ __all__ = [
     'PLUGIN_LAYERS', 'Scale', 'get_model_complexity_info', 'conv_ws_2d',
     'ConvAWS2d', 'ConvWS2d', 'fuse_conv_bn', 'DepthwiseSeparableConvModule',
     'Linear', 'Conv2d', 'ConvTranspose2d', 'MaxPool2d', 'ConvTranspose3d',
-    'MaxPool3d', 'Conv3d'
+    'MaxPool3d', 'Conv3d', 'pretrained_init', 'initialize', 'random_init'
 ]

--- a/mmcv/cnn/utils/__init__.py
+++ b/mmcv/cnn/utils/__init__.py
@@ -2,11 +2,13 @@
 from .flops_counter import get_model_complexity_info
 from .fuse_conv_bn import fuse_conv_bn
 from .weight_init import (bias_init_with_prob, caffe2_xavier_init,
-                          constant_init, kaiming_init, normal_init,
-                          uniform_init, xavier_init)
+                          constant_init, initialize, kaiming_init, normal_init,
+                          pretrained_init, random_init, uniform_init,
+                          xavier_init)
 
 __all__ = [
     'get_model_complexity_info', 'bias_init_with_prob', 'caffe2_xavier_init',
     'constant_init', 'kaiming_init', 'normal_init', 'uniform_init',
-    'xavier_init', 'fuse_conv_bn'
+    'xavier_init', 'fuse_conv_bn', 'pretrained_init', 'random_init',
+    'initialize'
 ]

--- a/mmcv/cnn/utils/__init__.py
+++ b/mmcv/cnn/utils/__init__.py
@@ -3,12 +3,14 @@ from .flops_counter import get_model_complexity_info
 from .fuse_conv_bn import fuse_conv_bn
 from .weight_init import (bias_init_with_prob, caffe2_xavier_init,
                           constant_init, initialize, kaiming_init, normal_init,
-                          pretrained_init, random_init, uniform_init,
-                          xavier_init)
+                          uniform_init, xavier_init, INITIALIZERS,
+                          ConstantInit, XavierInit, NormalInit, UniformInit,
+                          KaimingInit, BiasInitWithProb, PretrainedInit)
 
 __all__ = [
     'get_model_complexity_info', 'bias_init_with_prob', 'caffe2_xavier_init',
     'constant_init', 'kaiming_init', 'normal_init', 'uniform_init',
-    'xavier_init', 'fuse_conv_bn', 'pretrained_init', 'random_init',
-    'initialize'
+    'xavier_init', 'fuse_conv_bn', 'initialize', 'INITIALIZERS',
+    'ConstantInit', 'XavierInit', 'NormalInit', 'UniformInit', 'KaimingInit',
+    'BiasInitWithProb', 'PretrainedInit'
 ]

--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -341,7 +341,7 @@ class PretrainedInit(object):
         self.map_location = map_location
 
     def __call__(self, module):
-        logger = get_logger("mmcv")
+        logger = get_logger('mmcv')
         if self.prefix is None:
             print_log(f'load model from: {self.checkpoint}', logger=logger)
             load_checkpoint(

--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -1,6 +1,11 @@
 # Copyright (c) Open-MMLab. All rights reserved.
+import logging
 import numpy as np
 import torch.nn as nn
+
+from mmcv.runner import (_load_checkpoint, _load_checkpoint_with_prefix,
+                         load_checkpoint, load_state_dict)
+from mmcv.utils import print_log
 
 
 def constant_init(module, val, bias=0):
@@ -64,3 +69,145 @@ def bias_init_with_prob(prior_prob):
     """initialize conv/fc bias value according to giving probablity."""
     bias_init = float(-np.log((1 - prior_prob) / prior_prob))
     return bias_init
+
+
+def initialize(module, init_cfg):
+    """Initialize a module
+
+    Args:
+        module (``torch.nn.Module``): An module will be initialized.
+        init_cfg (dict):  Initialization config dict. It should at least
+            contain the key "type", and "type" value must be "random" or
+            "pretrained", which indicates weights initialization with values
+            drawn from random distribution or a pretrained model. The keys in
+            init_cfg with "random" type must be "Conv2d", "Linear",
+            "BatchNorm2d" etc., names of layers with learnable parameters.
+            The init_cfg with "pretrained" type must contain key "checkpoint"
+            that indicates where to load the pretrained model.
+
+    Example:
+        >>> model = nn.Linear(2, 3, bias=True)
+        >>> # the values of "Linear" is dict that refers to the initilization
+            # function and argments. OpenMMLab has implemented initialization
+            # functions including `constant_init`, `xavier_init`, `normal_init`,
+            # `uniform_init`, `kaiming_init`, `caffe2_xavier_init` and
+            # `bias_init_wth_prob` in mmcv.cnn.utils.
+        >>> init_cfg = dict(type='random', Linear=dict(function='constant_init',
+                val=1, bias=2))
+        >>> initialize(model, init_cfg)
+        >>> for name, param in model.named_parameters():
+                print(name, param)
+        weight Parameter containing:
+        tensor([[1., 1.],
+                [1., 1.],
+                [1., 1.]], requires_grad=True)
+        bias Parameter containing:
+        tensor([2., 2., 2.], requires_grad=True)
+        >>> # It also supports initialization functions implemented in pytorch.
+        >>> init_cfg = dict(type='random',
+                Linear=[
+                    dict(function='constant', parameters='weight', val=3),
+                    dict(function='constant', parameters='bias', val=4)
+                ])
+        >>> initialize(module, init_cfg)
+        >>> for name, param in model.named_parameters():
+                print(name, param)
+        weight Parameter containing:
+        tensor([[3., 3.],
+                [3., 3.],
+                [3., 3.]], requires_grad=True)
+        bias Parameter containing:
+        tensor([4., 4., 4.], requires_grad=True)
+
+        >>> from mmdet.models.backbones import ResNet
+        >>> model = ResNet(depth=50)
+        >>> # Initialize weights with the pretrained model.
+        >>> init_cfg = dict(type='pretrained',
+                checkpoint='torchvision://resnet50')
+        >>> initialize(module, init_cfg)
+
+        >>> # Intialize weights of a sub-module with the specific part of
+        >>> # a pretrained model by using "prefix".
+        >>> url = 'http://download.openmmlab.com/mmdetection/v2.0/retinanet/'\
+        >>>     'retinanet_r50_fpn_1x_coco/'\
+        >>>     'retinanet_r50_fpn_1x_coco_20200130-c2398f9e.pth'
+        >>> init_cfg = dict(type='pretrained',
+                checkpoint=url, prefix='backbone.')
+
+    """
+    if not isinstance(init_cfg, dict):
+        raise TypeError(f'init_cfg must be a dict, but got {type(init_cfg)}')
+    if 'type' not in init_cfg:
+        raise TypeError(
+            f'init_cfg must contain the key "type", but got {init_cfg}')
+    init_type = init_cfg.get('type')
+    if init_type == 'pretrained':
+        pretrained_init(module, init_cfg)
+    elif init_type == 'random':
+        random_init(module, init_cfg)
+    else:
+        raise TypeError(
+            'the type of init_cfg must be "random" or "pretrained", '
+            f'but got {init_type}')
+
+
+def random_init(module, init_cfg):
+    """Initialize module with values drawn from a random distribution.
+
+    Args:
+        module (nn.Module): An module will be initialized.
+        init_cfg (dict): Initialization config dict.
+    """
+
+    def init_func(m):
+        classname = m.__class__.__name__
+
+        if init_cfg.get(classname) is not None:
+            if isinstance(init_cfg[classname], list):
+                for cfg_ in init_cfg[classname]:
+                    args = cfg_.copy()
+                    parameters = args.pop('parameters')
+                    init_type = args.pop('function')
+                    if hasattr(nn.init, init_type + "_"):
+                        func = getattr(nn.init, init_type + "_")
+                        if getattr(m, parameters) is not None:
+                            func(getattr(m, parameters), **args)
+                    elif init_type == 'bias_init_with_prob':
+                        bias_cls = bias_init_with_prob(**args)
+                        nn.init.constant_(getattr(m, parameters), bias_cls)
+
+            else:
+                args = init_cfg[classname].copy()
+                init_type = args.pop('function')
+                func = None
+                if hasattr(nn.init, init_type + "_"):
+                    func = getattr(nn.init, init_type + "_")
+                else:
+                    func = eval(init_type)
+                func(m, **args)
+
+    module.apply(init_func)
+
+
+def pretrained_init(module, init_cfg):
+    """Initialize module by loading a pretrained model
+
+    Args:
+        module (nn.Module): An module will be initialized.
+        init_cfg (dict): Initialization config dict.
+
+    """
+    if 'checkpoint' not in init_cfg:
+        raise TypeError(
+            'init_cfg with "pretrained" type must contain the key "checkpoint"'
+        )
+    checkpoint = init_cfg.get('checkpoint')
+    prefix = init_cfg.get('prefix', '')
+    logger = logging.getLogger()
+    print_log(f'load model from: {checkpoint}', logger=logger)
+    if prefix == '':
+        load_checkpoint(module, checkpoint, strict=False, logger=logger)
+
+    else:
+        state_dict = _load_checkpoint_with_prefix(prefix, checkpoint)
+        load_state_dict(module, state_dict, strict=False, logger=logger)

--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -1,11 +1,14 @@
 # Copyright (c) Open-MMLab. All rights reserved.
-import logging
 import numpy as np
 import torch.nn as nn
 
 from mmcv.runner import (_load_checkpoint_with_prefix, load_checkpoint,
                          load_state_dict)
 from mmcv.utils import print_log
+from mmcv.utils import get_logger
+from mmcv.utils import Registry, build_from_cfg
+
+INITIALIZERS = Registry('initializer')
 
 
 def constant_init(module, val, bias=0):
@@ -17,22 +20,25 @@ def constant_init(module, val, bias=0):
 
 def xavier_init(module, gain=1, bias=0, distribution='normal'):
     assert distribution in ['uniform', 'normal']
-    if distribution == 'uniform':
-        nn.init.xavier_uniform_(module.weight, gain=gain)
-    else:
-        nn.init.xavier_normal_(module.weight, gain=gain)
+    if hasattr(module, 'weight') and module.weight is not None:
+        if distribution == 'uniform':
+            nn.init.xavier_uniform_(module.weight, gain=gain)
+        else:
+            nn.init.xavier_normal_(module.weight, gain=gain)
     if hasattr(module, 'bias') and module.bias is not None:
         nn.init.constant_(module.bias, bias)
 
 
 def normal_init(module, mean=0, std=1, bias=0):
-    nn.init.normal_(module.weight, mean, std)
+    if hasattr(module, 'weight') and module.weight is not None:
+        nn.init.normal_(module.weight, mean, std)
     if hasattr(module, 'bias') and module.bias is not None:
         nn.init.constant_(module.bias, bias)
 
 
 def uniform_init(module, a=0, b=1, bias=0):
-    nn.init.uniform_(module.weight, a, b)
+    if hasattr(module, 'weight') and module.weight is not None:
+        nn.init.uniform_(module.weight, a, b)
     if hasattr(module, 'bias') and module.bias is not None:
         nn.init.constant_(module.bias, bias)
 
@@ -44,12 +50,13 @@ def kaiming_init(module,
                  bias=0,
                  distribution='normal'):
     assert distribution in ['uniform', 'normal']
-    if distribution == 'uniform':
-        nn.init.kaiming_uniform_(
-            module.weight, a=a, mode=mode, nonlinearity=nonlinearity)
-    else:
-        nn.init.kaiming_normal_(
-            module.weight, a=a, mode=mode, nonlinearity=nonlinearity)
+    if hasattr(module, 'weight') and module.weight is not None:
+        if distribution == 'uniform':
+            nn.init.kaiming_uniform_(
+                module.weight, a=a, mode=mode, nonlinearity=nonlinearity)
+        else:
+            nn.init.kaiming_normal_(
+                module.weight, a=a, mode=mode, nonlinearity=nonlinearity)
     if hasattr(module, 'bias') and module.bias is not None:
         nn.init.constant_(module.bias, bias)
 
@@ -62,6 +69,7 @@ def caffe2_xavier_init(module, bias=0):
         a=1,
         mode='fan_in',
         nonlinearity='leaky_relu',
+        bias=bias,
         distribution='uniform')
 
 
@@ -71,143 +79,420 @@ def bias_init_with_prob(prior_prob):
     return bias_init
 
 
+class BaseInit(object):
+
+    def __init__(self, bias, layers):
+        if not isinstance(bias, (dict, int, float)):
+            raise TypeError(
+                f'bias must be a dict or numbel, but got {type(bias)}')
+        if isinstance(bias, dict):
+            func = build_from_cfg(bias, INITIALIZERS)
+            self.bias = func()
+        else:
+            self.bias = bias
+        self.layers = layers
+
+
+@INITIALIZERS.register_module()
+class ConstantInit(BaseInit):
+    """Initialize module parameters with constant values.
+
+    Args:
+        val (int | float): the value to fill the weights in the module with
+        bias (int | float | dict, optional): the value to fill the bias or
+        define initialization type for bias. Defaults to 0.
+        layers (str |  [str], optional): the layer will be initialized.
+        Defaults to None.
+    """
+
+    def __init__(self, val, bias=0, layers=None):
+        super().__init__(bias, layers)
+        self.val = val
+
+    def __call__(self, module):
+        if self.layers is None:
+            constant_init(module, self.val, self.bias)
+        else:
+            if isinstance(self.layers, str):
+                layername = module.__class__.__name__
+                if layername == self.layers:
+                    constant_init(module, self.val, self.bias)
+            elif isinstance(self.layers, list):
+                for layer in self.layers:
+                    layername = module.__class__.__name__
+                    if layername == layer:
+                        constant_init(module, self.val, self.bias)
+            else:
+                raise TypeError(
+                    f'layers must be str or [str], but gor {type(self.layers)}'
+                )
+
+
+@INITIALIZERS.register_module()
+class XavierInit(BaseInit):
+    """Initialize module parameters with values according to the method
+    described in `Understanding the difficulty of training deep feedforward
+    neural networks` - Glorot, X. & Bengio, Y. (2010).
+
+    Args:
+        gain (int | float, optional): an optional scaling factor. Defaults
+        to 1.
+        bias (int | float | dict, optional): the value to fill the bias or
+        define initialization type for bias. Defaults to 0.
+        distribution (str, optional): distribution either be ``'normal'``
+        or ``'uniform'``. Defaults to ``'normal'``.
+        layers (str | [str], optional): the layer will be initialized.
+        Defaults to None.
+    """
+
+    def __init__(self, gain=1, bias=0, distribution='normal', layers=None):
+        super().__init__(bias, layers)
+        self.gain = gain
+        self.distribution = distribution
+
+    def __call__(self, module):
+        if self.layers is None:
+            xavier_init(module, self.gain, self.bias, self.distribution)
+        else:
+            if isinstance(self.layers, str):
+                layername = module.__class__.__name__
+                if layername == self.layers:
+                    xavier_init(module, self.gain, self.bias,
+                                self.distribution)
+            elif isinstance(self.layers, list):
+                for layer in self.layers:
+                    layername = module.__class__.__name__
+                    if layername == layer:
+                        xavier_init(module, self.gain, self.bias,
+                                    self.distribution)
+            else:
+                raise TypeError(
+                    f'layers must be str or [str], but gor {type(self.layers)}'
+                )
+
+
+@INITIALIZERS.register_module()
+class NormalInit(BaseInit):
+    r"""Initialize module parameters with the values drawn from the normal
+    distribution :math:`\mathcal{N}(\text{mean}, \text{std}^2)`.
+
+    Args:
+        mean (int | float, optional):the mean of the normal distribution.
+        Defaults to 0.
+        std (int | float, optional): the standard deviation of the normal
+        distribution. Defaults to 1.
+        bias (int | float | dict, optional): the value to fill the bias or
+        define initialization type for bias. Defaults to 0.
+        layers (str | [str], optional): the layer will be initialized.
+        Defaults to None.
+
+    """
+
+    def __init__(self, mean=0, std=1, bias=0, layers=None):
+        super().__init__(bias, layers)
+        self.mean = mean
+        self.std = std
+
+    def __call__(self, module):
+        if self.layers is None:
+            normal_init(module, self.mean, self.std, self.bias)
+        else:
+            if isinstance(self.layers, str):
+                layername = module.__class__.__name__
+                if layername == self.layers:
+                    normal_init(module, self.mean, self.std, self.bias)
+            elif isinstance(self.layers, list):
+                for layer in self.layers:
+                    layername = module.__class__.__name__
+                    if layername == layer:
+                        normal_init(module, self.mean, self.std, self.bias)
+            else:
+                raise TypeError(
+                    f'layers must be str or [str], but gor {type(self.layers)}'
+                )
+
+
+@INITIALIZERS.register_module()
+class UniformInit(BaseInit):
+    r"""Initialize module parameters with values drawn from the uniform
+    distribution :math:`\mathcal{U}(a, b)`.
+
+    Args:
+        a (int | float, optional): the lower bound of the uniform
+        distribution. Defaults to 0.
+        b (int | float, optional): the upper bound of the uniform
+        distribution. Defaults to 1.
+        bias (int | float | dict, optional): the value to fill the bias or
+        define initialization type for bias. Defaults to 0.
+        layers (str | [str], optional): the layer will be initialized.
+        Defaults to None.
+    """
+
+    def __init__(self, a=0, b=1, bias=0, layers=None):
+        super().__init__(bias, layers)
+        self.a = a
+        self.b = b
+
+    def __call__(self, module):
+        if self.layers is None:
+            uniform_init(module, self.a, self.b, self.bias)
+        else:
+            if isinstance(self.layers, str):
+                layername = module.__class__.__name__
+                if layername == self.layers:
+                    uniform_init(module, self.a, self.b, self.bias)
+            elif isinstance(self.layers, list):
+                for layer in self.layers:
+                    layername = module.__class__.__name__
+                    if layername == layer:
+                        uniform_init(module, self.a, self.b, self.bias)
+            else:
+                raise TypeError(
+                    f'layers must be str or [str], but gor {type(self.layers)}'
+                )
+
+
+@INITIALIZERS.register_module()
+class KaimingInit(BaseInit):
+    """Initialize module paramters with the valuse according to the method
+    described in `Delving deep into rectifiers: Surpassing human-level
+    performance on ImageNet classification` - He, K. et al. (2015).
+
+    Args:
+        a (int | float, optional): the negative slope of the rectifier used
+        after this layer (only used with ``'leaky_relu'``). Defaults to 0.
+        mode (str, optional):  either ``'fan_in'`` or ``'fan_out'``.
+        Choosing ``'fan_in'`` preserves the magnitude of the variance of
+        the weights in the forward pass. Choosing ``'fan_out'`` preserves
+        the magnitudes in the backwards pass. Defaults to ``'fan_out'``.
+        nonlinearity (str, optional): the non-linear function
+        (`nn.functional` name), recommended to use only with ``'relu'`` or
+        ``'leaky_relu'`` . Defaults to 'relu'.
+        bias (int | float | dict, optional): the value to fill the bias or
+        define initialization type for bias. Defaults to 0.
+        distribution (str, optional): distribution either be ``'normal'``
+        or ``'uniform'``. Defaults to ``'normal'``.
+        layers (str | [str], optional): the layer will be initialized.
+        Defaults to None.
+    """
+
+    def __init__(self,
+                 a=0,
+                 mode='fan_out',
+                 nonlinearity='relu',
+                 bias=0,
+                 distribution='normal',
+                 layers=None):
+        super().__init__(bias, layers)
+        self.a = a
+        self.mode = mode
+        self.nonlinearity = nonlinearity
+        self.distribution = distribution
+
+    def __call__(self, module):
+        if self.layers is None:
+            kaiming_init(module, self.a, self.mode, self.nonlinearity,
+                         self.bias, self.distribution)
+        else:
+            if isinstance(self.layers, str):
+                layername = module.__class__.__name__
+                if layername == self.layers:
+                    kaiming_init(module, self.a, self.mode, self.nonlinearity,
+                                 self.bias, self.distribution)
+            elif isinstance(self.layers, list):
+                for layer in self.layers:
+                    layername = module.__class__.__name__
+                    if layername == layer:
+                        kaiming_init(module, self.a, self.mode,
+                                     self.nonlinearity, self.bias,
+                                     self.distribution)
+            else:
+                raise TypeError(
+                    f'layers must be str or [str], but gor {type(self.layers)}'
+                )
+
+
+@INITIALIZERS.register_module()
+class BiasInitWithProb(object):
+    """Initialize conv/fc bias value according to giving probablity.
+    Args:
+        prior_prob (float): value as prior probability
+    """
+
+    def __init__(self, prior_prob):
+        self.prior_prob = prior_prob
+
+    def __call__(self):
+        return bias_init_with_prob(self.prior_prob)
+
+
+@INITIALIZERS.register_module()
+class PretrainedInit(object):
+    """Initialize module by loading a pretrained model
+    Args:
+        checkpoint (str): the file should be load
+        prefix (str, optional): the prefix to indicate the sub-module.
+        Defaults to None.
+    """
+
+    def __init__(self, checkpoint, prefix=None, map_location=None):
+        self.checkpoint = checkpoint
+        self.prefix = prefix
+        self.map_location = map_location
+
+    def __call__(self, module):
+        logger = get_logger("mmcv")
+        if self.prefix is None:
+            print_log(f'load model from: {self.checkpoint}', logger=logger)
+            load_checkpoint(
+                module,
+                self.checkpoint,
+                map_location=self.map_location,
+                strict=False,
+                logger=logger)
+        else:
+            print_log(
+                f'load {self.prefix} in model from: {self.checkpoint}',
+                logger=logger)
+            state_dict = _load_checkpoint_with_prefix(
+                self.prefix, self.checkpoint, map_location=self.map_location)
+            load_state_dict(module, state_dict, strict=False, logger=logger)
+
+
+def _initialize(module, cfg):
+    func = build_from_cfg(cfg, INITIALIZERS)
+    if cfg.get('type') == 'PretrainedInit':
+        func(module)
+    else:
+        module.apply(func)
+
+
+def _initialize_cases(module, cases):
+    if isinstance(cases, list):
+        for case in cases:
+            name = case.pop('name', None)
+            if hasattr(module, name):
+                _initialize(getattr(module, name), case)
+            else:
+                raise RuntimeError(f'module did not have attribute {name}')
+
+    elif isinstance(cases, dict):
+        name = cases.pop('name', None)
+        if hasattr(module, name):
+            _initialize(getattr(module, name), cases)
+        else:
+            raise RuntimeError(f'module did not have attribute {name}')
+    else:
+        raise TypeError(f'cases must be a dict or list, but got {type(cases)}')
+
+
 def initialize(module, init_cfg):
     """Initialize a module
 
     Args:
-        module (``torch.nn.Module``): A module will be initialized.
-        init_cfg (dict):  Initialization config dict. It should at least
-            contain the key "type", and "type" value must be "random" or
-            "pretrained", which indicates weights initialization with values
-            drawn from random distribution or a pretrained model. The keys in
-            init_cfg with "random" type must be "Conv2d", "Linear",
-            "BatchNorm2d" etc., names of layers with learnable parameters.
-            The init_cfg with "pretrained" type must contain key "checkpoint"
-            that indicates where to load the pretrained model.
+        module (``torch.nn.Module``): the module will be initialized.
+        init_cfg (dict | list[dict]): initialization config dict to define
+        initializer. OpenMMLab has implemented 7 initializers including
+        ``ConstantInit``, ``XavierInit`, ``NormalInit``, ``UniformInit``,
+        ``KaimingInit``, ``PretrainedInit`` and ``BiasInitWithProb``(only for
+        bias initialization).
 
     Example:
-        >>> model = nn.Linear(2, 3, bias=True)
-        >>> # the value of key "Linear" is a dict that refers to the
-            # initilization function and argments. OpenMMLab has implemented
-            # initialization functions including `constant_init`,
-            # `xavier_init`, `normal_init`, `uniform_init`, `kaiming_init`,
-            # `caffe2_xavier_init` and `bias_init_wth_prob` in mmcv.cnn.utils.
-        >>> init_cfg = dict(type='random', Linear=dict(function='constant_init'
-                val=1, bias=2))
-        >>> initialize(model, init_cfg)
-        >>> for name, param in model.named_parameters():
-                print(name, param)
-        weight Parameter containing:
-        tensor([[1., 1.],
-                [1., 1.],
-                [1., 1.]], requires_grad=True)
-        bias Parameter containing:
-        tensor([2., 2., 2.], requires_grad=True)
-        >>> # It also supports initialization functions implemented in pytorch.
-        >>> init_cfg = dict(type='random',
-                Linear=[
-                    dict(function='constant', parameters='weight', val=3),
-                    dict(function='constant', parameters='bias', val=4)
-                ])
+        >>> module = nn.Linear(2, 3, bias=True)
+        >>> init_cfg = dict(type='ConstantInit', val=1 , bias=2)
         >>> initialize(module, init_cfg)
-        >>> for name, param in model.named_parameters():
-                print(name, param)
-        weight Parameter containing:
-        tensor([[3., 3.],
-                [3., 3.],
-                [3., 3.]], requires_grad=True)
-        bias Parameter containing:
-        tensor([4., 4., 4.], requires_grad=True)
+        >>> for p in module.parameters():
+                print(p)
+            Parameter containing:
+            tensor([[1., 1.],
+                    [1., 1.],
+                    [1., 1.]], requires_grad=True)
+            Parameter containing:
+            tensor([2., 2., 2.], requires_grad=True)
 
-        >>> from mmdet.models.backbones import ResNet
+        >>> module = nn.Sequential(nn.Conv1d(3, 1, 3), nn.Linear(1,2))
+        >>> # define key ``'layers'`` for initializing layers with different
+        >>> # configuration
+        >>> init_cfg = [dict(type='ConstantInit', layers='Conv1d', val=1),
+                dict(type='ConstantInit', layers='Linear', val=2)]
+        >>> initialize(module, init_cfg)
+        >>> for name, param in module.named_parameters():
+                print(name, param)
+        0.weight Parameter containing:
+        tensor([[[1., 1., 1.],
+                [1., 1., 1.],
+                [1., 1., 1.]]], requires_grad=True)
+        0.bias Parameter containing:
+        tensor([0.], requires_grad=True)
+        1.weight Parameter containing:
+        tensor([[2.],
+                [2.]], requires_grad=True)
+        1.bias Parameter containing:
+        tensor([0., 0.], requires_grad=True)
+
+        >>> # Omit ``'layers'`` to initialize module with same configuration
+        >>> init_cfg = dict(type='ConstantInit', val=1, bias=2)
+        >>> initialize(module, init_cfg)
+        >>> for name, param in module.named_parameters():
+                print(name, param)
+        0.weight Parameter containing:
+        tensor([[[1., 1., 1.],
+                [1., 1., 1.],
+                [1., 1., 1.]]], requires_grad=True)
+        0.bias Parameter containing:
+        tensor([2.], requires_grad=True)
+        1.weight Parameter containing:
+        tensor([[1.],
+                [1.]], requires_grad=True)
+        1.bias Parameter containing:
+        tensor([2., 2.], requires_grad=True)
+
+        >>> # define key``'cases'`` to initialize some specific cases in module
+        >>> class FooNet(nn.Module):
+        >>>     def __init__(self):
+        >>>         super().__init__()
+        >>>         self.feat = nn.Conv2d(3, 16, 3)
+        >>>         self.reg = nn.Conv2d(16, 10, 3)
+        >>>         self.cls = nn.Conv2d(16, 5, 3)
+        >>> model = FooNet()
+        >>> init_cfg = dict(type='ConstantInit', val=1, bias=2,
+        >>>     cases=dict(type='ConstantInit', name='reg', val=3, bias=4))
+        >>> initialize(model, init_cfg)
+
         >>> model = ResNet(depth=50)
         >>> # Initialize weights with the pretrained model.
-        >>> init_cfg = dict(type='pretrained',
+        >>> init_cfg = dict(type='PretrainedInit',
                 checkpoint='torchvision://resnet50')
-        >>> initialize(module, init_cfg)
+        >>> initialize(model, init_cfg)
 
         >>> # Intialize weights of a sub-module with the specific part of
         >>> # a pretrained model by using "prefix".
         >>> url = 'http://download.openmmlab.com/mmdetection/v2.0/retinanet/'\
         >>>     'retinanet_r50_fpn_1x_coco/'\
         >>>     'retinanet_r50_fpn_1x_coco_20200130-c2398f9e.pth'
-        >>> init_cfg = dict(type='pretrained',
+        >>> init_cfg = dict(type='PretrainedInit',
                 checkpoint=url, prefix='backbone.')
-
     """
-    if not isinstance(init_cfg, dict):
+    if not isinstance(init_cfg, (dict, list)):
         raise TypeError(f'init_cfg must be a dict, but got {type(init_cfg)}')
-    if 'type' not in init_cfg:
-        raise TypeError(
-            f'init_cfg must contain the key "type", but got {init_cfg}')
-    init_type = init_cfg.get('type')
-    if init_type == 'pretrained':
-        pretrained_init(module, init_cfg)
-    elif init_type == 'random':
-        random_init(module, init_cfg)
+
+    if isinstance(init_cfg, dict):
+        cases = init_cfg.pop('cases', None)
+        _initialize(module, init_cfg)
+
+        if cases is not None:
+            _initialize_cases(module, cases)
+        else:
+            # All attributes in module have same initialization.
+            pass
+
     else:
-        raise TypeError(
-            'the type of init_cfg must be "random" or "pretrained", '
-            f'but got {init_type}')
+        for cfg in init_cfg:
+            cases = cfg.pop('cases', None)
+            _initialize(module, cfg)
 
-
-def random_init(module, init_cfg):
-    """Initialize module with values drawn from a random distribution.
-
-    Args:
-        module (nn.Module): An module will be initialized.
-        init_cfg (dict): Initialization config dict.
-    """
-
-    def init_func(m):
-        classname = m.__class__.__name__
-
-        if init_cfg.get(classname) is not None:
-            if isinstance(init_cfg[classname], list):
-                for cfg_ in init_cfg[classname]:
-                    args = cfg_.copy()
-                    parameters = args.pop('parameters')
-                    init_type = args.pop('function')
-                    if hasattr(nn.init, init_type + "_"):
-                        func = getattr(nn.init, init_type + "_")
-                        if getattr(m, parameters) is not None:
-                            func(getattr(m, parameters), **args)
-                    elif init_type == 'bias_init_with_prob':
-                        bias_cls = bias_init_with_prob(**args)
-                        nn.init.constant_(getattr(m, parameters), bias_cls)
-
+            if cases is not None:
+                _initialize_cases(module, cases)
             else:
-                args = init_cfg[classname].copy()
-                init_type = args.pop('function')
-                func = None
-                if hasattr(nn.init, init_type + "_"):
-                    func = getattr(nn.init, init_type + "_")
-                else:
-                    func = eval(init_type)
-                func(m, **args)
-
-    module.apply(init_func)
-
-
-def pretrained_init(module, init_cfg):
-    """Initialize module by loading a pretrained model
-
-    Args:
-        module (nn.Module): An module will be initialized.
-        init_cfg (dict): Initialization config dict.
-
-    """
-    if 'checkpoint' not in init_cfg:
-        raise TypeError(
-            'init_cfg with "pretrained" type must contain the key "checkpoint"'
-        )
-    checkpoint = init_cfg.get('checkpoint')
-    prefix = init_cfg.get('prefix', '')
-    logger = logging.getLogger()
-    print_log(f'load model from: {checkpoint}', logger=logger)
-    if prefix == '':
-        load_checkpoint(module, checkpoint, strict=False, logger=logger)
-
-    else:
-        state_dict = _load_checkpoint_with_prefix(prefix, checkpoint)
-        load_state_dict(module, state_dict, strict=False, logger=logger)
+                # All attributes in module have same initialization.
+                pass

--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -3,8 +3,8 @@ import logging
 import numpy as np
 import torch.nn as nn
 
-from mmcv.runner import (_load_checkpoint, _load_checkpoint_with_prefix,
-                         load_checkpoint, load_state_dict)
+from mmcv.runner import (_load_checkpoint_with_prefix, load_checkpoint,
+                         load_state_dict)
 from mmcv.utils import print_log
 
 
@@ -75,7 +75,7 @@ def initialize(module, init_cfg):
     """Initialize a module
 
     Args:
-        module (``torch.nn.Module``): An module will be initialized.
+        module (``torch.nn.Module``): A module will be initialized.
         init_cfg (dict):  Initialization config dict. It should at least
             contain the key "type", and "type" value must be "random" or
             "pretrained", which indicates weights initialization with values
@@ -87,12 +87,12 @@ def initialize(module, init_cfg):
 
     Example:
         >>> model = nn.Linear(2, 3, bias=True)
-        >>> # the values of "Linear" is dict that refers to the initilization
-            # function and argments. OpenMMLab has implemented initialization
-            # functions including `constant_init`, `xavier_init`, `normal_init`,
-            # `uniform_init`, `kaiming_init`, `caffe2_xavier_init` and
-            # `bias_init_wth_prob` in mmcv.cnn.utils.
-        >>> init_cfg = dict(type='random', Linear=dict(function='constant_init',
+        >>> # the value of key "Linear" is a dict that refers to the
+            # initilization function and argments. OpenMMLab has implemented
+            # initialization functions including `constant_init`,
+            # `xavier_init`, `normal_init`, `uniform_init`, `kaiming_init`,
+            # `caffe2_xavier_init` and `bias_init_wth_prob` in mmcv.cnn.utils.
+        >>> init_cfg = dict(type='random', Linear=dict(function='constant_init'
                 val=1, bias=2))
         >>> initialize(model, init_cfg)
         >>> for name, param in model.named_parameters():

--- a/mmcv/runner/__init__.py
+++ b/mmcv/runner/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Open-MMLab. All rights reserved.
-from .base_runner import BaseRunner
+from .base_runner import BaseRunner, BaseModule
 from .builder import RUNNERS, build_runner
 from .checkpoint import (_load_checkpoint, _load_checkpoint_with_prefix,
                          load_checkpoint, load_state_dict, save_checkpoint,
@@ -35,5 +35,5 @@ __all__ = [
     'set_random_seed', 'auto_fp16', 'force_fp32', 'wrap_fp16_model',
     'Fp16OptimizerHook', 'SyncBuffersHook', 'EMAHook', 'build_runner',
     'RUNNERS', 'allreduce_grads', 'allreduce_params', 'LossScaler',
-    '_load_checkpoint_with_prefix'
+    '_load_checkpoint_with_prefix', 'BaseModule'
 ]

--- a/mmcv/runner/__init__.py
+++ b/mmcv/runner/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) Open-MMLab. All rights reserved.
-from .base_runner import BaseRunner, BaseModule
+from .base_runner import BaseRunner
+from .base_module import BaseModule
 from .builder import RUNNERS, build_runner
 from .checkpoint import (_load_checkpoint, _load_checkpoint_with_prefix,
                          load_checkpoint, load_state_dict, save_checkpoint,

--- a/mmcv/runner/__init__.py
+++ b/mmcv/runner/__init__.py
@@ -1,8 +1,9 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 from .base_runner import BaseRunner
 from .builder import RUNNERS, build_runner
-from .checkpoint import (_load_checkpoint, load_checkpoint, load_state_dict,
-                         save_checkpoint, weights_to_cpu)
+from .checkpoint import (_load_checkpoint, _load_checkpoint_with_prefix,
+                         load_checkpoint, load_state_dict, save_checkpoint,
+                         weights_to_cpu)
 from .dist_utils import (allreduce_grads, allreduce_params, get_dist_info,
                          init_dist, master_only)
 from .epoch_based_runner import EpochBasedRunner, Runner
@@ -33,5 +34,6 @@ __all__ = [
     'build_optimizer', 'build_optimizer_constructor', 'IterLoader',
     'set_random_seed', 'auto_fp16', 'force_fp32', 'wrap_fp16_model',
     'Fp16OptimizerHook', 'SyncBuffersHook', 'EMAHook', 'build_runner',
-    'RUNNERS', 'allreduce_grads', 'allreduce_params', 'LossScaler'
+    'RUNNERS', 'allreduce_grads', 'allreduce_params', 'LossScaler',
+    '_load_checkpoint_with_prefix'
 ]

--- a/mmcv/runner/base_module.py
+++ b/mmcv/runner/base_module.py
@@ -1,0 +1,42 @@
+# Copyright (c) Open-MMLab. All rights reserved.
+
+from abc import ABCMeta
+
+import torch.nn as nn
+
+from mmcv.cnn import initialize
+
+
+class BaseModule(nn.Module, metaclass=ABCMeta):
+    """Base module for all modules in openmmlab"""
+
+    def __init__(self, init_cfg=None):
+        """Initialize BaseModule, inherited from `torch.nn.Module`
+
+        Args:
+            init_cfg (dict, optional): Initialization config dict.
+        """
+
+        # NOTE init_cfg can be defined in different levels, but init_cfg
+        # in low levels has a higher priority.
+
+        super(BaseModule, self).__init__()
+        # define default value of init_cfg instead of hard code
+        # in init_weigt() function
+
+        if init_cfg is not None:
+            self.init_cfg = init_cfg
+
+        # Backward compatibility
+        # if pretrained is not None:
+        #     self.init_cfg = dict(
+        #         type='pretrained', checkpoint=pretrained)
+
+    def init_weight(self):
+        """Initialize the weights.
+        """
+        if hasattr(self, 'init_cfg'):
+            initialize(self, self.init_cfg)
+        for module in self.children():
+            if 'init_weight' in dir(module):
+                module.init_weight()

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -3,12 +3,12 @@ import os
 import os.path as osp
 import pkgutil
 import time
-import torch
-import torchvision
 import warnings
 from collections import OrderedDict
 from importlib import import_module
 from tempfile import TemporaryDirectory
+import torch
+import torchvision
 from torch.optim import Optimizer
 from torch.utils import model_zoo
 

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -16,7 +16,7 @@ import mmcv
 from ..fileio import load as load_file
 from ..parallel import is_module_wrapper
 from ..utils import mkdir_or_exist
-from .dist_utils import get_dist_info
+from .dist_utils import get_dist_infos
 
 ENV_MMCV_HOME = 'MMCV_HOME'
 ENV_XDG_CACHE_HOME = 'XDG_CACHE_HOME'
@@ -255,7 +255,7 @@ def _load_checkpoint(filename, map_location=None):
     return checkpoint
 
 
-def _load_checkpoint_with_prefix(prefix, filename):
+def _load_checkpoint_with_prefix(prefix, filename, map_location=None):
     """Load partial pretrained model with specific prefix.
 
     Args:
@@ -263,25 +263,28 @@ def _load_checkpoint_with_prefix(prefix, filename):
         filename (str): Accept local filepath, URL, ``torchvision://xxx``,
             ``open-mmlab://xxx``. Please refer to ``docs/model_zoo.md`` for
             details.
+        map_location (str | None): Same as :func:`torch.load`. Default: None.
 
     Returns:
         dict or OrderedDict: The loaded checkpoint.
     """
 
-    checkpoint = _load_checkpoint(filename)
+    checkpoint = _load_checkpoint(filename, map_location=map_location)
+
     if 'state_dict' in checkpoint:
         state_dict = checkpoint['state_dict']
     else:
         state_dict = checkpoint
-
     if not prefix.endswith('.'):
         prefix += '.'
     prefix_len = len(prefix)
+
     state_dict = {
         k[prefix_len:]: v
         for k, v in state_dict.items() if k.startswith(prefix)
     }
-    assert state_dict, 'f{prefix} is not in the pretrained model'
+
+    assert state_dict, f'{prefix} is not in the pretrained model'
     return state_dict
 
 

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -16,7 +16,7 @@ import mmcv
 from ..fileio import load as load_file
 from ..parallel import is_module_wrapper
 from ..utils import mkdir_or_exist
-from .dist_utils import get_dist_infos
+from .dist_utils import get_dist_info
 
 ENV_MMCV_HOME = 'MMCV_HOME'
 ENV_XDG_CACHE_HOME = 'XDG_CACHE_HOME'

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -7,6 +7,7 @@ import warnings
 from collections import OrderedDict
 from importlib import import_module
 from tempfile import TemporaryDirectory
+
 import torch
 import torchvision
 from torch.optim import Optimizer

--- a/tests/test_cnn/test_weight_init.py
+++ b/tests/test_cnn/test_weight_init.py
@@ -1,12 +1,18 @@
 # Copyright (c) Open-MMLab. All rights reserved.
+from sys import prefix
 import numpy as np
+from tempfile import TemporaryDirectory
 import pytest
 import torch
 from torch import nn
+from torch.nn.modules.conv import Conv1d
+from torch.serialization import check_module_version_greater_or_equal
 
 from mmcv.cnn import (bias_init_with_prob, caffe2_xavier_init, constant_init,
-                      initialize, kaiming_init, normal_init, pretrained_init,
-                      random_init, uniform_init, xavier_init)
+                      initialize, kaiming_init, normal_init, uniform_init,
+                      xavier_init, ConstantInit, XavierInit, NormalInit,
+                      UniformInit, KaimingInit, BiasInitWithProb,
+                      PretrainedInit)
 
 
 def test_constant_init():
@@ -78,74 +84,215 @@ def test_bias_init_with_prob():
     assert conv_module.bias.allclose(torch.full_like(conv_module.bias, bias))
 
 
+def test_constaninit():
+    """test ConstantInit class"""
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Linear(1, 2))
+    func = ConstantInit(val=1, bias=2, layers='Conv2d')
+    model.apply(func)
+    assert model[0].weight.allclose(torch.tensor(1.0), rtol=0)
+    assert model[0].bias.allclose(torch.tensor(2.0), rtol=0)
+    assert not model[2].weight.allclose(torch.tensor(1.0), rtol=0)
+    assert not model[2].bias.allclose(torch.tensor(2.0), rtol=0)
+
+    func = ConstantInit(
+        val=3,
+        bias=dict(type='BiasInitWithProb', prior_prob=0.01),
+        layers='Linear')
+    model.apply(func)
+    res = bias_init_with_prob(0.01)
+    assert model[0].weight.allclose(torch.tensor(1.0))
+    assert model[2].weight.allclose(torch.tensor(3.0))
+    assert model[0].bias.allclose(torch.tensor(2.0))
+    assert model[2].bias.allclose(torch.tensor(res))
+
+    func = ConstantInit(val=4, bias=5)
+    model.apply(func)
+    assert model[0].weight.allclose(torch.tensor(4.0))
+    assert model[2].weight.allclose(torch.tensor(4.0))
+    assert model[0].bias.allclose(torch.tensor(5.0))
+    assert model[2].bias.allclose(torch.tensor(5.0))
+
+    with pytest.raises(TypeError):
+        func = ConstantInit(val=1, bias='1')
+
+
+def test_xavierinit():
+    """test XavierInit class """
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Linear(1, 2))
+    func = XavierInit(bias=0.1, layers='Conv2d')
+    model.apply(func)
+    assert model[0].bias.allclose(torch.full_like(model[2].bias, 0.1))
+    assert not model[2].bias.allclose(torch.full_like(model[0].bias, 0.1))
+
+    constant_func = ConstantInit(val=0, bias=0)
+    func = XavierInit(
+        gain=100, bias=dict(type='BiasInitWithProb', prior_prob=0.01))
+    model.apply(constant_func)
+    assert model[0].weight.allclose(torch.tensor(0.0))
+    assert model[2].weight.allclose(torch.tensor(0.0))
+    assert model[0].bias.allclose(torch.tensor(0.0))
+    assert model[2].bias.allclose(torch.tensor(0.0))
+    res = bias_init_with_prob(0.01)
+    model.apply(func)
+    assert not model[0].weight.allclose(torch.tensor(0.0))
+    assert not model[2].weight.allclose(torch.tensor(0.0))
+    assert model[0].bias.allclose(torch.tensor(res))
+    assert model[2].bias.allclose(torch.tensor(res))
+
+
+def test_normalinit():
+    """test Normalinit class"""
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Linear(1, 2))
+
+    func = NormalInit(mean=100, std=1e-5, bias=200)
+    model.apply(func)
+    assert model[0].weight.allclose(torch.tensor(100.0))
+    assert model[2].weight.allclose(torch.tensor(100.0))
+    assert model[0].bias.allclose(torch.tensor(200.0), rtol=0)
+    assert model[2].bias.allclose(torch.tensor(200.0), rtol=0)
+
+    func = NormalInit(
+        mean=300,
+        std=1e-5,
+        bias=dict(type='BiasInitWithProb', prior_prob=0.01),
+        layers=['Conv2d', 'Linear'])
+    res = bias_init_with_prob(0.01)
+    model.apply(func)
+    assert model[0].weight.allclose(torch.tensor(300.0))
+    assert model[2].weight.allclose(torch.tensor(300.0))
+    assert model[0].bias.allclose(torch.tensor(res), rtol=0)
+    assert model[2].bias.allclose(torch.tensor(res), rtol=0)
+
+
+def test_uniforminit():
+    """"test UniformInit class"""
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Linear(1, 2))
+    func = UniformInit(a=1, b=1, bias=2)
+    model.apply(func)
+    assert model[0].weight.allclose(torch.tensor(1.0))
+    assert model[2].weight.allclose(torch.tensor(1.0))
+    assert model[0].bias.allclose(torch.tensor(2.0))
+    assert model[2].bias.allclose(torch.tensor(2.0))
+
+    func = UniformInit(a=100, b=100, layers=['Conv2d', 'Linear'], bias=10)
+    model.apply(func)
+    assert model[0].weight.allclose(torch.tensor(100.0))
+    assert model[2].weight.allclose(torch.tensor(100.0))
+    assert model[0].bias.allclose(torch.tensor(10.0))
+    assert model[2].bias.allclose(torch.tensor(10.0))
+
+
+def test_kaiminginit():
+    """test KaimingInit class"""
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Linear(1, 2))
+    func = KaimingInit(bias=0.1, layers='Conv2d')
+    model.apply(func)
+    assert model[0].bias.allclose(torch.full_like(model[2].bias, 0.1))
+    assert not model[2].bias.allclose(torch.full_like(model[0].bias, 0.1))
+
+    func = KaimingInit(a=100, bias=10)
+    constant_func = ConstantInit(val=0, bias=0)
+    model.apply(constant_func)
+    assert model[0].weight.allclose(torch.tensor(0.0))
+    assert model[2].weight.allclose(torch.tensor(0.0))
+    assert model[0].bias.allclose(torch.tensor(0.0))
+    assert model[2].bias.allclose(torch.tensor(0.0))
+
+    model.apply(func)
+    assert not model[0].weight.allclose(torch.tensor(0.0))
+    assert not model[2].weight.allclose(torch.tensor(0.0))
+    assert model[0].bias.allclose(torch.tensor(10.0))
+    assert model[2].bias.allclose(torch.tensor(10.0))
+
+
+def test_biasinitwithprob():
+    """test BiasInitWithProb class"""
+    func = BiasInitWithProb(0.5)
+    res = func()
+    assert res == bias_init_with_prob(0.5)
+
+
+class FooModule(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(1, 2)
+        self.conv2d = nn.Conv2d(3, 1, 3)
+        self.conv2d_2 = nn.Conv2d(3, 2, 3)
+
+
+def test_pretrainedinit():
+    """test PretrainedInit class"""
+
+    modelA = FooModule()
+    constant_func = ConstantInit(val=1, bias=2)
+    modelA.apply(constant_func)
+    modelB = FooModule()
+    funcB = PretrainedInit(checkpoint='modelA.pth')
+    modelC = nn.Linear(1, 2)
+    funcC = PretrainedInit(checkpoint='modelA.pth', prefix='linear.')
+    with TemporaryDirectory():
+        torch.save(modelA.state_dict(), 'modelA.pth')
+        funcB(modelB)
+        assert modelB.linear.weight.allclose(torch.tensor(1.0))
+        assert modelB.linear.bias.allclose(torch.tensor(2.0))
+        assert modelB.conv2d.weight.allclose(torch.tensor(1.0))
+        assert modelB.conv2d.bias.allclose(torch.tensor(2.0))
+        assert modelB.conv2d_2.weight.allclose(torch.tensor(1.0))
+        assert modelB.conv2d_2.bias.allclose(torch.tensor(2.0))
+        funcC(modelC)
+        assert modelC.weight.allclose(torch.tensor(1.0))
+        assert modelC.bias.allclose(torch.tensor(2.0))
+
+
 def test_initialize():
-    model = nn.Sequential(nn.Conv2d(2, 5, 3), nn.ReLU(), nn.Linear(20, 10))
-    init_cfg = dict(
-        type='random',
-        Conv2d=[
-            dict(function='constant', parameters='weight', val=1),
-            dict(function='constant', parameters='bias', val=2)
-        ],
-        Linear=dict(function='constant_init', val=3, bias=4))
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Linear(1, 2))
+    foonet = FooModule()
 
+    init_cfg = dict(type='ConstantInit', val=1, bias=2)
     initialize(model, init_cfg)
-    for i, parameter in enumerate(model.parameters()):
-        assert parameter.allclose(torch.tensor(float(i + 1)))
-    init_cfg = 'torchvision://resnet50'
-    with pytest.raises(TypeError):
-        initialize(model, init_cfg)
-    init_cfg = dict()
-    with pytest.raises(TypeError):
-        initialize(model, init_cfg)
+    assert model[0].weight.allclose(torch.tensor(1.0))
+    assert model[2].weight.allclose(torch.tensor(1.0))
+    assert model[0].bias.allclose(torch.tensor(2.0))
+    assert model[2].bias.allclose(torch.tensor(2.0))
+
+    init_cfg = [
+        dict(type='ConstantInit', layers='Conv1d', val=1, bias=2),
+        dict(type='ConstantInit', layers='Linear', val=3, bias=4)
+    ]
+    initialize(model, init_cfg)
+    assert model[0].weight.allclose(torch.tensor(1.0))
+    assert model[2].weight.allclose(torch.tensor(3.0))
+    assert model[0].bias.allclose(torch.tensor(2.0))
+    assert model[2].bias.allclose(torch.tensor(4.0))
+
     init_cfg = dict(
-        type='init', Linear=dict(function='constant_init', val=3, bias=4))
-    with pytest.raises(TypeError):
-        initialize(model, init_cfg)
+        type='ConstantInit',
+        val=1,
+        bias=2,
+        layers=['Conv2d', 'Linear'],
+        cases=dict(type='ConstantInit', name='conv2d_2', val=3, bias=4))
+    initialize(foonet, init_cfg)
+    assert foonet.linear.weight.allclose(torch.tensor(1.0))
+    assert foonet.linear.bias.allclose(torch.tensor(2.0))
+    assert foonet.conv2d.weight.allclose(torch.tensor(1.0))
+    assert foonet.conv2d.bias.allclose(torch.tensor(2.0))
+    assert foonet.conv2d_2.weight.allclose(torch.tensor(3.0))
+    assert foonet.conv2d_2.bias.allclose(torch.tensor(4.0))
 
-
-def test_random_init():
-    model = nn.Conv2d(2, 5, 3, bias=True)
     init_cfg = dict(
-        type='random',
-        Conv2d=[
-            dict(function='constant', parameters='weight', val=1),
-            dict(function='constant', parameters='bias', val=2)
-        ])
-    random_init(model, init_cfg)
-    assert model.weight.allclose(torch.tensor(1.0))
-    assert model.bias.allclose(torch.tensor(2.0))
-    init_cfg = dict(
-        type='random', Conv2d=dict(function='constant_init', val=3, bias=4))
-    random_init(model, init_cfg)
-    assert model.weight.allclose(torch.tensor(3.0))
-    assert model.bias.allclose(torch.tensor(4.0))
-
-
-def test_pretrained_init():
-    from mmdet.models import ResNet
-    model = ResNet(
-        depth=50,
-        num_stages=4,
-        out_indices=(0, 1, 2, 3),
-    )
-    url = 'torchvision://resnet50'
-    init_cfg = dict(type='pretrained', checkpoint=url)
-    pretrained_init(model, init_cfg)
-    from torchvision.models import resnet50
-    model_from_torchvision = resnet50(pretrained=True)
-    for (name,
-         p), (name_torchvision,
-              p_torchvision) in zip(model.named_parameters(),
-                                    model_from_torchvision.named_parameters()):
-        assert name == name_torchvision
-        assert torch.equal(p, p_torchvision)
-
-    url = 'http://download.openmmlab.com/mmdetection/v2.0/retinanet/'\
-        'retinanet_r50_fpn_1x_coco/'\
-        'retinanet_r50_fpn_1x_coco_20200130-c2398f9e.pth'
-    init_cfg = dict(type='pretrained', checkpoint=url, prefix='backbone.')
-    pretrained_init(model, init_cfg)
-
-    init_cfg = dict(type='pretrained')
-    with pytest.raises(TypeError):
-        pretrained_init(model, init_cfg)
+        type='PretrainedInit',
+        checkpoint='modelA.pth',
+        cases=dict(type='ConstantInit', name='conv2d_2', val=3, bias=4))
+    modelA = FooModule()
+    constant_func = ConstantInit(val=1, bias=2)
+    modelA.apply(constant_func)
+    with TemporaryDirectory():
+        torch.save(modelA.state_dict(), 'modelA.pth')
+        initialize(foonet, init_cfg)
+        assert foonet.linear.weight.allclose(torch.tensor(1.0))
+        assert foonet.linear.bias.allclose(torch.tensor(2.0))
+        assert foonet.conv2d.weight.allclose(torch.tensor(1.0))
+        assert foonet.conv2d.bias.allclose(torch.tensor(2.0))
+        assert foonet.conv2d_2.weight.allclose(torch.tensor(3.0))
+        assert foonet.conv2d_2.bias.allclose(torch.tensor(4.0))

--- a/tests/test_cnn/test_weight_init.py
+++ b/tests/test_cnn/test_weight_init.py
@@ -5,7 +5,8 @@ import torch
 from torch import nn
 
 from mmcv.cnn import (bias_init_with_prob, caffe2_xavier_init, constant_init,
-                      kaiming_init, normal_init, uniform_init, xavier_init)
+                      initialize, kaiming_init, normal_init, pretrained_init,
+                      random_init, uniform_init, xavier_init)
 
 
 def test_constant_init():
@@ -75,3 +76,76 @@ def test_bias_init_with_prob():
     # TODO: sanity check of weight distribution, e.g. mean, std
     bias = float(-np.log((1 - prior_prob) / prior_prob))
     assert conv_module.bias.allclose(torch.full_like(conv_module.bias, bias))
+
+
+def test_initialize():
+    model = nn.Sequential(nn.Conv2d(2, 5, 3), nn.ReLU(), nn.Linear(20, 10))
+    init_cfg = dict(
+        type='random',
+        Conv2d=[
+            dict(function='constant', parameters='weight', val=1),
+            dict(function='constant', parameters='bias', val=2)
+        ],
+        Linear=dict(function='constant_init', val=3, bias=4))
+
+    initialize(model, init_cfg)
+    for i, parameter in enumerate(model.parameters()):
+        assert parameter.allclose(torch.tensor(float(i + 1)))
+    init_cfg = 'torchvision://resnet50'
+    with pytest.raises(TypeError):
+        initialize(model, init_cfg)
+    init_cfg = dict()
+    with pytest.raises(TypeError):
+        initialize(model, init_cfg)
+    init_cfg = init_cfg = dict(
+        type='init', Linear=dict(function='constant_init', val=3, bias=4))
+    with pytest.raises(TypeError):
+        initialize(model, init_cfg)
+
+
+def test_random_init():
+    model = nn.Conv2d(2, 5, 3, bias=True)
+    init_cfg = dict(
+        type='random',
+        Conv2d=[
+            dict(function='constant', parameters='weight', val=1),
+            dict(function='constant', parameters='bias', val=2)
+        ])
+    random_init(model, init_cfg)
+    assert model.weight.allclose(torch.tensor(1.0))
+    assert model.bias.allclose(torch.tensor(2.0))
+    init_cfg = dict(
+        type='random', Conv2d=dict(function='constant_init', val=3, bias=4))
+    random_init(model, init_cfg)
+    assert model.weight.allclose(torch.tensor(3.0))
+    assert model.bias.allclose(torch.tensor(4.0))
+
+
+def test_pretrained_init():
+    from mmdet.models import ResNet
+    model = ResNet(
+        depth=50,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+    )
+    url = 'torchvision://resnet50'
+    init_cfg = dict(type='pretrained', checkpoint=url)
+    pretrained_init(model, init_cfg)
+    from torchvision.models import resnet50
+    model_from_torchvision = resnet50(pretrained=True)
+    for (name,
+         p), (name_torchvision,
+              p_torchvision) in zip(model.named_parameters(),
+                                    model_from_torchvision.named_parameters()):
+        assert name == name_torchvision
+        assert torch.equal(p, p_torchvision)
+
+    url = 'http://download.openmmlab.com/mmdetection/v2.0/retinanet/'\
+        'retinanet_r50_fpn_1x_coco/'\
+        'retinanet_r50_fpn_1x_coco_20200130-c2398f9e.pth'
+    init_cfg = dict(type='pretrained', checkpoint=url, prefix='backbone.')
+    pretrained_init(model, init_cfg)
+
+    init_cfg = dict(type='pretrained')
+    with pytest.raises(TypeError):
+        pretrained_init(model, init_cfg)

--- a/tests/test_cnn/test_weight_init.py
+++ b/tests/test_cnn/test_weight_init.py
@@ -86,10 +86,12 @@ def test_constaninit():
     model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Linear(1, 2))
     func = ConstantInit(val=1, bias=2, layers='Conv2d')
     model.apply(func)
-    assert model[0].weight.allclose(torch.tensor(1.0), rtol=0)
-    assert model[0].bias.allclose(torch.tensor(2.0), rtol=0)
-    assert not model[2].weight.allclose(torch.tensor(1.0), rtol=0)
-    assert not model[2].bias.allclose(torch.tensor(2.0), rtol=0)
+    assert torch.equal(model[0].weight, torch.full(model[0].weight.shape, 1.0))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 2.0))
+
+    assert not torch.equal(model[2].weight,
+                           torch.full(model[2].weight.shape, 1.0))
+    assert not torch.equal(model[2].bias, torch.full(model[2].bias.shape, 2.0))
 
     func = ConstantInit(
         val=3,
@@ -97,17 +99,18 @@ def test_constaninit():
         layers='Linear')
     model.apply(func)
     res = bias_init_with_prob(0.01)
-    assert model[0].weight.allclose(torch.tensor(1.0))
-    assert model[2].weight.allclose(torch.tensor(3.0))
-    assert model[0].bias.allclose(torch.tensor(2.0))
-    assert model[2].bias.allclose(torch.tensor(res))
+
+    assert torch.equal(model[0].weight, torch.full(model[0].weight.shape, 1.0))
+    assert torch.equal(model[2].weight, torch.full(model[2].weight.shape, 3.0))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 2.0))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, res))
 
     func = ConstantInit(val=4, bias=5)
     model.apply(func)
-    assert model[0].weight.allclose(torch.tensor(4.0))
-    assert model[2].weight.allclose(torch.tensor(4.0))
-    assert model[0].bias.allclose(torch.tensor(5.0))
-    assert model[2].bias.allclose(torch.tensor(5.0))
+    assert torch.equal(model[0].weight, torch.full(model[0].weight.shape, 4.0))
+    assert torch.equal(model[2].weight, torch.full(model[2].weight.shape, 4.0))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 5.0))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, 5.0))
     # test bias input type
     with pytest.raises(TypeError):
         func = ConstantInit(val=1, bias='1')
@@ -125,16 +128,19 @@ def test_xavierinit():
     func = XavierInit(
         gain=100, bias=dict(type='BiasInitWithProb', prior_prob=0.01))
     model.apply(constant_func)
-    assert model[0].weight.allclose(torch.tensor(0.0))
-    assert model[2].weight.allclose(torch.tensor(0.0))
-    assert model[0].bias.allclose(torch.tensor(0.0))
-    assert model[2].bias.allclose(torch.tensor(0.0))
+    assert torch.equal(model[0].weight, torch.full(model[0].weight.shape, 0.0))
+    assert torch.equal(model[2].weight, torch.full(model[2].weight.shape, 0.0))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 0.0))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, 0.0))
+
     res = bias_init_with_prob(0.01)
     model.apply(func)
-    assert not model[0].weight.allclose(torch.tensor(0.0))
-    assert not model[2].weight.allclose(torch.tensor(0.0))
-    assert model[0].bias.allclose(torch.tensor(res))
-    assert model[2].bias.allclose(torch.tensor(res))
+    assert not torch.equal(model[0].weight,
+                           torch.full(model[0].weight.shape, 0.0))
+    assert not torch.equal(model[2].weight,
+                           torch.full(model[2].weight.shape, 0.0))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, res))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, res))
 
 
 def test_normalinit():
@@ -145,8 +151,8 @@ def test_normalinit():
     model.apply(func)
     assert model[0].weight.allclose(torch.tensor(100.0))
     assert model[2].weight.allclose(torch.tensor(100.0))
-    assert model[0].bias.allclose(torch.tensor(200.0), rtol=0)
-    assert model[2].bias.allclose(torch.tensor(200.0), rtol=0)
+    assert model[0].bias.allclose(torch.tensor(200.0))
+    assert model[2].bias.allclose(torch.tensor(200.0))
 
     func = NormalInit(
         mean=300,
@@ -157,8 +163,8 @@ def test_normalinit():
     model.apply(func)
     assert model[0].weight.allclose(torch.tensor(300.0))
     assert model[2].weight.allclose(torch.tensor(300.0))
-    assert model[0].bias.allclose(torch.tensor(res), rtol=0)
-    assert model[2].bias.allclose(torch.tensor(res), rtol=0)
+    assert model[0].bias.allclose(torch.tensor(res))
+    assert model[2].bias.allclose(torch.tensor(res))
 
 
 def test_uniforminit():
@@ -166,17 +172,19 @@ def test_uniforminit():
     model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Linear(1, 2))
     func = UniformInit(a=1, b=1, bias=2)
     model.apply(func)
-    assert model[0].weight.allclose(torch.tensor(1.0))
-    assert model[2].weight.allclose(torch.tensor(1.0))
-    assert model[0].bias.allclose(torch.tensor(2.0))
-    assert model[2].bias.allclose(torch.tensor(2.0))
+    assert torch.equal(model[0].weight, torch.full(model[0].weight.shape, 1.0))
+    assert torch.equal(model[2].weight, torch.full(model[2].weight.shape, 1.0))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 2.0))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, 2.0))
 
     func = UniformInit(a=100, b=100, layers=['Conv2d', 'Linear'], bias=10)
     model.apply(func)
-    assert model[0].weight.allclose(torch.tensor(100.0))
-    assert model[2].weight.allclose(torch.tensor(100.0))
-    assert model[0].bias.allclose(torch.tensor(10.0))
-    assert model[2].bias.allclose(torch.tensor(10.0))
+    assert torch.equal(model[0].weight, torch.full(model[0].weight.shape,
+                                                   100.0))
+    assert torch.equal(model[2].weight, torch.full(model[2].weight.shape,
+                                                   100.0))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 10.0))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, 10.0))
 
 
 def test_kaiminginit():
@@ -184,22 +192,24 @@ def test_kaiminginit():
     model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Linear(1, 2))
     func = KaimingInit(bias=0.1, layers='Conv2d')
     model.apply(func)
-    assert model[0].bias.allclose(torch.full_like(model[2].bias, 0.1))
-    assert not model[2].bias.allclose(torch.full_like(model[0].bias, 0.1))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 0.1))
+    assert not torch.equal(model[2].bias, torch.full(model[2].bias.shape, 0.1))
 
     func = KaimingInit(a=100, bias=10)
     constant_func = ConstantInit(val=0, bias=0)
     model.apply(constant_func)
-    assert model[0].weight.allclose(torch.tensor(0.0))
-    assert model[2].weight.allclose(torch.tensor(0.0))
-    assert model[0].bias.allclose(torch.tensor(0.0))
-    assert model[2].bias.allclose(torch.tensor(0.0))
+    assert torch.equal(model[0].weight, torch.full(model[0].weight.shape, 0.0))
+    assert torch.equal(model[2].weight, torch.full(model[2].weight.shape, 0.0))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 0.0))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, 0.0))
 
     model.apply(func)
-    assert not model[0].weight.allclose(torch.tensor(0.0))
-    assert not model[2].weight.allclose(torch.tensor(0.0))
-    assert model[0].bias.allclose(torch.tensor(10.0))
-    assert model[2].bias.allclose(torch.tensor(10.0))
+    assert not torch.equal(model[0].weight,
+                           torch.full(model[0].weight.shape, 0.0))
+    assert not torch.equal(model[2].weight,
+                           torch.full(model[2].weight.shape, 0.0))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 10.0))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, 10.0))
 
 
 def test_biasinitwithprob():
@@ -231,15 +241,22 @@ def test_pretrainedinit():
     with TemporaryDirectory():
         torch.save(modelA.state_dict(), 'modelA.pth')
         funcB(modelB)
-        assert modelB.linear.weight.allclose(torch.tensor(1.0))
-        assert modelB.linear.bias.allclose(torch.tensor(2.0))
-        assert modelB.conv2d.weight.allclose(torch.tensor(1.0))
-        assert modelB.conv2d.bias.allclose(torch.tensor(2.0))
-        assert modelB.conv2d_2.weight.allclose(torch.tensor(1.0))
-        assert modelB.conv2d_2.bias.allclose(torch.tensor(2.0))
+        assert torch.equal(modelB.linear.weight,
+                           torch.full(modelB.linear.weight.shape, 1.0))
+        assert torch.equal(modelB.linear.bias,
+                           torch.full(modelB.linear.bias.shape, 2.0))
+        assert torch.equal(modelB.conv2d.weight,
+                           torch.full(modelB.conv2d.weight.shape, 1.0))
+        assert torch.equal(modelB.conv2d.bias,
+                           torch.full(modelB.conv2d.bias.shape, 2.0))
+        assert torch.equal(modelB.conv2d_2.weight,
+                           torch.full(modelB.conv2d_2.weight.shape, 1.0))
+        assert torch.equal(modelB.conv2d_2.bias,
+                           torch.full(modelB.conv2d_2.bias.shape, 2.0))
+
         funcC(modelC)
-        assert modelC.weight.allclose(torch.tensor(1.0))
-        assert modelC.bias.allclose(torch.tensor(2.0))
+        assert torch.equal(modelC.weight, torch.full(modelC.weight.shape, 1.0))
+        assert torch.equal(modelC.bias, torch.full(modelC.bias.shape, 2.0))
 
 
 def test_initialize():
@@ -248,20 +265,20 @@ def test_initialize():
 
     init_cfg = dict(type='ConstantInit', val=1, bias=2)
     initialize(model, init_cfg)
-    assert model[0].weight.allclose(torch.tensor(1.0))
-    assert model[2].weight.allclose(torch.tensor(1.0))
-    assert model[0].bias.allclose(torch.tensor(2.0))
-    assert model[2].bias.allclose(torch.tensor(2.0))
+    assert torch.equal(model[0].weight, torch.full(model[0].weight.shape, 1.0))
+    assert torch.equal(model[2].weight, torch.full(model[2].weight.shape, 1.0))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 2.0))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, 2.0))
 
     init_cfg = [
         dict(type='ConstantInit', layers='Conv1d', val=1, bias=2),
         dict(type='ConstantInit', layers='Linear', val=3, bias=4)
     ]
     initialize(model, init_cfg)
-    assert model[0].weight.allclose(torch.tensor(1.0))
-    assert model[2].weight.allclose(torch.tensor(3.0))
-    assert model[0].bias.allclose(torch.tensor(2.0))
-    assert model[2].bias.allclose(torch.tensor(4.0))
+    assert torch.equal(model[0].weight, torch.full(model[0].weight.shape, 1.0))
+    assert torch.equal(model[2].weight, torch.full(model[2].weight.shape, 3.0))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 2.0))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, 4.0))
 
     init_cfg = dict(
         type='ConstantInit',
@@ -270,12 +287,18 @@ def test_initialize():
         layers=['Conv2d', 'Linear'],
         cases=dict(type='ConstantInit', name='conv2d_2', val=3, bias=4))
     initialize(foonet, init_cfg)
-    assert foonet.linear.weight.allclose(torch.tensor(1.0))
-    assert foonet.linear.bias.allclose(torch.tensor(2.0))
-    assert foonet.conv2d.weight.allclose(torch.tensor(1.0))
-    assert foonet.conv2d.bias.allclose(torch.tensor(2.0))
-    assert foonet.conv2d_2.weight.allclose(torch.tensor(3.0))
-    assert foonet.conv2d_2.bias.allclose(torch.tensor(4.0))
+    assert torch.equal(foonet.linear.weight,
+                       torch.full(foonet.linear.weight.shape, 1.0))
+    assert torch.equal(foonet.linear.bias,
+                       torch.full(foonet.linear.bias.shape, 2.0))
+    assert torch.equal(foonet.conv2d.weight,
+                       torch.full(foonet.conv2d.weight.shape, 1.0))
+    assert torch.equal(foonet.conv2d.bias,
+                       torch.full(foonet.conv2d.bias.shape, 2.0))
+    assert torch.equal(foonet.conv2d_2.weight,
+                       torch.full(foonet.conv2d_2.weight.shape, 3.0))
+    assert torch.equal(foonet.conv2d_2.bias,
+                       torch.full(foonet.conv2d_2.bias.shape, 4.0))
 
     init_cfg = dict(
         type='PretrainedInit',
@@ -287,9 +310,15 @@ def test_initialize():
     with TemporaryDirectory():
         torch.save(modelA.state_dict(), 'modelA.pth')
         initialize(foonet, init_cfg)
-        assert foonet.linear.weight.allclose(torch.tensor(1.0))
-        assert foonet.linear.bias.allclose(torch.tensor(2.0))
-        assert foonet.conv2d.weight.allclose(torch.tensor(1.0))
-        assert foonet.conv2d.bias.allclose(torch.tensor(2.0))
-        assert foonet.conv2d_2.weight.allclose(torch.tensor(3.0))
-        assert foonet.conv2d_2.bias.allclose(torch.tensor(4.0))
+        assert torch.equal(foonet.linear.weight,
+                           torch.full(foonet.linear.weight.shape, 1.0))
+        assert torch.equal(foonet.linear.bias,
+                           torch.full(foonet.linear.bias.shape, 2.0))
+        assert torch.equal(foonet.conv2d.weight,
+                           torch.full(foonet.conv2d.weight.shape, 1.0))
+        assert torch.equal(foonet.conv2d.bias,
+                           torch.full(foonet.conv2d.bias.shape, 2.0))
+        assert torch.equal(foonet.conv2d_2.weight,
+                           torch.full(foonet.conv2d_2.weight.shape, 3.0))
+        assert torch.equal(foonet.conv2d_2.bias,
+                           torch.full(foonet.conv2d_2.bias.shape, 4.0))

--- a/tests/test_cnn/test_weight_init.py
+++ b/tests/test_cnn/test_weight_init.py
@@ -4,8 +4,6 @@ from tempfile import TemporaryDirectory
 import pytest
 import torch
 from torch import nn
-from torch.nn.modules.conv import Conv1d
-from torch.serialization import check_module_version_greater_or_equal
 
 from mmcv.cnn import (bias_init_with_prob, caffe2_xavier_init, constant_init,
                       initialize, kaiming_init, normal_init, uniform_init,

--- a/tests/test_cnn/test_weight_init.py
+++ b/tests/test_cnn/test_weight_init.py
@@ -108,7 +108,7 @@ def test_constaninit():
     assert model[2].weight.allclose(torch.tensor(4.0))
     assert model[0].bias.allclose(torch.tensor(5.0))
     assert model[2].bias.allclose(torch.tensor(5.0))
-
+    # test bias input type
     with pytest.raises(TypeError):
         func = ConstantInit(val=1, bias='1')
 

--- a/tests/test_cnn/test_weight_init.py
+++ b/tests/test_cnn/test_weight_init.py
@@ -97,7 +97,7 @@ def test_initialize():
     init_cfg = dict()
     with pytest.raises(TypeError):
         initialize(model, init_cfg)
-    init_cfg = init_cfg = dict(
+    init_cfg = dict(
         type='init', Linear=dict(function='constant_init', val=3, bias=4))
     with pytest.raises(TypeError):
         initialize(model, init_cfg)

--- a/tests/test_cnn/test_weight_init.py
+++ b/tests/test_cnn/test_weight_init.py
@@ -1,5 +1,4 @@
 # Copyright (c) Open-MMLab. All rights reserved.
-from sys import prefix
 import numpy as np
 from tempfile import TemporaryDirectory
 import pytest

--- a/tests/test_runner/test_basemodule_init_weight.py
+++ b/tests/test_runner/test_basemodule_init_weight.py
@@ -1,5 +1,3 @@
-import pytest
-
 import torch
 from torch import nn
 

--- a/tests/test_runner/test_basemodule_init_weight.py
+++ b/tests/test_runner/test_basemodule_init_weight.py
@@ -77,7 +77,7 @@ class FooModel(BaseModule):
         if component4 is not None:
             self.component4 = build_from_cfg(component4, COMPONENTS)
 
-        # its type is not BaseModule
+        # its type is not BaseModule, it can be initialized with "cases" key.
         self.reg = nn.Linear(3, 4)
 
 
@@ -122,23 +122,38 @@ def test_model_weight_init():
     model = build_from_cfg(model_cfg, FOOMODELS)
     model.init_weight()
 
-    assert model.component1.conv1d.weight.allclose(torch.tensor(3.0))
-    assert model.component1.conv1d.bias.allclose(torch.tensor(4.0))
-    assert model.component2.conv2d.weight.allclose(torch.tensor(5.0))
-    assert model.component2.conv2d.bias.allclose(torch.tensor(6.0))
-    assert model.component3.linear.weight.allclose(torch.tensor(1.0))
-    assert model.component3.linear.bias.allclose(torch.tensor(2.0))
-    assert model.component4.linear.linear.weight.allclose(torch.tensor(1.0))
-    assert model.component4.linear.linear.bias.allclose(torch.tensor(2.0))
-    assert model.component4.conv1d.conv1d.weight.allclose(torch.tensor(3.0))
-    assert model.component4.conv1d.conv1d.bias.allclose(torch.tensor(4.0))
-    assert model.reg.weight.allclose(torch.tensor(1.0))
-    assert model.reg.bias.allclose(torch.tensor(2.0))
+    assert torch.equal(model.component1.conv1d.weight,
+                       torch.full(model.component1.conv1d.weight.shape, 3.0))
+    assert torch.equal(model.component1.conv1d.bias,
+                       torch.full(model.component1.conv1d.bias.shape, 4.0))
+    assert torch.equal(model.component2.conv2d.weight,
+                       torch.full(model.component2.conv2d.weight.shape, 5.0))
+    assert torch.equal(model.component2.conv2d.bias,
+                       torch.full(model.component2.conv2d.bias.shape, 6.0))
+    assert torch.equal(model.component3.linear.weight,
+                       torch.full(model.component3.linear.weight.shape, 1.0))
+    assert torch.equal(model.component3.linear.bias,
+                       torch.full(model.component3.linear.bias.shape, 2.0))
+    assert torch.equal(
+        model.component4.linear.linear.weight,
+        torch.full(model.component4.linear.linear.weight.shape, 1.0))
+    assert torch.equal(
+        model.component4.linear.linear.bias,
+        torch.full(model.component4.linear.linear.bias.shape, 2.0))
+    assert torch.equal(
+        model.component4.conv1d.conv1d.weight,
+        torch.full(model.component4.conv1d.conv1d.weight.shape, 3.0))
+    assert torch.equal(
+        model.component4.conv1d.conv1d.bias,
+        torch.full(model.component4.conv1d.conv1d.bias.shape, 4.0))
+    assert torch.equal(model.reg.weight, torch.full(model.reg.weight.shape,
+                                                    1.0))
+    assert torch.equal(model.reg.bias, torch.full(model.reg.bias.shape, 2.0))
 
 
 def test_nest_components_weight_init():
     """
-        Config
+    Config
     model (FooModel, Linear: weight=1, bias=2, Conv1d: weight=3, bias=4,
                      Conv2d: weight=5, bias=6)
     ├──component1 (FooConv1d, Conv1d: weight=7, bias=8)
@@ -187,15 +202,30 @@ def test_nest_components_weight_init():
     model = build_from_cfg(model_cfg, FOOMODELS)
     model.init_weight()
 
-    assert model.component1.conv1d.weight.allclose(torch.tensor(7.0))
-    assert model.component1.conv1d.bias.allclose(torch.tensor(8.0))
-    assert model.component2.conv2d.weight.allclose(torch.tensor(9.0))
-    assert model.component2.conv2d.bias.allclose(torch.tensor(10.0))
-    assert model.component3.linear.weight.allclose(torch.tensor(1.0))
-    assert model.component3.linear.bias.allclose(torch.tensor(2.0))
-    assert model.component4.linear.linear.weight.allclose(torch.tensor(1.0))
-    assert model.component4.linear.linear.bias.allclose(torch.tensor(2.0))
-    assert model.component4.conv1d.conv1d.weight.allclose(torch.tensor(3.0))
-    assert model.component4.conv1d.conv1d.bias.allclose(torch.tensor(4.0))
-    assert model.reg.weight.allclose(torch.tensor(13.0))
-    assert model.reg.bias.allclose(torch.tensor(14.0))
+    assert torch.equal(model.component1.conv1d.weight,
+                       torch.full(model.component1.conv1d.weight.shape, 7.0))
+    assert torch.equal(model.component1.conv1d.bias,
+                       torch.full(model.component1.conv1d.bias.shape, 8.0))
+    assert torch.equal(model.component2.conv2d.weight,
+                       torch.full(model.component2.conv2d.weight.shape, 9.0))
+    assert torch.equal(model.component2.conv2d.bias,
+                       torch.full(model.component2.conv2d.bias.shape, 10.0))
+    assert torch.equal(model.component3.linear.weight,
+                       torch.full(model.component3.linear.weight.shape, 1.0))
+    assert torch.equal(model.component3.linear.bias,
+                       torch.full(model.component3.linear.bias.shape, 2.0))
+    assert torch.equal(
+        model.component4.linear.linear.weight,
+        torch.full(model.component4.linear.linear.weight.shape, 1.0))
+    assert torch.equal(
+        model.component4.linear.linear.bias,
+        torch.full(model.component4.linear.linear.bias.shape, 2.0))
+    assert torch.equal(
+        model.component4.conv1d.conv1d.weight,
+        torch.full(model.component4.conv1d.conv1d.weight.shape, 3.0))
+    assert torch.equal(
+        model.component4.conv1d.conv1d.bias,
+        torch.full(model.component4.conv1d.conv1d.bias.shape, 4.0))
+    assert torch.equal(model.reg.weight,
+                       torch.full(model.reg.weight.shape, 13.0))
+    assert torch.equal(model.reg.bias, torch.full(model.reg.bias.shape, 14.0))

--- a/tests/test_runner/test_basemodule_init_weight.py
+++ b/tests/test_runner/test_basemodule_init_weight.py
@@ -1,0 +1,201 @@
+import pytest
+
+import torch
+from torch import nn
+
+from mmcv.utils import Registry, build_from_cfg
+from mmcv.runner import BaseModule
+
+COMPONENTS = Registry('component')
+FOOMODELS = Registry('model')
+
+
+@COMPONENTS.register_module()
+class FooConv1d(BaseModule):
+
+    def __init__(self, init_cfg=None):
+        super().__init__(init_cfg)
+        self.conv1d = nn.Conv1d(4, 1, 4)
+
+    def forward(self, x):
+        return self.conv1d(x)
+
+
+@COMPONENTS.register_module()
+class FooConv2d(BaseModule):
+
+    def __init__(self, init_cfg=None):
+        super().__init__(init_cfg)
+        self.conv2d = nn.Conv2d(3, 1, 3)
+
+    def forward(self, x):
+        return self.conv2d(x)
+
+
+@COMPONENTS.register_module()
+class FooLinear(BaseModule):
+
+    def __init__(self, init_cfg=None):
+        super().__init__(init_cfg)
+        self.linear = nn.Linear(3, 4)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+@COMPONENTS.register_module()
+class FooLinearConv1d(BaseModule):
+
+    def __init__(self, linear=None, conv1d=None, init_cfg=None):
+        super().__init__(init_cfg)
+        if linear is not None:
+            self.linear = build_from_cfg(linear, COMPONENTS)
+        if conv1d is not None:
+            self.conv1d = build_from_cfg(conv1d, COMPONENTS)
+
+    def forward(self, x):
+        x = self.linear(x)
+        return self.conv1d(x)
+
+
+@FOOMODELS.register_module()
+class FooModel(BaseModule):
+
+    def __init__(self,
+                 component1=None,
+                 component2=None,
+                 component3=None,
+                 component4=None,
+                 init_cfg=None) -> None:
+        super().__init__(init_cfg)
+        if component1 is not None:
+            self.component1 = build_from_cfg(component1, COMPONENTS)
+        if component2 is not None:
+            self.component2 = build_from_cfg(component2, COMPONENTS)
+        if component3 is not None:
+            self.component3 = build_from_cfg(component3, COMPONENTS)
+        if component4 is not None:
+            self.component4 = build_from_cfg(component4, COMPONENTS)
+
+        # its type is not BaseModule
+        self.reg = nn.Linear(3, 4)
+
+
+def test_model_weight_init():
+    """
+    Config
+    model (FooModel, Linear: weight=1, bias=2, Conv1d: weight=3, bias=4,
+                     Conv2d: weight=5, bias=6)
+    ├──component1 (FooConv1d)
+    ├──component2 (FooConv2d)
+    ├──component3 (FooLinear)
+    ├──component4 (FooLinearConv1d)
+        ├──linear (FooLinear)
+        ├──conv1d (FooConv1d)
+    ├──reg (nn.Linear)
+
+    Parameters after initialization
+    model (FooModel)
+    ├──component1 (FooConv1d, weight=3, bias=4)
+    ├──component2 (FooConv2d, weight=5, bias=6)
+    ├──component3 (FooLinear, weight=1, bias=2)
+    ├──component4 (FooLinearConv1d)
+        ├──linear (FooLinear, weight=1, bias=2)
+        ├──conv1d (FooConv1d, weight=3, bias=4)
+    ├──reg (nn.Linear, weight=1, bias=2)
+    """
+    model_cfg = dict(
+        type="FooModel",
+        init_cfg=[
+            dict(type='ConstantInit', val=1, bias=2, layers='Linear'),
+            dict(type='ConstantInit', val=3, bias=4, layers='Conv1d'),
+            dict(type='ConstantInit', val=5, bias=6, layers='Conv2d')
+        ],
+        component1=dict(type='FooConv1d'),
+        component2=dict(type='FooConv2d'),
+        component3=dict(type='FooLinear'),
+        component4=dict(
+            type='FooLinearConv1d',
+            linear=dict(type='FooLinear'),
+            conv1d=dict(type='FooConv1d')))
+
+    model = build_from_cfg(model_cfg, FOOMODELS)
+    model.init_weight()
+
+    assert model.component1.conv1d.weight.allclose(torch.tensor(3.0))
+    assert model.component1.conv1d.bias.allclose(torch.tensor(4.0))
+    assert model.component2.conv2d.weight.allclose(torch.tensor(5.0))
+    assert model.component2.conv2d.bias.allclose(torch.tensor(6.0))
+    assert model.component3.linear.weight.allclose(torch.tensor(1.0))
+    assert model.component3.linear.bias.allclose(torch.tensor(2.0))
+    assert model.component4.linear.linear.weight.allclose(torch.tensor(1.0))
+    assert model.component4.linear.linear.bias.allclose(torch.tensor(2.0))
+    assert model.component4.conv1d.conv1d.weight.allclose(torch.tensor(3.0))
+    assert model.component4.conv1d.conv1d.bias.allclose(torch.tensor(4.0))
+    assert model.reg.weight.allclose(torch.tensor(1.0))
+    assert model.reg.bias.allclose(torch.tensor(2.0))
+
+
+def test_nest_components_weight_init():
+    """
+        Config
+    model (FooModel, Linear: weight=1, bias=2, Conv1d: weight=3, bias=4,
+                     Conv2d: weight=5, bias=6)
+    ├──component1 (FooConv1d, Conv1d: weight=7, bias=8)
+    ├──component2 (FooConv2d, Conv2d: weight=9, bias=10)
+    ├──component3 (FooLinear)
+    ├──component4 (FooLinearConv1d, Linear: weight=11, bias=12)
+        ├──linear (FooLinear, Linear: weight=11, bias=12)
+        ├──conv1d (FooConv1d)
+    ├──reg (nn.Linear, weight=13, bias=14)
+
+    Parameters after initialization
+    model (FooModel)
+    ├──component1 (FooConv1d, weight=7, bias=8)
+    ├──component2 (FooConv2d, weight=9, bias=10)
+    ├──component3 (FooLinear, weight=1, bias=2)
+    ├──component4 (FooLinearConv1d)
+        ├──linear (FooLinear, weight=1, bias=2)
+        ├──conv1d (FooConv1d, weight=3, bias=4)
+    ├──reg (nn.Linear, weight=13, bias=14)
+    """
+
+    model_cfg = dict(
+        type="FooModel",
+        init_cfg=[
+            dict(
+                type='ConstantInit',
+                val=1,
+                bias=2,
+                layers='Linear',
+                cases=dict(type='ConstantInit', name='reg', val=13, bias=14)),
+            dict(type='ConstantInit', val=3, bias=4, layers='Conv1d'),
+            dict(type='ConstantInit', val=5, bias=6, layers='Conv2d'),
+        ],
+        component1=dict(
+            type='FooConv1d',
+            init_cfg=dict(type='ConstantInit', val=7, bias=8)),
+        component2=dict(
+            type='FooConv2d',
+            init_cfg=dict(type='ConstantInit', val=9, bias=10)),
+        component3=dict(type='FooLinear'),
+        component4=dict(
+            type='FooLinearConv1d',
+            linear=dict(type='FooLinear'),
+            conv1d=dict(type='FooConv1d')))
+
+    model = build_from_cfg(model_cfg, FOOMODELS)
+    model.init_weight()
+
+    assert model.component1.conv1d.weight.allclose(torch.tensor(7.0))
+    assert model.component1.conv1d.bias.allclose(torch.tensor(8.0))
+    assert model.component2.conv2d.weight.allclose(torch.tensor(9.0))
+    assert model.component2.conv2d.bias.allclose(torch.tensor(10.0))
+    assert model.component3.linear.weight.allclose(torch.tensor(1.0))
+    assert model.component3.linear.bias.allclose(torch.tensor(2.0))
+    assert model.component4.linear.linear.weight.allclose(torch.tensor(1.0))
+    assert model.component4.linear.linear.bias.allclose(torch.tensor(2.0))
+    assert model.component4.conv1d.conv1d.weight.allclose(torch.tensor(3.0))
+    assert model.component4.conv1d.conv1d.bias.allclose(torch.tensor(4.0))
+    assert model.reg.weight.allclose(torch.tensor(13.0))
+    assert model.reg.bias.allclose(torch.tensor(14.0))

--- a/tests/test_runner/test_checkpoint.py
+++ b/tests/test_runner/test_checkpoint.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
-import torch.nn as nn
 from collections import OrderedDict
+import torch.nn as nn
 from torch.nn.parallel import DataParallel
 from unittest.mock import MagicMock
 

--- a/tests/test_runner/test_checkpoint.py
+++ b/tests/test_runner/test_checkpoint.py
@@ -1,12 +1,12 @@
+import pytest
 import sys
+import torch.nn as nn
 from collections import OrderedDict
+from torch.nn.parallel import DataParallel
 from unittest.mock import MagicMock
 
-import pytest
-import torch.nn as nn
-from torch.nn.parallel import DataParallel
-
 from mmcv.parallel.registry import MODULE_WRAPPERS
+from mmcv.runner import _load_checkpoint_with_prefix
 from mmcv.runner.checkpoint import get_state_dict, load_pavimodel_dist
 
 
@@ -133,3 +133,14 @@ def test_load_pavimodel_dist():
     with pytest.raises(FileNotFoundError):
         # there is not such checkpoint for us to load
         _ = load_pavimodel_dist('MyPaviFolder/checkpoint.pth')
+
+
+def test_load_checkpoint_with_prefix():
+    prefix = 'backbone.'
+    checkpoint = 'http://download.openmmlab.com/mmdetection/v2.0/retinanet/'\
+        'retinanet_r50_fpn_1x_coco/'\
+        'retinanet_r50_fpn_1x_coco_20200130-c2398f9e.pth'
+    _load_checkpoint_with_prefix(prefix, checkpoint)
+    prefix = 'back'
+    with pytest.raises(AssertionError):
+        _load_checkpoint_with_prefix(prefix, checkpoint)


### PR DESCRIPTION
Add functions `initialize`, `random_init`, `pretrained_init`, `_load_checkpoint_with_prefix` 

These functions serve for parameters initialization with unified configuration approach. There are two type of initialization configuration, "random" and "pretrained".
e.g. `init_cfg = dict(type='random', Conv2d=dict(function='constant_init', val=3, bias=4))`
`init_cfg = dict(type='pretrained', checkpoint='torchvision://resnet50')`
For further details, please refer to `initialize` docstring.