### PR TITLE
Support auto_fp16 using torch.cuda.amp

### DIFF
--- a/mmcv/runner/fp16_utils.py
+++ b/mmcv/runner/fp16_utils.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 
 from mmcv.utils import TORCH_VERSION
 from .dist_utils import allreduce_grads as _allreduce_grads
+
 try:
     from torch.cuda.amp import autocast
 except ImportError:
@@ -136,8 +137,8 @@ def force_fp32(apply_to=None, out_fp16=False):
     mixed precision training. If there are some inputs that must be processed
     in fp32 mode, then this decorator can handle it. If inputs arguments are
     fp16 tensors, they will be converted to fp32 automatically. Arguments other
-    than fp16 tensors are ignored. If you are using PyTorch >= 1.6, 
-    torch.cuda.amp is used as the backend, otherwise, original mmcv 
+    than fp16 tensors are ignored. If you are using PyTorch >= 1.6,
+    torch.cuda.amp is used as the backend, otherwise, original mmcv
     implementation will be adopted.
 
     Args:

--- a/mmcv/runner/fp16_utils.py
+++ b/mmcv/runner/fp16_utils.py
@@ -7,7 +7,12 @@ import numpy as np
 import torch
 import torch.nn as nn
 
+from mmcv.utils import TORCH_VERSION
 from .dist_utils import allreduce_grads as _allreduce_grads
+try:
+    from torch.cuda.amp import autocast
+except ImportError:
+    pass
 
 
 def cast_tensor_type(inputs, src_type, dst_type):
@@ -45,7 +50,8 @@ def auto_fp16(apply_to=None, out_fp32=False):
     This decorator is useful when you write custom modules and want to support
     mixed precision training. If inputs arguments are fp32 tensors, they will
     be converted to fp16 automatically. Arguments other than fp32 tensors are
-    ignored.
+    ignored. If you are using PyTorch >= 1.6, torch.cuda.amp is used as the
+    backend, otherwise, original mmcv implementation will be adopted.
 
     Args:
         apply_to (Iterable, optional): The argument names to be converted.
@@ -82,6 +88,7 @@ def auto_fp16(apply_to=None, out_fp32=False):
                                 'method of nn.Module')
             if not (hasattr(args[0], 'fp16_enabled') and args[0].fp16_enabled):
                 return old_func(*args, **kwargs)
+
             # get the arg spec of the decorated method
             args_info = getfullargspec(old_func)
             # get the argument names to be casted
@@ -107,7 +114,11 @@ def auto_fp16(apply_to=None, out_fp32=False):
                     else:
                         new_kwargs[arg_name] = arg_value
             # apply converted arguments to the decorated method
-            output = old_func(*new_args, **new_kwargs)
+            if TORCH_VERSION != 'parrots' and TORCH_VERSION >= '1.6.0':
+                output = autocast(enabled=True)(old_func)(*new_args,
+                                                          **new_kwargs)
+            else:
+                output = old_func(*new_args, **new_kwargs)
             # cast the results back to fp32 if necessary
             if out_fp32:
                 output = cast_tensor_type(output, torch.half, torch.float)
@@ -125,7 +136,9 @@ def force_fp32(apply_to=None, out_fp16=False):
     mixed precision training. If there are some inputs that must be processed
     in fp32 mode, then this decorator can handle it. If inputs arguments are
     fp16 tensors, they will be converted to fp32 automatically. Arguments other
-    than fp16 tensors are ignored.
+    than fp16 tensors are ignored. If you are using PyTorch >= 1.6, 
+    torch.cuda.amp is used as the backend, otherwise, original mmcv 
+    implementation will be adopted.
 
     Args:
         apply_to (Iterable, optional): The argument names to be converted.
@@ -186,7 +199,11 @@ def force_fp32(apply_to=None, out_fp16=False):
                     else:
                         new_kwargs[arg_name] = arg_value
             # apply converted arguments to the decorated method
-            output = old_func(*new_args, **new_kwargs)
+            if TORCH_VERSION != 'parrots' and TORCH_VERSION >= '1.6.0':
+                output = autocast(enabled=False)(old_func)(*new_args,
+                                                           **new_kwargs)
+            else:
+                output = old_func(*new_args, **new_kwargs)
             # cast the results back to fp32 if necessary
             if out_fp16:
                 output = cast_tensor_type(output, torch.float, torch.half)
@@ -207,16 +224,26 @@ def allreduce_grads(params, coalesce=True, bucket_size_mb=-1):
 def wrap_fp16_model(model):
     """Wrap the FP32 model to FP16.
 
+    If you are using PyTorch >= 1.6, torch.cuda.amp is used as the
+    backend, otherwise, original mmcv implementation will be adopted.
+
+    For PyTorch >= 1.6, this function will
+    1. Set fp16 flag inside the model to True.
+
+    Otherwise:
     1. Convert FP32 model to FP16.
     2. Remain some necessary layers to be FP32, e.g., normalization layers.
+    3. Set fp16 flag inside the model to True.
 
     Args:
         model (nn.Module): Model in FP32.
     """
-    # convert model to fp16
-    model.half()
-    # patch the normalization layers to make it work in fp32 mode
-    patch_norm_fp32(model)
+
+    if TORCH_VERSION == 'parrots' or TORCH_VERSION < '1.6.0':
+        # convert model to fp16
+        model.half()
+        # patch the normalization layers to make it work in fp32 mode
+        patch_norm_fp32(model)
     # set `fp16_enabled` flag
     for m in model.modules():
         if hasattr(m, 'fp16_enabled'):

--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -63,7 +63,19 @@ class Fp16OptimizerHook(OptimizerHook):
             the specified scale. If loss_scale is a string, it must be
             'dynamic', then dynamic loss scaling will be used.
             It can also be a dict containing arguments of LossScaler.
-            Defaults to 512.
+            Defaults to 512. For Pytorch >= 1.6, mmcv uses official 
+            implementation of GradScaler. If you use a dict version of 
+            loss_scale to create GradScaler, plese refer to:
+
+            https://pytorch.org/docs/stable/amp.html#torch.cuda.amp.GradScaler
+            
+            for the parameters. Here is an example:
+            loss_scale = dict(
+                init_scale=65536.0, 
+                growth_factor=2.0, 
+                backoff_factor=0.5, 
+                growth_interval=2000
+            )
     """
 
     def __init__(self,

--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -9,8 +9,9 @@ from mmcv.utils import TORCH_VERSION
 from ..dist_utils import allreduce_grads
 from ..fp16_utils import LossScaler, wrap_fp16_model
 from .hook import HOOKS, Hook
+
 try:
-    from torch.cuda.amp import autocast, GradScaler
+    from torch.cuda.amp import GradScaler
 except ImportError:
     pass
 
@@ -43,7 +44,7 @@ class OptimizerHook(Hook):
 class Fp16OptimizerHook(OptimizerHook):
     """FP16 optimizer hook.
 
-    If you are using PyTorch >= 1.6, torch.cuda.amp is used as the backend, 
+    If you are using PyTorch >= 1.6, torch.cuda.amp is used as the backend,
     otherwise, original mmcv implementation will be adopted.
 
     The steps of fp16 optimizer with mmcv implementation is as follows.
@@ -63,17 +64,17 @@ class Fp16OptimizerHook(OptimizerHook):
             the specified scale. If loss_scale is a string, it must be
             'dynamic', then dynamic loss scaling will be used.
             It can also be a dict containing arguments of LossScaler.
-            Defaults to 512. For Pytorch >= 1.6, mmcv uses official 
-            implementation of GradScaler. If you use a dict version of 
+            Defaults to 512. For Pytorch >= 1.6, mmcv uses official
+            implementation of GradScaler. If you use a dict version of
             loss_scale to create GradScaler, plese refer to:
 
             https://pytorch.org/docs/stable/amp.html#torch.cuda.amp.GradScaler
-            
+
             for the parameters. Here is an example:
             loss_scale = dict(
-                init_scale=65536.0, 
-                growth_factor=2.0, 
-                backoff_factor=0.5, 
+                init_scale=65536.0,
+                growth_factor=2.0,
+                backoff_factor=0.5,
                 growth_interval=2000
             )
     """


### PR DESCRIPTION
Testing using mmdet faster_rcnn_r50_fpn_fp16_1x_coco.

Ubuntu 18.04
torch1.7.1
CUDA10.2
GPU: 2080Ti

Train speed 0.3s/iter;
Memory: 2.8GB;
Inference: 99fps;
mAP 37.4 (compared with previous fp16 implementation 37.5)
