### PR TITLE
[Bug] fix for norm attribute in ConvModule

### DIFF
--- a/mmcv/cnn/bricks/conv_module.py
+++ b/mmcv/cnn/bricks/conv_module.py
@@ -162,7 +162,7 @@ class ConvModule(nn.Module):
 
     @property
     def norm(self):
-        return getattr(self, self.norm_name)
+        return getattr(self, self.norm_name) if self.with_norm else None
 
     def init_weights(self):
         # 1. It is mainly for customized conv layers with their own


### PR DESCRIPTION
The attribute self.norm_name only exists when self.with_norm is True.
Calling getattr will throw error if self.norm_name is not a attribute,