### PR TITLE
[Feature] Support revise_keys in load_checkpoint().

### DIFF
--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -310,6 +310,7 @@ class PretrainedInit(object):
             initialize. For example, if we would like to only load the
             backbone of a detector model, we can set ``prefix='backbone.'``.
             Defaults to None.
+        map_location (str): map tensors into proper locations.
     """
 
     def __init__(self, checkpoint, prefix=None, map_location=None):

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -45,7 +45,6 @@ class BaseRunner(metaclass=ABCMeta):
             Defaults to None.
         max_epochs (int, optional): Total training epochs.
         max_iters (int, optional): Total training iterations.
-
     """
 
     def __init__(self,
@@ -306,8 +305,11 @@ class BaseRunner(metaclass=ABCMeta):
         for hook in self._hooks:
             getattr(hook, fn_name)(self)
 
-    def load_checkpoint(self, filename, map_location='cpu', strict=False,
-                 revise_keys=[(r'^module.', '')]):
+    def load_checkpoint(self,
+                        filename,
+                        map_location='cpu',
+                        strict=False,
+                        revise_keys=[(r'^module.', '')]):
 
         self.logger.info('load checkpoint from %s', filename)
         return load_checkpoint(

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -312,8 +312,13 @@ class BaseRunner(metaclass=ABCMeta):
     def load_checkpoint(self, filename, map_location='cpu', strict=False):
 
         self.logger.info('load checkpoint from %s', filename)
-        return load_checkpoint(self.model, filename, map_location, strict,
-                               self.logger, revise_keys=self.revise_keys)
+        return load_checkpoint(
+            self.model,
+            filename,
+            map_location,
+            strict,
+            self.logger,
+            revise_keys=self.revise_keys)
 
     def resume(self,
                checkpoint,

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -313,7 +313,7 @@ class BaseRunner(metaclass=ABCMeta):
 
         self.logger.info('load checkpoint from %s', filename)
         return load_checkpoint(self.model, filename, map_location, strict,
-                               self.logger, self.revise_keys)
+                               self.logger, revise_keys=self.revise_keys)
 
     def resume(self,
                checkpoint,

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -45,8 +45,7 @@ class BaseRunner(metaclass=ABCMeta):
             Defaults to None.
         max_epochs (int, optional): Total training epochs.
         max_iters (int, optional): Total training iterations.
-        revise_keys (list): Customized keywords to modify for compatibility
-            between model and checkpoint. Default: remove 'module.'.
+
     """
 
     def __init__(self,
@@ -57,8 +56,7 @@ class BaseRunner(metaclass=ABCMeta):
                  logger=None,
                  meta=None,
                  max_iters=None,
-                 max_epochs=None,
-                 revise_keys=[(r'^module.', '')]):
+                 max_epochs=None):
         if batch_processor is not None:
             if not callable(batch_processor):
                 raise TypeError('batch_processor must be callable, '
@@ -105,7 +103,6 @@ class BaseRunner(metaclass=ABCMeta):
         self.optimizer = optimizer
         self.logger = logger
         self.meta = meta
-        self.revise_keys = revise_keys
         # create work_dir
         if mmcv.is_str(work_dir):
             self.work_dir = osp.abspath(work_dir)
@@ -309,7 +306,8 @@ class BaseRunner(metaclass=ABCMeta):
         for hook in self._hooks:
             getattr(hook, fn_name)(self)
 
-    def load_checkpoint(self, filename, map_location='cpu', strict=False):
+    def load_checkpoint(self, filename, map_location='cpu', strict=False,
+                 revise_keys=[(r'^module.', '')]):
 
         self.logger.info('load checkpoint from %s', filename)
         return load_checkpoint(
@@ -318,7 +316,7 @@ class BaseRunner(metaclass=ABCMeta):
             map_location,
             strict,
             self.logger,
-            revise_keys=self.revise_keys)
+            revise_keys=revise_keys)
 
     def resume(self,
                checkpoint,

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -504,8 +504,7 @@ def load_checkpoint(model,
                     filename,
                     map_location=None,
                     strict=False,
-                    rmword='module',
-                    addword=None,
+                    revise_keys=[(r'^module.', '')],
                     logger=None):
     """Load checkpoint from a file or URI.
 
@@ -517,10 +516,8 @@ def load_checkpoint(model,
         map_location (str): Same as :func:`torch.load`.
         strict (bool): Whether to allow different params for the model and
             checkpoint.
-        rmword (str): Customized keywords to remove for compatibility
-            between model and checkpoint.
-        addword (str): Customized keywords to add for compatibility
-            between model and checkpoint.
+        revise_keys (list): Customized keywords to modify for compatibility
+            between model and checkpoint. Default: remove 'module.'.
         logger (:mod:`logging.Logger` or None): The logger for error message.
 
     Returns:
@@ -537,20 +534,8 @@ def load_checkpoint(model,
     else:
         state_dict = checkpoint
     # strip prefix of state_dict
-    blank = r''
-    if rmword is not None:
-        prefix = rmword + '.'
-        state_dict = {
-            re.sub(prefix, blank, k): v
-            for k, v in state_dict.items()
-        }
-    if addword is not None:
-        prefix = r'^'
-        toadd = addword + '.'
-        state_dict = {
-            re.sub(blank, toadd, k): v
-            for k, v in state_dict.items()
-        }
+    for (p, s) in revise_keys:
+        state_dict = {re.sub(p, s, k): v for k, v in state_dict.items()}
     # load state_dict
     load_state_dict(model, state_dict, strict, logger)
     return checkpoint

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -504,8 +504,8 @@ def load_checkpoint(model,
                     filename,
                     map_location=None,
                     strict=False,
-                    revise_keys=[(r'^module.', '')],
-                    logger=None):
+                    logger=None,
+                    revise_keys=[(r'^module.', '')]):
     """Load checkpoint from a file or URI.
 
     Args:

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -504,7 +504,8 @@ def load_checkpoint(model,
                     filename,
                     map_location=None,
                     strict=False,
-                    rmkey=None,
+                    rmword='module.',
+                    addword=None,
                     logger=None):
     """Load checkpoint from a file or URI.
 
@@ -516,7 +517,9 @@ def load_checkpoint(model,
         map_location (str): Same as :func:`torch.load`.
         strict (bool): Whether to allow different params for the model and
             checkpoint.
-        rmkey (str): Customized keywords to remove for compatibility
+        rmword (str): Customized keywords to remove for compatibility
+            between model and checkpoint.
+        addword (str): Customized keywords to add for compatibility
             between model and checkpoint.
         logger (:mod:`logging.Logger` or None): The logger for error message.
 
@@ -535,12 +538,17 @@ def load_checkpoint(model,
         state_dict = checkpoint
     # strip prefix of state_dict
     blank = r''
-    prefix = r'module.'
-    state_dict = {re.sub(prefix, blank, k): v for k, v in state_dict.items()}
-    if rmkey is not None:
-        prefix = rmkey + '.'
+    if rmword is not None:
+        prefix = rmword + '.'
         state_dict = {
             re.sub(prefix, blank, k): v
+            for k, v in state_dict.items()
+        }
+    if addword is not None:
+        prefix = r'^'
+        toadd = addword + '.'
+        state_dict = {
+            re.sub(blank, toadd, k): v
             for k, v in state_dict.items()
         }
     # load state_dict

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -518,7 +518,8 @@ def load_checkpoint(model,
             checkpoint.
         logger (:mod:`logging.Logger` or None): The logger for error message.
         revise_keys (list): Customized keywords to modify for compatibility
-            between model and checkpoint. Default: remove 'module.'.
+            between model and checkpoint. Default: strip the prefix 'module.'
+            by [(r'^module.', '')]).
 
     Returns:
         dict or OrderedDict: The loaded checkpoint.

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -516,9 +516,9 @@ def load_checkpoint(model,
         map_location (str): Same as :func:`torch.load`.
         strict (bool): Whether to allow different params for the model and
             checkpoint.
+        logger (:mod:`logging.Logger` or None): The logger for error message.
         revise_keys (list): Customized keywords to modify for compatibility
             between model and checkpoint. Default: remove 'module.'.
-        logger (:mod:`logging.Logger` or None): The logger for error message.
 
     Returns:
         dict or OrderedDict: The loaded checkpoint.

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -517,9 +517,11 @@ def load_checkpoint(model,
         strict (bool): Whether to allow different params for the model and
             checkpoint.
         logger (:mod:`logging.Logger` or None): The logger for error message.
-        revise_keys (list): Customized keywords to modify for compatibility
-            between model and checkpoint. Default: strip the prefix 'module.'
-            by [(r'^module.', '')]).
+        revise_keys (list): A list of customized keywords to modify the
+            state_dict in checkpoint. Each item is a (pattern, replacement)
+            pair of the regular expression operations. Default: strip
+            the prefix 'module.' by [(r'^module.', '')].
+
 
     Returns:
         dict or OrderedDict: The loaded checkpoint.

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -504,6 +504,7 @@ def load_checkpoint(model,
                     filename,
                     map_location=None,
                     strict=False,
+                    rmkey=None,
                     logger=None):
     """Load checkpoint from a file or URI.
 
@@ -515,6 +516,8 @@ def load_checkpoint(model,
         map_location (str): Same as :func:`torch.load`.
         strict (bool): Whether to allow different params for the model and
             checkpoint.
+        rmkey (str): Customized keywords to remove for compatibility
+            between model and checkpoint.
         logger (:mod:`logging.Logger` or None): The logger for error message.
 
     Returns:
@@ -531,9 +534,15 @@ def load_checkpoint(model,
     else:
         state_dict = checkpoint
     # strip prefix of state_dict
-    blank = r'^'
+    blank = r''
     prefix = r'module.'
-    state_dict = {re.sub(blank, prefix, k): v for k, v in state_dict.items()}
+    state_dict = {re.sub(prefix, blank, k): v for k, v in state_dict.items()}
+    if rmkey is not None:
+        prefix = rmkey + '.'
+        state_dict = {
+            re.sub(prefix, blank, k): v
+            for k, v in state_dict.items()
+        }
     # load state_dict
     load_state_dict(model, state_dict, strict, logger)
     return checkpoint

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -504,7 +504,7 @@ def load_checkpoint(model,
                     filename,
                     map_location=None,
                     strict=False,
-                    rmword='module.',
+                    rmword='module',
                     addword=None,
                     logger=None):
     """Load checkpoint from a file or URI.

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -505,7 +505,7 @@ def load_checkpoint(model,
                     map_location=None,
                     strict=False,
                     logger=None,
-                    revise_keys=[(r'^module.', '')]):
+                    revise_keys=[(r'^module\.', '')]):
     """Load checkpoint from a file or URI.
 
     Args:
@@ -520,7 +520,7 @@ def load_checkpoint(model,
         revise_keys (list): A list of customized keywords to modify the
             state_dict in checkpoint. Each item is a (pattern, replacement)
             pair of the regular expression operations. Default: strip
-            the prefix 'module.' by [(r'^module.', '')].
+            the prefix 'module.' by [(r'^module\\.', '')].
 
 
     Returns:
@@ -537,8 +537,8 @@ def load_checkpoint(model,
     else:
         state_dict = checkpoint
     # strip prefix of state_dict
-    for p, s in revise_keys:
-        state_dict = {re.sub(p, s, k): v for k, v in state_dict.items()}
+    for p, r in revise_keys:
+        state_dict = {re.sub(p, r, k): v for k, v in state_dict.items()}
     # load state_dict
     load_state_dict(model, state_dict, strict, logger)
     return checkpoint

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -535,7 +535,7 @@ def load_checkpoint(model,
     else:
         state_dict = checkpoint
     # strip prefix of state_dict
-    for (p, s) in revise_keys:
+    for p, s in revise_keys:
         state_dict = {re.sub(p, s, k): v for k, v in state_dict.items()}
     # load state_dict
     load_state_dict(model, state_dict, strict, logger)

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -3,6 +3,7 @@ import io
 import os
 import os.path as osp
 import pkgutil
+import re
 import time
 import warnings
 from collections import OrderedDict
@@ -530,8 +531,9 @@ def load_checkpoint(model,
     else:
         state_dict = checkpoint
     # strip prefix of state_dict
-    if list(state_dict.keys())[0].startswith('module.'):
-        state_dict = {k[7:]: v for k, v in state_dict.items()}
+    blank = r'^'
+    prefix = r'module.'
+    state_dict = {re.sub(blank, prefix, k): v for k, v in state_dict.items()}
     # load state_dict
     load_state_dict(model, state_dict, strict, logger)
     return checkpoint

--- a/tests/test_runner/test_checkpoint.py
+++ b/tests/test_runner/test_checkpoint.py
@@ -213,10 +213,10 @@ def test_load_checkpoint():
     # strip prefix
     torch.save(pmodel.state_dict(), checkpoint_path)
     state_dict = load_checkpoint(
-        model, checkpoint_path, revise_keys=[('backbone.', '')])
+        model, checkpoint_path, revise_keys=[(r'^backbone\.', '')])
 
     for key in state_dict.keys():
-        key_stripped = re.sub('^backbone.', '', key)
+        key_stripped = re.sub(r'^backbone\.', '', key)
         assert torch.equal(model.state_dict()[key_stripped], state_dict[key])
     os.remove(checkpoint_path)
 

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -450,8 +450,8 @@ def test_runner_with_revise_keys():
     torch.save(pmodel.state_dict(), checkpoint_path)
     runner.model = model
     state_dict = runner.load_checkpoint(
-        checkpoint_path, revise_keys=[('backbone.', '')])
+        checkpoint_path, revise_keys=[(r'^backbone\.', '')])
     for key in state_dict.keys():
-        key_stripped = re.sub('^backbone.', '', key)
+        key_stripped = re.sub(r'^backbone\.', '', key)
         assert torch.equal(model.state_dict()[key_stripped], state_dict[key])
     os.remove(checkpoint_path)

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -416,14 +416,17 @@ def _build_demo_runner(runner_type='EpochBasedRunner',
     runner.register_logger_hooks(log_config)
     return runner
 
+
 def test_runner_with_revise_keys():
 
     import os
+
     class Model(nn.Module):
 
         def __init__(self):
             super().__init__()
             self.conv = nn.Conv2d(3, 3, 1)
+
     class PrefixModel(nn.Module):
 
         def __init__(self):
@@ -437,14 +440,14 @@ def test_runner_with_revise_keys():
     # add prefix
     torch.save(model.state_dict(), chkpt_path)
     runner = _build_demo_runner(runner_type='EpochBasedRunner')
-    runner.model=pmodel
-    runner.revise_keys=[(r'^', 'backbone.')]
+    runner.model = pmodel
+    runner.revise_keys = [(r'^', 'backbone.')]
     runner.load_checkpoint(chkpt_path)
 
     # strip prefix
     torch.save(pmodel.state_dict(), chkpt_path)
-    runner.model=model
-    runner.revise_keys=[('backbone.', '')]
+    runner.model = model
+    runner.revise_keys = [('backbone.', '')]
     runner.load_checkpoint(chkpt_path)
 
     os.remove(chkpt_path)

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -441,13 +441,11 @@ def test_runner_with_revise_keys():
     torch.save(model.state_dict(), chkpt_path)
     runner = _build_demo_runner(runner_type='EpochBasedRunner')
     runner.model = pmodel
-    runner.revise_keys = [(r'^', 'backbone.')]
-    runner.load_checkpoint(chkpt_path)
+    runner.load_checkpoint(chkpt_path,revise_keys=[(r'^', 'backbone.')])
 
     # strip prefix
     torch.save(pmodel.state_dict(), chkpt_path)
     runner.model = model
-    runner.revise_keys = [('backbone.', '')]
-    runner.load_checkpoint(chkpt_path)
+    runner.load_checkpoint(chkpt_path,revise_keys=[('backbone.', '')])
 
     os.remove(chkpt_path)

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -441,11 +441,11 @@ def test_runner_with_revise_keys():
     torch.save(model.state_dict(), chkpt_path)
     runner = _build_demo_runner(runner_type='EpochBasedRunner')
     runner.model = pmodel
-    runner.load_checkpoint(chkpt_path,revise_keys=[(r'^', 'backbone.')])
+    runner.load_checkpoint(chkpt_path, revise_keys=[(r'^', 'backbone.')])
 
     # strip prefix
     torch.save(pmodel.state_dict(), chkpt_path)
     runner.model = model
-    runner.load_checkpoint(chkpt_path,revise_keys=[('backbone.', '')])
+    runner.load_checkpoint(chkpt_path, revise_keys=[('backbone.', '')])
 
     os.remove(chkpt_path)

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -435,17 +435,17 @@ def test_runner_with_revise_keys():
 
     pmodel = PrefixModel()
     model = Model()
-    chkpt_path = './chk.pth'
+    checkpoint_path = os.path.join(tempfile.gettempdir(), 'checkpoint.pth')
 
     # add prefix
-    torch.save(model.state_dict(), chkpt_path)
+    torch.save(model.state_dict(), checkpoint_path)
     runner = _build_demo_runner(runner_type='EpochBasedRunner')
     runner.model = pmodel
-    runner.load_checkpoint(chkpt_path, revise_keys=[(r'^', 'backbone.')])
+    runner.load_checkpoint(checkpoint_path, revise_keys=[(r'^', 'backbone.')])
 
     # strip prefix
-    torch.save(pmodel.state_dict(), chkpt_path)
+    torch.save(pmodel.state_dict(), checkpoint_path)
     runner.model = model
-    runner.load_checkpoint(chkpt_path, revise_keys=[('backbone.', '')])
+    runner.load_checkpoint(checkpoint_path, revise_keys=[('backbone.', '')])
 
-    os.remove(chkpt_path)
+    os.remove(checkpoint_path)

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -415,3 +415,36 @@ def _build_demo_runner(runner_type='EpochBasedRunner',
     runner.register_checkpoint_hook(dict(interval=1))
     runner.register_logger_hooks(log_config)
     return runner
+
+def test_runner_with_revise_keys():
+
+    import os
+    class Model(nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(3, 3, 1)
+    class PrefixModel(nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.backbone = Model()
+
+    pmodel = PrefixModel()
+    model = Model()
+    chkpt_path = './chk.pth'
+
+    # add prefix
+    torch.save(model.state_dict(), chkpt_path)
+    runner = _build_demo_runner(runner_type='EpochBasedRunner')
+    runner.model=pmodel
+    runner.revise_keys=[(r'^', 'backbone.')]
+    runner.load_checkpoint(chkpt_path)
+
+    # strip prefix
+    torch.save(pmodel.state_dict(), chkpt_path)
+    runner.model=model
+    runner.revise_keys=[('backbone.', '')]
+    runner.load_checkpoint(chkpt_path)
+
+    os.remove(chkpt_path)


### PR DESCRIPTION
This would be useful when one would like to incorporate other models into open-mmlab series, e.g. when using simple encoder-decoder structure in mmediting, the keyword backbone may need to be added for the checkpoint. Then one can set the addword='backbone'. 