### PR TITLE
Add more error info in build_from_cfg

### DIFF
--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -176,4 +176,10 @@ def build_from_cfg(cfg, registry, default_args=None):
         raise TypeError(
             f'type must be a str or valid type, but got {type(obj_type)}')
 
-    return obj_cls(**args)
+    try:
+        return obj_cls(**args)
+    except TypeError as e:
+        # Normal TypeError does not print class name.
+        raise TypeError(f'{obj_cls.__name__}: {e}')
+    except:  # noqa: E722
+        raise

--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -175,9 +175,8 @@ def build_from_cfg(cfg, registry, default_args=None):
     else:
         raise TypeError(
             f'type must be a str or valid type, but got {type(obj_type)}')
-
     try:
         return obj_cls(**args)
     except Exception as e:
         # Normal TypeError does not print class name.
-        raise type(e)(f'When instantiating {obj_cls.__name__}, {e}')
+        raise type(e)(f'{obj_cls.__name__}: {e}')

--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -178,8 +178,6 @@ def build_from_cfg(cfg, registry, default_args=None):
 
     try:
         return obj_cls(**args)
-    except TypeError as e:
+    except Exception as e:
         # Normal TypeError does not print class name.
-        raise TypeError(f'{obj_cls.__name__}: {e}')
-    except:  # noqa: E722
-        raise
+        raise type(e)(f'When instantiating {obj_cls.__name__}, {e}')

--- a/tests/test_utils/test_registry.py
+++ b/tests/test_utils/test_registry.py
@@ -221,3 +221,8 @@ def test_build_from_cfg():
     with pytest.raises(TypeError):
         cfg = dict(type='ResNet', depth=50)
         model = mmcv.build_from_cfg(cfg, BACKBONES, default_args=0)
+
+    # incorrect arguments
+    with pytest.raises(TypeError):
+        cfg = dict(type='ResNet', non_existing_arg=50)
+        model = mmcv.build_from_cfg(cfg, BACKBONES)


### PR DESCRIPTION
Description of the PR:
It add more error information about the object class when building from cfg
Previous error info:

> TypeError: __init__() got an unexpected keyword argument 'non_existing_arg'

Current error info:

> TypeError: ResNet: __init__() got an unexpected keyword argument 'non_existing_arg'

