### PR TITLE
Fix pytorch2onnx failed for interpolate op with PyTorch==1.6.0(mmdet#4646)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Run unittests and generate coverage report
         run: |
           pip install -r requirements/test.txt
-          coverage run --branch --source=mmcv -m pytest tests/ --ignore=tests/test_ops/test_onnx.py
+          coverage run --branch --source=mmcv -m pytest tests/
           coverage xml
           coverage report -m
       # Only upload coverage report for python3.7 && pytorch1.6

--- a/mmcv/onnx/onnx_utils/symbolic_helper.py
+++ b/mmcv/onnx/onnx_utils/symbolic_helper.py
@@ -226,20 +226,35 @@ def _interpolate_size_to_scales(g, input, output_size, dim):
 
 
 def _interpolate_get_scales_if_available(g, scales):
-    if len(scales) == 0:
+    scale_size = len(scales)
+    if scale_size == 0:
         return None
-    available_scales = _maybe_get_const(scales[0],
-                                        'fs') != -1 and not _is_none(scales[0])
+    # scales[0] is TensorType in Pytorch <=1.7.0
+    scale_desc = 'fs' if scale_size == 1 else 'f'
+    available_scales = _maybe_get_const(
+        scales[0], scale_desc) != -1 and not _is_none(scales[0])
 
     if not available_scales:
         return None
 
     offsets = g.op('Constant', value_t=torch.ones(2, dtype=torch.float32))
-    scales_list = g.op(
-        'Constant', value_t=torch.tensor(_maybe_get_const(scales[0], 'fs')))
-    # modify to support PyTorch==1.7.0
-    # https://github.com/pytorch/pytorch/blob/75ee5756715e7161314ce037474843b68f69fc04/torch/onnx/symbolic_helper.py#L375 # noqa: E501
-    scales = g.op('Concat', offsets, scales_list, axis_i=0)
+    if scale_size == 1:
+        scales_list = g.op(
+            'Constant',
+            value_t=torch.tensor(_maybe_get_const(scales[0], scale_desc)))
+        # modify to support PyTorch==1.7.0
+        # https://github.com/pytorch/pytorch/blob/75ee5756715e7161314ce037474843b68f69fc04/torch/onnx/symbolic_helper.py#L375 # noqa: E501
+        scales = g.op('Concat', offsets, scales_list, axis_i=0)
+    else:
+        # for PyTorch < 1.7.0
+        scales_list = []
+        for scale in scales:
+            unsqueezed_scale = _unsqueeze_helper(g, scale, 0)
+            # ONNX only supports float for the scales. double -> float.
+            unsqueezed_scale = g.op(
+                'Cast', unsqueezed_scale, to_i=cast_pytorch_to_onnx['Float'])
+            scales_list.append(unsqueezed_scale)
+        scales = g.op('Concat', offsets, *scales_list, axis_i=0)
     return scales
 
 

--- a/mmcv/onnx/onnx_utils/symbolic_helper.py
+++ b/mmcv/onnx/onnx_utils/symbolic_helper.py
@@ -226,11 +226,10 @@ def _interpolate_size_to_scales(g, input, output_size, dim):
 
 
 def _interpolate_get_scales_if_available(g, scales):
-    scale_size = len(scales)
-    if scale_size == 0:
+    if len(scales) == 0:
         return None
-    # scales[0] is TensorType in Pytorch <=1.7.0
-    scale_desc = 'fs' if scale_size == 1 else 'f'
+    # scales[0] is ListType in Pytorch == 1.7.0
+    scale_desc = 'fs' if scales[0].type().kind() == 'ListType' else 'f'
     available_scales = _maybe_get_const(
         scales[0], scale_desc) != -1 and not _is_none(scales[0])
 
@@ -238,7 +237,7 @@ def _interpolate_get_scales_if_available(g, scales):
         return None
 
     offsets = g.op('Constant', value_t=torch.ones(2, dtype=torch.float32))
-    if scale_size == 1:
+    if scale_desc == 'fs':
         scales_list = g.op(
             'Constant',
             value_t=torch.tensor(_maybe_get_const(scales[0], scale_desc)))


### PR DESCRIPTION
Fix issue in mmdet issue [4646](https://github.com/open-mmlab/mmdetection/issues/4646)

This PR includes:
1. Fix  `interpolate` op's pytorch2onnx conversion error with PyTorch==1.6.0
2. Add unit test of pytorch2onnx for `interpolate` op
