### PR TITLE
[Bug]Fix bugs in imequalize, adjust_brightness and adjust_contrast

### DIFF
--- a/mmcv/image/photometric.py
+++ b/mmcv/image/photometric.py
@@ -166,7 +166,7 @@ def imequalize(img):
     s2 = _scale_channel(img, 1)
     s3 = _scale_channel(img, 2)
     equalized_img = np.stack([s1, s2, s3], axis=-1)
-    return equalized_img
+    return equalized_img.astype((img.dtype))
 
 
 def adjust_brightness(img, factor=1.):
@@ -196,6 +196,7 @@ def adjust_brightness(img, factor=1.):
     brightened_img = cv2.addWeighted(
         img.astype(np.float32), factor, degenerated.astype(np.float32),
         1 - factor, 0)
+    brightened_img = np.clip(brightened_img, 0, 255)
     return brightened_img.astype(img.dtype)
 
 
@@ -224,6 +225,7 @@ def adjust_contrast(img, factor=1.):
     contrasted_img = cv2.addWeighted(
         img.astype(np.float32), factor, degenerated.astype(np.float32),
         1 - factor, 0)
+    contrasted_img = np.clip(contrasted_img, 0, 255)
     return contrasted_img.astype(img.dtype)
 
 

--- a/tests/test_image/test_photometric.py
+++ b/tests/test_image/test_photometric.py
@@ -132,7 +132,7 @@ class TestPhotometric:
         # test equalize with randomly sampled image.
         for _ in range(nb_rand_test):
             img = np.clip(
-                np.random.uniform(0, 1, (1000, 1200, 3)) * 260, 0,
+                np.random.normal(0, 1, (1000, 1200, 3)) * 260, 0,
                 255).astype(np.uint8)
             equalized_img = mmcv.imequalize(img)
             assert_array_equal(equalized_img, _imequalize(img))
@@ -160,7 +160,7 @@ class TestPhotometric:
             img = np.clip(
                 np.random.uniform(0, 1, (1000, 1200, 3)) * 260, 0,
                 255).astype(np.uint8)
-            factor = np.random.uniform()
+            factor = np.random.uniform() + np.random.choice([0, 1])
             np.testing.assert_allclose(
                 mmcv.adjust_brightness(img, factor).astype(np.int32),
                 _adjust_brightness(img, factor).astype(np.int32),
@@ -192,7 +192,7 @@ class TestPhotometric:
             img = np.clip(
                 np.random.uniform(0, 1, (1200, 1000, 3)) * 260, 0,
                 255).astype(np.uint8)
-            factor = np.random.uniform()
+            factor = np.random.uniform() + np.random.choice([0, 1])
             # Note the gap (less_equal 1) between PIL.ImageEnhance.Contrast
             # and mmcv.adjust_contrast comes from the gap that converts from
             # a color image to gray image using mmcv or PIL.


### PR DESCRIPTION
Hi,

In this pull request, bugs in `imequalize`, `adjust_brightness` and `adjust_contrast` are fixed and unittests are updated.

For `imequalize`, `astpye` is missing, which will cause the output to be in wrong type(int64). #861 
For `adjust_brightness` and `adjust_contrast`, factor could be larger than 1. Clipping is needed since we use float32 to calculate.

Pls kindly take a look. Thank you.