### PR TITLE
fix scatter in pytorch18

### DIFF
--- a/mmcv/parallel/distributed.py
+++ b/mmcv/parallel/distributed.py
@@ -18,6 +18,11 @@ class MMDistributedDataParallel(DistributedDataParallel):
     - It implement two APIs ``train_step()`` and ``val_step()``.
     """
 
+    def to_kwargs(self, inputs, kwargs, device_id):
+        #  Use `self.to_kwargs` instead of `self.scatter` in pytorch1.8
+        # to move all tensors to device_id
+        return scatter_kwargs(inputs, kwargs, [device_id], dim=self.dim)
+
     def scatter(self, inputs, kwargs, device_ids):
         return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
 

--- a/mmcv/parallel/distributed.py
+++ b/mmcv/parallel/distributed.py
@@ -19,7 +19,7 @@ class MMDistributedDataParallel(DistributedDataParallel):
     """
 
     def to_kwargs(self, inputs, kwargs, device_id):
-        #  Use `self.to_kwargs` instead of `self.scatter` in pytorch1.8
+        # Use `self.to_kwargs` instead of `self.scatter` in pytorch1.8
         # to move all tensors to device_id
         return scatter_kwargs(inputs, kwargs, [device_id], dim=self.dim)
 


### PR DESCRIPTION
This PR adds a method named `to_kwargs`  to `MMDistributedDataParallel`.

`DistributedDataParallel` in PyTorch 1.8 use `to_kwargs` instead of `scatter` to move all tensor in dataflow to 
 the device. it is necessary to overload this function as `scatter`.

### breaking change
None


Fixes open-mmlab/mmdetection#4737