### PR TITLE
fix bug of convmodule

### DIFF
--- a/mmcv/cnn/bricks/conv_module.py
+++ b/mmcv/cnn/bricks/conv_module.py
@@ -146,6 +146,8 @@ class ConvModule(nn.Module):
                 norm_channels = in_channels
             self.norm_name, norm = build_norm_layer(norm_cfg, norm_channels)
             self.add_module(self.norm_name, norm)
+        else:
+            self.norm_name = None
 
         # build activation layer
         if self.with_activation:
@@ -162,7 +164,10 @@ class ConvModule(nn.Module):
 
     @property
     def norm(self):
-        return getattr(self, self.norm_name)
+        if self.norm_name:
+            return getattr(self, self.norm_name)
+        else:
+            return None
 
     def init_weights(self):
         # 1. It is mainly for customized conv layers with their own

--- a/mmcv/cnn/bricks/conv_module.py
+++ b/mmcv/cnn/bricks/conv_module.py
@@ -145,8 +145,6 @@ class ConvModule(nn.Module):
             else:
                 norm_channels = in_channels
             self.norm_name, norm = build_norm_layer(norm_cfg, norm_channels)
-            assert self.norm_name != 'norm', 'norm has been used as' \
-                'property of ConvModule'
             self.add_module(self.norm_name, norm)
         else:
             self.norm_name = None

--- a/mmcv/cnn/bricks/conv_module.py
+++ b/mmcv/cnn/bricks/conv_module.py
@@ -145,6 +145,8 @@ class ConvModule(nn.Module):
             else:
                 norm_channels = in_channels
             self.norm_name, norm = build_norm_layer(norm_cfg, norm_channels)
+            assert self.norm_name != 'norm', 'norm has been used as' \
+                'property of ConvModule'
             self.add_module(self.norm_name, norm)
         else:
             self.norm_name = None

--- a/tests/test_cnn/test_conv_module.py
+++ b/tests/test_cnn/test_conv_module.py
@@ -75,7 +75,7 @@ def test_conv_module():
     assert conv.with_activation
     assert hasattr(conv, 'activate')
     assert not conv.with_norm
-    assert not hasattr(conv, 'norm')
+    assert conv.norm is None
     x = torch.rand(1, 3, 256, 256)
     output = conv(x)
     assert output.shape == (1, 8, 255, 255)
@@ -83,7 +83,7 @@ def test_conv_module():
     # conv
     conv = ConvModule(3, 8, 2, act_cfg=None)
     assert not conv.with_norm
-    assert not hasattr(conv, 'norm')
+    assert conv.norm is None
     assert not conv.with_activation
     assert not hasattr(conv, 'activate')
     x = torch.rand(1, 3, 256, 256)


### PR DESCRIPTION
This PR fixes the potential bug of `ConvModule` when specifying the `norm_cfg` as None.
The original implementation would raise the `ConvModule' object has no attribute 'norm` when you try to call
`self.norm` when passing `norm_cfg` as None.

I believe the original design is not reasonable, because you can find an attribute named `norm` by `dir(instance)` or `instance.__dict__`,  but when you access it by `instance.norm`, it will raise an error. 


Closes #871