### PR TITLE
[Refactoring] Revise function of layers and override keys in init_cfg

### DIFF
--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -344,6 +344,9 @@ class PretrainedInit(object):
 
 def _initialize(module, cfg, wholemodule=False):
     func = build_from_cfg(cfg, INITIALIZERS)
+    # wholemodule flag is for override mode, there is no layer key in override
+    # and initializer will give init values for the whole module with the name
+    # in override.
     func.wholemodule = wholemodule
     func(module)
 

--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -348,7 +348,7 @@ def _initialize(module, cfg, overmodule=False):
     func(module)
 
 
-def _initialize_override(module, override):
+def _initialize_override(module, override, cfg):
     if not isinstance(override, (dict, list)):
         raise TypeError(f'override must be a dict or a list of dict, \
                 but got {type(override)}')
@@ -356,6 +356,8 @@ def _initialize_override(module, override):
     override = [override] if isinstance(override, dict) else override
 
     for override_ in override:
+        if 'type' not in override_.keys():
+            override_.update(cfg)
         name = override_.pop('name', None)
         if hasattr(module, name):
             _initialize(getattr(module, name), override_, overmodule=True)
@@ -428,10 +430,8 @@ def initialize(module, init_cfg):
         _initialize(module, cfg)
 
         if override is not None:
-            if 'type' not in override.keys():
-                cfg.pop('layer', None)
-                override.update(cfg)
-            _initialize_override(module, override)
+            cfg.pop('layer', None)
+            _initialize_override(module, override, cfg)
         else:
             # All attributes in module have same initialization.
             pass

--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -80,7 +80,7 @@ def bias_init_with_prob(prior_prob):
 class BaseInit(object):
 
     def __init__(self, *, bias=0, bias_prob=None, layer=None):
-        self.overmodule = False
+        self.wholemodule = False
         if not isinstance(bias, (int, float)):
             raise TypeError(f'bias must be a numbel, but got a {type(bias)}')
 
@@ -126,7 +126,7 @@ class ConstantInit(BaseInit):
     def __call__(self, module):
 
         def init(m):
-            if self.overmodule:
+            if self.wholemodule:
                 constant_init(m, self.val, self.bias)
             else:
                 layername = m.__class__.__name__
@@ -163,7 +163,7 @@ class XavierInit(BaseInit):
     def __call__(self, module):
 
         def init(m):
-            if self.overmodule:
+            if self.wholemodule:
                 xavier_init(m, self.gain, self.bias, self.distribution)
             else:
                 layername = m.__class__.__name__
@@ -199,7 +199,7 @@ class NormalInit(BaseInit):
     def __call__(self, module):
 
         def init(m):
-            if self.overmodule:
+            if self.wholemodule:
                 normal_init(m, self.mean, self.std, self.bias)
             else:
                 layername = m.__class__.__name__
@@ -236,7 +236,7 @@ class UniformInit(BaseInit):
     def __call__(self, module):
 
         def init(m):
-            if self.overmodule:
+            if self.wholemodule:
                 uniform_init(m, self.a, self.b, self.bias)
             else:
                 layername = m.__class__.__name__
@@ -289,7 +289,7 @@ class KaimingInit(BaseInit):
     def __call__(self, module):
 
         def init(m):
-            if self.overmodule:
+            if self.wholemodule:
                 kaiming_init(m, self.a, self.mode, self.nonlinearity,
                              self.bias, self.distribution)
             else:
@@ -342,9 +342,9 @@ class PretrainedInit(object):
             load_state_dict(module, state_dict, strict=False, logger=logger)
 
 
-def _initialize(module, cfg, overmodule=False):
+def _initialize(module, cfg, wholemodule=False):
     func = build_from_cfg(cfg, INITIALIZERS)
-    func.overmodule = overmodule
+    func.wholemodule = wholemodule
     func(module)
 
 
@@ -360,7 +360,7 @@ def _initialize_override(module, override, cfg):
             override_.update(cfg)
         name = override_.pop('name', None)
         if hasattr(module, name):
-            _initialize(getattr(module, name), override_, overmodule=True)
+            _initialize(getattr(module, name), override_, wholemodule=True)
         else:
             raise RuntimeError(f'module did not have attribute {name}')
 


### PR DESCRIPTION
Hi,

As developers would like to only initialize parameters with attribute names, I just revise the initialization mechanism. If we don't define `layer` key or `override` key, it will not initialize anything; if we define `override` but don't define `layer`, it will initialize parameters with the attribute name in `override`; if we only define `layer`, it just initialize the layer in `layer` key; if we define `override` and `layer`, `override` has higher priority and will override initialization mechanism.

Moreover, for ease of use, if we only define `override`, and `override` without `type` key, the `type` key and other kwargs will merge in `override`.