### PR TITLE
[Feature]: support to calculate FLOPs of GN, IN, LN

### DIFF
--- a/mmcv/cnn/utils/flops_counter.py
+++ b/mmcv/cnn/utils/flops_counter.py
@@ -56,7 +56,8 @@ def get_model_complexity_info(model,
             ``nn.AdaptiveMaxPool3d``, ``nn.AdaptiveAvgPool1d``,
             ``nn.AdaptiveAvgPool2d``, ``nn.AdaptiveAvgPool3d``.
         - BatchNorms: ``nn.BatchNorm1d``, ``nn.BatchNorm2d``,
-            ``nn.BatchNorm3d``.
+            ``nn.BatchNorm3d``, ``nn.GroupNorm``, ``nn.InstanceNorm1d``,
+            ``InstanceNorm2d``, ``InstanceNorm3d``, ``nn.LayerNorm``.
         - Linear: ``nn.Linear``.
         - Deconvolution: ``nn.ConvTranspose2d``.
         - Upsample: ``nn.Upsample``.
@@ -426,11 +427,12 @@ def pool_flops_counter_hook(module, input, output):
     module.__flops__ += int(np.prod(input.shape))
 
 
-def bn_flops_counter_hook(module, input, output):
+def norm_flops_counter_hook(module, input, output):
     input = input[0]
 
     batch_flops = np.prod(input.shape)
-    if module.affine:
+    if (hasattr(module, 'affine') and module.affine or
+        hasattr(module, 'elementwise_affine') and module.elementwise_affine):
         batch_flops *= 2
     module.__flops__ += int(batch_flops)
 
@@ -577,10 +579,15 @@ def get_modules_mapping():
         nn.AdaptiveAvgPool2d: pool_flops_counter_hook,
         nn.AdaptiveMaxPool3d: pool_flops_counter_hook,
         nn.AdaptiveAvgPool3d: pool_flops_counter_hook,
-        # BNs
-        nn.BatchNorm1d: bn_flops_counter_hook,
-        nn.BatchNorm2d: bn_flops_counter_hook,
-        nn.BatchNorm3d: bn_flops_counter_hook,
+        # normalizations
+        nn.BatchNorm1d: norm_flops_counter_hook,
+        nn.BatchNorm2d: norm_flops_counter_hook,
+        nn.BatchNorm3d: norm_flops_counter_hook,
+        nn.GroupNorm: norm_flops_counter_hook,
+        nn.InstanceNorm1d: norm_flops_counter_hook,
+        nn.InstanceNorm2d: norm_flops_counter_hook,
+        nn.InstanceNorm3d: norm_flops_counter_hook,
+        nn.LayerNorm: norm_flops_counter_hook,
         # FC
         nn.Linear: linear_flops_counter_hook,
         mmcv.cnn.bricks.Linear: linear_flops_counter_hook,

--- a/mmcv/cnn/utils/flops_counter.py
+++ b/mmcv/cnn/utils/flops_counter.py
@@ -431,8 +431,8 @@ def norm_flops_counter_hook(module, input, output):
     input = input[0]
 
     batch_flops = np.prod(input.shape)
-    if (getattr(module, 'affine', False) or
-           getattr(module, 'elementwise_affine', False)):
+    if (getattr(module, 'affine', False)
+            or getattr(module, 'elementwise_affine', False)):
         batch_flops *= 2
     module.__flops__ += int(batch_flops)
 

--- a/mmcv/cnn/utils/flops_counter.py
+++ b/mmcv/cnn/utils/flops_counter.py
@@ -431,8 +431,8 @@ def norm_flops_counter_hook(module, input, output):
     input = input[0]
 
     batch_flops = np.prod(input.shape)
-    if (hasattr(module, 'affine') and module.affine or
-        hasattr(module, 'elementwise_affine') and module.elementwise_affine):
+    if (getattr(module, 'affine', False) or
+           getattr(module, 'elementwise_affine', False)):
         batch_flops *= 2
     module.__flops__ += int(batch_flops)
 

--- a/tests/test_cnn/test_flops_counter.py
+++ b/tests/test_cnn/test_flops_counter.py
@@ -32,11 +32,19 @@ gt_results = [
     {'model': nn.AdaptiveAvgPool1d(2), 'input': (3, 16), 'flops': 48.0, 'params': 0},  # noqa: E501
     {'model': nn.AdaptiveAvgPool2d(2), 'input': (3, 16, 16), 'flops': 768.0, 'params': 0},  # noqa: E501
     {'model': nn.AdaptiveAvgPool3d(2), 'input': (3, 3, 16, 16), 'flops': 2304.0, 'params': 0},  # noqa: E501
-    {'model': nn.BatchNorm1d(3, 8), 'input': (3, 16), 'flops': 96.0, 'params': 6.0},  # noqa: E501
-    {'model': nn.BatchNorm2d(3, 8), 'input': (3, 16, 16), 'flops': 1536.0, 'params': 6.0},  # noqa: E501
-    {'model': nn.BatchNorm3d(3, 8), 'input': (3, 3, 16, 16), 'flops': 4608.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.BatchNorm1d(3), 'input': (3, 16), 'flops': 96.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.BatchNorm2d(3), 'input': (3, 16, 16), 'flops': 1536.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.BatchNorm3d(3), 'input': (3, 3, 16, 16), 'flops': 4608.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.GroupNorm(2, 6), 'input': (6, 16, 16), 'flops': 3072.0, 'params': 12.0},  # noqa: E501
+    {'model': nn.InstanceNorm1d(3, affine=True), 'input': (3, 16), 'flops': 96.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.InstanceNorm2d(3, affine=True), 'input': (3, 16, 16), 'flops': 1536.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.InstanceNorm3d(3, affine=True), 'input': (3, 3, 16, 16), 'flops': 4608.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.LayerNorm((3, 16, 16)), 'input': (3, 16, 16), 'flops': 1536.0, 'params': 1536.0},  # noqa: E501
+    {'model': nn.LayerNorm((3, 16, 16), elementwise_affine=False), 'input': (3, 16, 16), 'flops': 768.0, 'params': 0},  # noqa: E501
     {'model': nn.Linear(1024, 2), 'input': (1024, ), 'flops': 2048.0, 'params': 2050.0},  # noqa: E501
+    # {'model': nn.ConvTranspose1d(3, 8, 3), 'input': (3, 16), 'flops': 57888, 'params': 224.0},  # noqa: E501
     {'model': nn.ConvTranspose2d(3, 8, 3), 'input': (3, 16, 16), 'flops': 57888, 'params': 224.0},  # noqa: E501
+    # {'model': nn.ConvTranspose3d(3, 8, 3), 'input': (3, 16, 16, 16), 'flops': 57888, 'params': 224.0},  # noqa: E501
     {'model': nn.Upsample((32, 32)), 'input': (3, 16, 16), 'flops': 3072.0, 'params': 0}  # noqa: E501
 ]
 # yapf: enable


### PR DESCRIPTION
Related Issue：https://github.com/open-mmlab/mmcv/issues/886

**Support:**

1. Support to calculate FLOPs of GroupNorm, InstanceNorm1d, InstanceNorm2d, InstanceNorm3d, LayerNorm

**Discussion:**
**1. how to support torch.bmm**
Now we only support to calculate FLOPs of those modules inherited from `nn.Module`. Therefore, operations which are not inherited from `nn.Module` are not supported, such as `torch.bmm`, `torch.nn.functional.conv2d`.
```python
import torch
import torch.nn as nn
import torch.nn.functional as F

from mmcv.cnn.utils import get_model_complexity_info


class Dummy(nn.Module):
    def __init__(self):
        super().__init__()
        self.conv1 = nn.Conv2d(3, 8, 3)
        self.conv2 = nn.Conv2d(8, 256, 3)
        self.conv3 = nn.Conv2d(256, 8, 3)
        self.avg_pool = nn.AdaptiveAvgPool2d((1, 1))
        self.flatten = nn.Flatten()
        self.fc = nn.Linear(8, 1)
    def forward(self, x):
        # nn.Module
        x = self.conv1(x)
        x = self.conv2(x)
        x = self.conv3(x)
        x = self.avg_pool(x)
        x = self.flatten(x)
        x = self.fc(x)
        # torch.nn.functional.conv1d is not supported
        filters = torch.randn(33, 16, 3)
        inputs = torch.randn(20, 16, 50)
        outputs = F.conv1d(inputs, filters)
        # torch.bmm is not supported
        inputs_1 = torch.randn(10, 3, 4)
        inputs_2 = torch.randn(10, 4, 5)
        outputs = torch.bmm(inputs_1, inputs_2)
        return outputs


get_model_complexity_info(Dummy(), (3, 16, 16))
"""
Dummy(
  0.037 M, 100.000% Params, 0.005 GFLOPs, 100.000% FLOPs, 
  (conv1): Conv2d(0.0 M, 0.600% Params, 0.0 GFLOPs, 0.959% FLOPs, 3, 8, kernel_size=(3, 3), stride=(1, 1))
  (conv2): Conv2d(0.019 M, 50.020% Params, 0.003 GFLOPs, 58.760% FLOPs, 8, 256, kernel_size=(3, 3), stride=(1, 1))
  (conv3): Conv2d(0.018 M, 49.356% Params, 0.002 GFLOPs, 40.264% FLOPs, 256, 8, kernel_size=(3, 3), stride=(1, 1))
  (avg_pool): AdaptiveAvgPool2d(0.0 M, 0.000% Params, 0.0 GFLOPs, 0.017% FLOPs, output_size=(1, 1))
  (flatten): Flatten(0.0 M, 0.000% Params, 0.0 GFLOPs, 0.000% FLOPs, )
  (fc): Linear(0.0 M, 0.024% Params, 0.0 GFLOPs, 0.000% FLOPs, in_features=8, out_features=1, bias=True)
)
"""
```

Maybe we can use decorator to support torch.bmm or `torch.nn.functional.conv2d` and so on.

```python
from collections import defaultdict
import functools

import numpy as np
import torch
import torch.nn as nn
import torch.nn.functional as F
from mmcv.cnn.utils import get_model_complexity_info


def bmm_flops_count(input, output):
    input1, input2, *remain = input[0]
    return np.prod(input1.shape[1:]) * input2.shape[-1]


method_mapping = {
    'bmm': bmm_flops_count,
}
flops_cnt = defaultdict(int)


def flops_count_wrapper(func):
    @functools.wraps(func)
    def wrapper(*args, **kwargs):
        output = func(*args, **kwargs)
        name = func.__name__
        flops_cnt[name] += method_mapping[name](input=(args, kwargs),
                                                output=output)
        return output
    return wrapper


# decorate wrapper
torch.bmm = flops_count_wrapper(torch.bmm)


class Dummy(nn.Module):
    def __init__(self):
        super().__init__()
        self.conv1 = nn.Conv2d(3, 8, 3)
        self.conv2 = nn.Conv2d(8, 256, 3)
        self.conv3 = nn.Conv2d(256, 8, 3)
        self.avg_pool = nn.AdaptiveAvgPool2d((1, 1))
        self.flatten = nn.Flatten()
        self.fc = nn.Linear(8, 1)
    def forward(self, x):
        # nn.Module
        x = self.conv1(x)
        x = self.conv2(x)
        x = self.conv3(x)
        x = self.avg_pool(x)
        x = self.flatten(x)
        x = self.fc(x)
        # torch.nn.functional.conv1d
        filters = torch.randn(33, 16, 3)
        inputs = torch.randn(20, 16, 50)
        outputs = F.conv1d(inputs, filters)
        # torch.bmm
        inputs_1 = torch.randn(10, 3, 4)
        inputs_2 = torch.randn(10, 4, 5)
        outputs = torch.bmm(inputs_1, inputs_2)
        return outputs


get_model_complexity_info(Dummy(), (3, 16, 16))
print(flops_cnt)
"""
Dummy(
  0.037 M, 100.000% Params, 0.005 GFLOPs, 100.000% FLOPs, 
  (conv1): Conv2d(0.0 M, 0.600% Params, 0.0 GFLOPs, 0.959% FLOPs, 3, 8, kernel_size=(3, 3), stride=(1, 1))
  (conv2): Conv2d(0.019 M, 50.020% Params, 0.003 GFLOPs, 58.760% FLOPs, 8, 256, kernel_size=(3, 3), stride=(1, 1))
  (conv3): Conv2d(0.018 M, 49.356% Params, 0.002 GFLOPs, 40.264% FLOPs, 256, 8, kernel_size=(3, 3), stride=(1, 1))
  (avg_pool): AdaptiveAvgPool2d(0.0 M, 0.000% Params, 0.0 GFLOPs, 0.017% FLOPs, output_size=(1, 1))
  (flatten): Flatten(0.0 M, 0.000% Params, 0.0 GFLOPs, 0.000% FLOPs, )
  (fc): Linear(0.0 M, 0.024% Params, 0.0 GFLOPs, 0.000% FLOPs, in_features=8, out_features=1, bias=True)
)
defaultdict(<class 'int'>, {'bmm': 60})
"""
```
**2. deconv_flops_counter_hook and conv_flops_counter_hook**
Should [deconv_flops_counter_hook](https://github.com/zhouzaida/mmcv/blob/flops_cnt_support/mmcv/cnn/utils/flops_counter.py#L440) and 
[conv_flops_counter_hook](https://github.com/zhouzaida/mmcv/blob/flops_cnt_support/mmcv/cnn/utils/flops_counter.py#L467) be the same?