### PR TITLE
[Feature] support to calculate FLOPs of GN, IN, LN

### DIFF
--- a/mmcv/cnn/utils/flops_counter.py
+++ b/mmcv/cnn/utils/flops_counter.py
@@ -40,11 +40,13 @@ def get_model_complexity_info(model,
                               input_constructor=None,
                               flush=False,
                               ost=sys.stdout):
-    """Get complexity information of a model. This method can calculate FLOPs
+    """Get complexity information of a model.
+    
+    This method can calculate FLOPs
     and parameter counts of a model with corresponding input shape. It can also
-    print complexity information for each layer in a model. Supported layers
-    are listed as below:
-
+    print complexity information for each layer in a model.
+    
+    Supported layers are listed as below:
         - Convolutions: ``nn.Conv1d``, ``nn.Conv2d``, ``nn.Conv3d``.
         - Activations: ``nn.ReLU``, ``nn.PReLU``, ``nn.ELU``, ``nn.LeakyReLU``,
             ``nn.ReLU6``.
@@ -59,6 +61,7 @@ def get_model_complexity_info(model,
         - Linear: ``nn.Linear``.
         - Deconvolution: ``nn.ConvTranspose2d``.
         - Upsample: ``nn.Upsample``.
+
     Args:
         model (nn.Module): The model for complexity calculation.
         input_shape (tuple): Input shape used for calculation.
@@ -72,6 +75,7 @@ def get_model_complexity_info(model,
         flush (bool): same as that in :func:`print`. Default: False.
         ost (stream): same as ``file`` param in :func:`print`.
             Default: sys.stdout.
+
     Returns:
         tuple[float | str]: If ``as_strings`` is set to True, it will return
             FLOPs and parameter counts in a string format. otherwise, it will
@@ -113,15 +117,19 @@ def get_model_complexity_info(model,
 
 def flops_to_string(flops, units='GFLOPs', precision=2):
     """Convert FLOPs number into a string.
+
     Note that Here we take a multiply-add counts as one FLOP.
+
     Args:
         flops (float): FLOPs number to be converted.
         units (str | None): Converted FLOPs units. Options are None, 'GFLOPs',
             'MFLOPs', 'KFLOPs', 'FLOPs'. If set to None, it will automatically
             choose the most suitable unit for FLOPs. Default: 'GFLOPs'.
         precision (int): Digit number after the decimal point. Default: 2.
+
     Returns:
         str: The converted FLOPs number with units.
+
     Examples:
         >>> flops_to_string(1e9)
         '1.0 GFLOPs'
@@ -152,14 +160,17 @@ def flops_to_string(flops, units='GFLOPs', precision=2):
 
 def params_to_string(num_params, units=None, precision=2):
     """Convert parameter number into a string.
+
     Args:
         num_params (float): Parameter number to be converted.
         units (str | None): Converted FLOPs units. Options are None, 'M',
             'K' and ''. If set to None, it will automatically choose the most
             suitable unit for Parameter number. Default: None.
         precision (int): Digit number after the decimal point. Default: 2.
+
     Returns:
         str: The converted parameter number with units.
+
     Examples:
         >>> params_to_string(1e9)
         '1000.0 M'
@@ -192,6 +203,7 @@ def print_model_with_flops(model,
                            ost=sys.stdout,
                            flush=False):
     """Print a model with FLOPs for each layer.
+
     Args:
         model (nn.Module): The model to be printed.
         total_flops (float): Total FLOPs of the model.
@@ -201,8 +213,10 @@ def print_model_with_flops(model,
         ost (stream): same as `file` param in :func:`print`.
             Default: sys.stdout.
         flush (bool): same as that in :func:`print`. Default: False.
+
     Example:
         >>> class ExampleModel(nn.Module):
+
         >>> def __init__(self):
         >>>     super().__init__()
         >>>     self.conv1 = nn.Conv2d(3, 8, 3)
@@ -211,6 +225,7 @@ def print_model_with_flops(model,
         >>>     self.avg_pool = nn.AdaptiveAvgPool2d((1, 1))
         >>>     self.flatten = nn.Flatten()
         >>>     self.fc = nn.Linear(8, 1)
+
         >>> def forward(self, x):
         >>>     x = self.conv1(x)
         >>>     x = self.conv2(x)
@@ -219,6 +234,7 @@ def print_model_with_flops(model,
         >>>     x = self.flatten(x)
         >>>     x = self.fc(x)
         >>>     return x
+
         >>> model = ExampleModel()
         >>> x = (3, 16, 16)
         to print the complexity inforamtion state for each layer, you can use
@@ -293,6 +309,7 @@ def get_model_parameters_number(model):
 
     Args:
         model (nn.module): The model for parameter number calculation.
+
     Returns:
         float: Parameter number of the model.
     """
@@ -322,6 +339,7 @@ def compute_average_flops_cost(self):
 
     A method to compute average FLOPs cost, which will be available after
     `add_flops_counting_methods()` is called on a desired net object.
+
     Returns:
         float: Current mean flops consumption per image.
     """

--- a/mmcv/cnn/utils/flops_counter.py
+++ b/mmcv/cnn/utils/flops_counter.py
@@ -41,11 +41,11 @@ def get_model_complexity_info(model,
                               flush=False,
                               ost=sys.stdout):
     """Get complexity information of a model.
-    
-    This method can calculate FLOPs
-    and parameter counts of a model with corresponding input shape. It can also
-    print complexity information for each layer in a model.
-    
+
+    This method can calculate FLOPs and parameter counts of a model with
+    corresponding input shape. It can also print complexity information for
+    each layer in a model.
+
     Supported layers are listed as below:
         - Convolutions: ``nn.Conv1d``, ``nn.Conv2d``, ``nn.Conv3d``.
         - Activations: ``nn.ReLU``, ``nn.PReLU``, ``nn.ELU``, ``nn.LeakyReLU``,

--- a/tests/test_cnn/test_flops_counter.py
+++ b/tests/test_cnn/test_flops_counter.py
@@ -32,9 +32,15 @@ gt_results = [
     {'model': nn.AdaptiveAvgPool1d(2), 'input': (3, 16), 'flops': 48.0, 'params': 0},  # noqa: E501
     {'model': nn.AdaptiveAvgPool2d(2), 'input': (3, 16, 16), 'flops': 768.0, 'params': 0},  # noqa: E501
     {'model': nn.AdaptiveAvgPool3d(2), 'input': (3, 3, 16, 16), 'flops': 2304.0, 'params': 0},  # noqa: E501
-    {'model': nn.BatchNorm1d(3, 8), 'input': (3, 16), 'flops': 96.0, 'params': 6.0},  # noqa: E501
-    {'model': nn.BatchNorm2d(3, 8), 'input': (3, 16, 16), 'flops': 1536.0, 'params': 6.0},  # noqa: E501
-    {'model': nn.BatchNorm3d(3, 8), 'input': (3, 3, 16, 16), 'flops': 4608.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.BatchNorm1d(3), 'input': (3, 16), 'flops': 96.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.BatchNorm2d(3), 'input': (3, 16, 16), 'flops': 1536.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.BatchNorm3d(3), 'input': (3, 3, 16, 16), 'flops': 4608.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.GroupNorm(2, 6), 'input': (6, 16, 16), 'flops': 3072.0, 'params': 12.0},  # noqa: E501
+    {'model': nn.InstanceNorm1d(3, affine=True), 'input': (3, 16), 'flops': 96.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.InstanceNorm2d(3, affine=True), 'input': (3, 16, 16), 'flops': 1536.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.InstanceNorm3d(3, affine=True), 'input': (3, 3, 16, 16), 'flops': 4608.0, 'params': 6.0},  # noqa: E501
+    {'model': nn.LayerNorm((3, 16, 16)), 'input': (3, 16, 16), 'flops': 1536.0, 'params': 1536.0},  # noqa: E501
+    {'model': nn.LayerNorm((3, 16, 16), elementwise_affine=False), 'input': (3, 16, 16), 'flops': 768.0, 'params': 0},  # noqa: E501
     {'model': nn.Linear(1024, 2), 'input': (1024, ), 'flops': 2048.0, 'params': 2050.0},  # noqa: E501
     {'model': nn.ConvTranspose2d(3, 8, 3), 'input': (3, 16, 16), 'flops': 57888, 'params': 224.0},  # noqa: E501
     {'model': nn.Upsample((32, 32)), 'input': (3, 16, 16), 'flops': 3072.0, 'params': 0}  # noqa: E501


### PR DESCRIPTION
Related Issue：https://github.com/open-mmlab/mmcv/issues/886

**Support:**

1. Support to calculate FLOPs of GroupNorm, InstanceNorm1d, InstanceNorm2d, InstanceNorm3d, LayerNorm

**Discussion:**
**1. how to support torch.bmm**
Now we only support to calculate FLOPs of those modules inherited from `nn.Module`. Therefore, operations which are not inherited from `nn.Module` are not supported, such as `torch.bmm`, `torch.nn.functional.conv2d`.
```python
import torch
import torch.nn as nn
import torch.nn.functional as F

from mmcv.cnn.utils import get_model_complexity_info


class Dummy(nn.Module):
    def __init__(self):
        super().__init__()
        self.conv1 = nn.Conv2d(3, 8, 3)
        self.conv2 = nn.Conv2d(8, 256, 3)
        self.conv3 = nn.Conv2d(256, 8, 3)
        self.avg_pool = nn.AdaptiveAvgPool2d((1, 1))
        self.flatten = nn.Flatten()
        self.fc = nn.Linear(8, 1)
    def forward(self, x):
        # nn.Module
        x = self.conv1(x)
        x = self.conv2(x)
        x = self.conv3(x)
        x = self.avg_pool(x)
        x = self.flatten(x)
        x = self.fc(x)
        # torch.nn.functional.conv1d is not supported
        filters = torch.randn(33, 16, 3)
        inputs = torch.randn(20, 16, 50)
        outputs = F.conv1d(inputs, filters)
        # torch.bmm is not supported
        inputs_1 = torch.randn(10, 3, 4)
        inputs_2 = torch.randn(10, 4, 5)
        outputs = torch.bmm(inputs_1, inputs_2)
        return outputs


get_model_complexity_info(Dummy(), (3, 16, 16))
"""
Dummy(
  0.037 M, 100.000% Params, 0.005 GFLOPs, 100.000% FLOPs, 
  (conv1): Conv2d(0.0 M, 0.600% Params, 0.0 GFLOPs, 0.959% FLOPs, 3, 8, kernel_size=(3, 3), stride=(1, 1))
  (conv2): Conv2d(0.019 M, 50.020% Params, 0.003 GFLOPs, 58.760% FLOPs, 8, 256, kernel_size=(3, 3), stride=(1, 1))
  (conv3): Conv2d(0.018 M, 49.356% Params, 0.002 GFLOPs, 40.264% FLOPs, 256, 8, kernel_size=(3, 3), stride=(1, 1))
  (avg_pool): AdaptiveAvgPool2d(0.0 M, 0.000% Params, 0.0 GFLOPs, 0.017% FLOPs, output_size=(1, 1))
  (flatten): Flatten(0.0 M, 0.000% Params, 0.0 GFLOPs, 0.000% FLOPs, )
  (fc): Linear(0.0 M, 0.024% Params, 0.0 GFLOPs, 0.000% FLOPs, in_features=8, out_features=1, bias=True)
)
"""
```

Maybe we can use decorator to support torch.bmm or `torch.nn.functional.conv2d` and so on.

```python
from collections import defaultdict
import functools

import numpy as np
import torch
import torch.nn as nn
import torch.nn.functional as F
from mmcv.cnn.utils import get_model_complexity_info


def bmm_flops_count(input, output):
    input1, input2, *remain = input[0]
    return np.prod(input1.shape[1:]) * input2.shape[-1]


method_mapping = {
    'bmm': bmm_flops_count,
}
flops_cnt = defaultdict(int)


def flops_count_wrapper(func):
    @functools.wraps(func)
    def wrapper(*args, **kwargs):
        output = func(*args, **kwargs)
        name = func.__name__
        flops_cnt[name] += method_mapping[name](input=(args, kwargs),
                                                output=output)
        return output
    return wrapper


# decorate wrapper
torch.bmm = flops_count_wrapper(torch.bmm)


class Dummy(nn.Module):
    def __init__(self):
        super().__init__()
        self.conv1 = nn.Conv2d(3, 8, 3)
        self.conv2 = nn.Conv2d(8, 256, 3)
        self.conv3 = nn.Conv2d(256, 8, 3)
        self.avg_pool = nn.AdaptiveAvgPool2d((1, 1))
        self.flatten = nn.Flatten()
        self.fc = nn.Linear(8, 1)
    def forward(self, x):
        # nn.Module
        x = self.conv1(x)
        x = self.conv2(x)
        x = self.conv3(x)
        x = self.avg_pool(x)
        x = self.flatten(x)
        x = self.fc(x)
        # torch.nn.functional.conv1d
        filters = torch.randn(33, 16, 3)
        inputs = torch.randn(20, 16, 50)
        outputs = F.conv1d(inputs, filters)
        # torch.bmm
        inputs_1 = torch.randn(10, 3, 4)
        inputs_2 = torch.randn(10, 4, 5)
        outputs = torch.bmm(inputs_1, inputs_2)
        return outputs


get_model_complexity_info(Dummy(), (3, 16, 16))
print(flops_cnt)
"""
Dummy(
  0.037 M, 100.000% Params, 0.005 GFLOPs, 100.000% FLOPs, 
  (conv1): Conv2d(0.0 M, 0.600% Params, 0.0 GFLOPs, 0.959% FLOPs, 3, 8, kernel_size=(3, 3), stride=(1, 1))
  (conv2): Conv2d(0.019 M, 50.020% Params, 0.003 GFLOPs, 58.760% FLOPs, 8, 256, kernel_size=(3, 3), stride=(1, 1))
  (conv3): Conv2d(0.018 M, 49.356% Params, 0.002 GFLOPs, 40.264% FLOPs, 256, 8, kernel_size=(3, 3), stride=(1, 1))
  (avg_pool): AdaptiveAvgPool2d(0.0 M, 0.000% Params, 0.0 GFLOPs, 0.017% FLOPs, output_size=(1, 1))
  (flatten): Flatten(0.0 M, 0.000% Params, 0.0 GFLOPs, 0.000% FLOPs, )
  (fc): Linear(0.0 M, 0.024% Params, 0.0 GFLOPs, 0.000% FLOPs, in_features=8, out_features=1, bias=True)
)
defaultdict(<class 'int'>, {'bmm': 60})
"""
```
**2. deconv_flops_counter_hook and conv_flops_counter_hook**
Should [deconv_flops_counter_hook](https://github.com/zhouzaida/mmcv/blob/flops_cnt_support/mmcv/cnn/utils/flops_counter.py#L440) and 
[conv_flops_counter_hook](https://github.com/zhouzaida/mmcv/blob/flops_cnt_support/mmcv/cnn/utils/flops_counter.py#L467) be the same?