### PR TITLE
fix wandb logger drop result bug

### DIFF
--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -67,6 +67,7 @@ class EpochBasedRunner(BaseRunner):
             self.run_iter(data_batch, train_mode=False)
             self.call_hook('after_val_iter')
 
+        self._iter += 1
         self.call_hook('after_val_epoch')
 
     def run(self, data_loaders, workflow, max_epochs=None, **kwargs):


### PR DESCRIPTION
### What is the bug

If you use Wandb logger in mmdetection and set workflow to `[('train', 1), ('val', 1)]`, you will get some wandb warning like follows:

![截屏2021-03-29 09 54 06](https://user-images.githubusercontent.com/32559715/112778911-2966a480-9078-11eb-967a-4d747b5a0819.png)

which means we have log twice with non-increase step number.

### How to reproduce it

Add follow code to configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py of mmdetection project

```python
workflow = [('train', 1), ('val', 1)]
log_config = dict(
    hooks = [
        dict(type = 'TextLoggerHook'),
        dict(type = 'WandbLoggerHook',
             init_kwargs = dict(project = 'your project name',
                                name = 'your run name')
```

and then, use command

```
python tools/train.py configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py
```

to run it. By the way, you may want to use a small dataset to reproduce it. You can just rewrite the `__len__` function as follow:

```python
def __len__(self):
    """Total number of samples of data."""
    return 4
```

### Why it occurs

In mmcv/runner/epoch_based_runner.py of mmcv project, there are two functions like follows:

```python
    def train(self, data_loader, **kwargs):
        self.model.train()
        self.mode = 'train'
        self.data_loader = data_loader
        self._max_iters = self._max_epochs * len(self.data_loader)
        self.call_hook('before_train_epoch')
        time.sleep(2)  # Prevent possible deadlock during epoch transition
        for i, data_batch in enumerate(self.data_loader):
            self._inner_iter = i
            self.call_hook('before_train_iter')
            self.run_iter(data_batch, train_mode=True)
            self.call_hook('after_train_iter')
            self._iter += 1

        self.call_hook('after_train_epoch')
        self._epoch += 1

    @torch.no_grad()
    def val(self, data_loader, **kwargs):
        self.model.eval()
        self.mode = 'val'
        self.data_loader = data_loader
        self.call_hook('before_val_epoch')
        time.sleep(2)  # Prevent possible deadlock during epoch transition
        for i, data_batch in enumerate(self.data_loader):
            self._inner_iter = i
            self.call_hook('before_val_iter')
            self.run_iter(data_batch, train_mode=False)
            self.call_hook('after_val_iter')

        self.call_hook('after_val_epoch')
```

At the end of train epoch, we call after_train_epoch func of all the hooks including the wandb logger hook, so it will log once. 

And then, we run into val func, and after the val epoch, we call after_val_epoch func of the wandb logger hook, and it will log again. 

But, we didn’t increase self._iter in val func, so the wandb logger get the same step param, which cause the wandb warning and the droping result of wandb.

So, we have to increase at least 1, after ‘after_train_epoch’ and before ‘after_val_epoch’, which is this pr.