### PR TITLE
Fix onnx interpolate conversion

### DIFF
--- a/mmcv/onnx/onnx_utils/symbolic_helper.py
+++ b/mmcv/onnx/onnx_utils/symbolic_helper.py
@@ -229,7 +229,8 @@ def _interpolate_get_scales_if_available(g, scales):
     if len(scales) == 0:
         return None
     # scales[0] is ListType in Pytorch == 1.7.0
-    scale_desc = 'fs' if scales[0].type().kind() == 'ListType' else 'f'
+    scale_desc = 'fs' if scales[0].type().kind(
+    ) == 'ListType' or scales[0].type().sizes()[0] != 1 else 'f'
     available_scales = _maybe_get_const(
         scales[0], scale_desc) != -1 and not _is_none(scales[0])
 

--- a/mmcv/onnx/onnx_utils/symbolic_helper.py
+++ b/mmcv/onnx/onnx_utils/symbolic_helper.py
@@ -229,7 +229,6 @@ def _interpolate_get_scales_if_available(g, scales):
     if len(scales) == 0:
         return None
     # scales[0] is ListType in Pytorch == 1.7.0
-    print(scales[0])
     scale_desc = 'fs' if scales[0].type().kind() == 'ListType' or (
         sum(scales[0].type().sizes()) > 1) else 'f'
     available_scales = _maybe_get_const(

--- a/mmcv/onnx/onnx_utils/symbolic_helper.py
+++ b/mmcv/onnx/onnx_utils/symbolic_helper.py
@@ -229,8 +229,9 @@ def _interpolate_get_scales_if_available(g, scales):
     if len(scales) == 0:
         return None
     # scales[0] is ListType in Pytorch == 1.7.0
-    scale_desc = 'fs' if scales[0].type().kind(
-    ) == 'ListType' or scales[0].type().sizes()[0] != 1 else 'f'
+    print(scales[0])
+    scale_desc = 'fs' if scales[0].type().kind() == 'ListType' or (
+        sum(scales[0].type().sizes()) > 1) else 'f'
     available_scales = _maybe_get_const(
         scales[0], scale_desc) != -1 and not _is_none(scales[0])
 

--- a/mmcv/onnx/onnx_utils/symbolic_helper.py
+++ b/mmcv/onnx/onnx_utils/symbolic_helper.py
@@ -228,9 +228,13 @@ def _interpolate_size_to_scales(g, input, output_size, dim):
 def _interpolate_get_scales_if_available(g, scales):
     if len(scales) == 0:
         return None
+    # scales[0] is NoneType in Pytorch == 1.5.1
+    # scales[0] is TensorType with sizes = [] in Pytorch == 1.6.0
     # scales[0] is ListType in Pytorch == 1.7.0
+    # scales[0] is TensorType with sizes = [2] in Pytorch == 1.8.0
     scale_desc = 'fs' if scales[0].type().kind() == 'ListType' or (
-        sum(scales[0].type().sizes()) > 1) else 'f'
+        scales[0].type().kind() == 'TensorType' and
+        (sum(scales[0].type().sizes()) > 1)) else 'f'
     available_scales = _maybe_get_const(
         scales[0], scale_desc) != -1 and not _is_none(scales[0])
 


### PR DESCRIPTION
https://github.com/open-mmlab/mmcv/blob/9d80f56ae8c416556f08d0e04d03785ac036c9c7/mmcv/onnx/onnx_utils/symbolic_helper.py#L232

scales[0] could be 'TensorType' with sizes = [2].
Tested on pytorch==1.8.1