### PR TITLE
Load `hook_msgs` when resume checkpoint

### DIFF
--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -339,6 +339,8 @@ class BaseRunner(metaclass=ABCMeta):
 
         self._epoch = checkpoint['meta']['epoch']
         self._iter = checkpoint['meta']['iter']
+        if self.meta is None:
+            self.meta = dict()
         self.meta.setdefault('hook_msgs', dict())
         # load `last_ckpt`, `best_score`, `best_ckpt`, etc. for hook messages
         self.meta['hook_msgs'].update(checkpoint['meta']['hook_msgs'])

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -343,7 +343,8 @@ class BaseRunner(metaclass=ABCMeta):
             self.meta = dict()
         self.meta.setdefault('hook_msgs', dict())
         # load `last_ckpt`, `best_score`, `best_ckpt`, etc. for hook messages
-        self.meta['hook_msgs'].update(checkpoint['meta']['hook_msgs'])
+        self.meta['hook_msgs'].update(checkpoint['meta'].get(
+            'hook_msgs', dict()))
 
         # Re-calculate the number of iterations when resuming
         # models with different number of GPUs

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -339,6 +339,9 @@ class BaseRunner(metaclass=ABCMeta):
 
         self._epoch = checkpoint['meta']['epoch']
         self._iter = checkpoint['meta']['iter']
+        self.meta.setdefault('hook_msgs', dict())
+        # load `last_ckpt`, `best_score`, `best_ckpt`, etc. for hook messages
+        self.meta['hook_msgs'].update(checkpoint['meta']['hook_msgs'])
 
         # Re-calculate the number of iterations when resuming
         # models with different number of GPUs

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -340,7 +340,7 @@ class BaseRunner(metaclass=ABCMeta):
         self._epoch = checkpoint['meta']['epoch']
         self._iter = checkpoint['meta']['iter']
         if self.meta is None:
-            self.meta = dict()
+            self.meta = {}
         self.meta.setdefault('hook_msgs', {})
         # load `last_ckpt`, `best_score`, `best_ckpt`, etc. for hook messages
         self.meta['hook_msgs'].update(checkpoint['meta'].get('hook_msgs', {}))

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -341,10 +341,9 @@ class BaseRunner(metaclass=ABCMeta):
         self._iter = checkpoint['meta']['iter']
         if self.meta is None:
             self.meta = dict()
-        self.meta.setdefault('hook_msgs', dict())
+        self.meta.setdefault('hook_msgs', {})
         # load `last_ckpt`, `best_score`, `best_ckpt`, etc. for hook messages
-        self.meta['hook_msgs'].update(checkpoint['meta'].get(
-            'hook_msgs', dict()))
+        self.meta['hook_msgs'].update(checkpoint['meta'].get('hook_msgs', {}))
 
         # Re-calculate the number of iterations when resuming
         # models with different number of GPUs

--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -237,8 +237,10 @@ class EvalHook(Hook):
             best_score = key_score
             runner.meta['hook_msgs']['best_score'] = best_score
 
-            if self.best_ckpt_path and osp.isfile(self.best_ckpt_path):
-                os.remove(self.best_ckpt_path)
+            best_ckpt_path = runner.meta['hook_msgs'].get('best_ckpt', None)
+
+            if best_ckpt_path and osp.isfile(best_ckpt_path):
+                os.remove(best_ckpt_path)
 
             best_ckpt_name = f'best_{self.key_indicator}_{current}.pth'
             runner.save_checkpoint(

--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -144,6 +144,8 @@ class EvalHook(Hook):
                 warnings.warn('runner.meta is None. Creating an empty one.')
                 runner.meta = dict()
             runner.meta.setdefault('hook_msgs', dict())
+            self.best_ckpt_path = runner.meta['hook_msgs'].get(
+                'best_ckpt', None)
 
     def before_train_iter(self, runner):
         """Evaluate the model only at the start of training by iteration."""
@@ -237,16 +239,15 @@ class EvalHook(Hook):
             best_score = key_score
             runner.meta['hook_msgs']['best_score'] = best_score
 
-            best_ckpt_path = runner.meta['hook_msgs'].get('best_ckpt', None)
-
-            if best_ckpt_path and osp.isfile(best_ckpt_path):
-                os.remove(best_ckpt_path)
+            if self.best_ckpt_path and osp.isfile(self.best_ckpt_path):
+                os.remove(self.best_ckpt_path)
 
             best_ckpt_name = f'best_{self.key_indicator}_{current}.pth'
-            runner.save_checkpoint(
-                runner.work_dir, best_ckpt_name, create_symlink=False)
             self.best_ckpt_path = osp.join(runner.work_dir, best_ckpt_name)
             runner.meta['hook_msgs']['best_ckpt'] = self.best_ckpt_path
+
+            runner.save_checkpoint(
+                runner.work_dir, best_ckpt_name, create_symlink=False)
             runner.logger.info(
                 f'Now best checkpoint is saved as {best_ckpt_name}.')
             runner.logger.info(

--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -32,7 +32,7 @@ class EvalHook(Hook):
             checkpoint would be saved in ``runner.meta['hook_msgs']`` to keep
             best score value and best checkpoint path, which will be also
             loaded when resume checkpoint. Options are the evaluation metrics
-            to the test dataset. e.g., ``bbox_mAP``, ``segm_mAP`` for bbox
+            on the test dataset. e.g., ``bbox_mAP``, ``segm_mAP`` for bbox
             detection and instance segmentation. ``AR@100`` for proposal
             recall. If ``save_best`` is ``auto``, the first key of the returned
              ``OrderedDict`` result will be used. Default: None.
@@ -298,7 +298,7 @@ class DistEvalHook(EvalHook):
             checkpoint would be saved in ``runner.meta['hook_msgs']`` to keep
             best score value and best checkpoint path, which will be also
             loaded when resume checkpoint. Options are the evaluation metrics
-            to the test dataset. e.g., ``bbox_mAP``, ``segm_mAP`` for bbox
+            on the test dataset. e.g., ``bbox_mAP``, ``segm_mAP`` for bbox
             detection and instance segmentation. ``AR@100`` for proposal
             recall. If ``save_best`` is ``auto``, the first key of the returned
              ``OrderedDict`` result will be used. Default: None.

--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -29,7 +29,7 @@ class EvalHook(Hook):
             default: True.
         save_best (str, optional): If a metric is specified, it would measure
             the best checkpoint during evaluation. The information about best
-            checkpoint would be save in ``runner.meta['hook_msgs']`` to keep
+            checkpoint would be saved in ``runner.meta['hook_msgs']`` to keep
             best score value and best checkpoint path, which will be also
             loaded when resume checkpoint. Options are the evaluation metrics
             to the test dataset. e.g., ``bbox_mAP``, ``segm_mAP`` for bbox
@@ -295,7 +295,7 @@ class DistEvalHook(EvalHook):
             default: True.
         save_best (str, optional): If a metric is specified, it would measure
             the best checkpoint during evaluation. The information about best
-            checkpoint would be save in ``runner.meta['hook_msgs']`` to keep
+            checkpoint would be saved in ``runner.meta['hook_msgs']`` to keep
             best score value and best checkpoint path, which will be also
             loaded when resume checkpoint. Options are the evaluation metrics
             to the test dataset. e.g., ``bbox_mAP``, ``segm_mAP`` for bbox

--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -29,13 +29,13 @@ class EvalHook(Hook):
             default: True.
         save_best (str, optional): If a metric is specified, it would measure
             the best checkpoint during evaluation. The information about best
-            checkpoint would be save in ``runner.meta['hook_msgs']``.
-            Options are the evaluation metrics to the test dataset. e.g.,
-            ``bbox_mAP``, ``segm_mAP`` for bbox detection and instance
-            segmentation. ``AR@100`` for proposal recall. If ``save_best`` is
-            ``auto``, the first key of the returned ``OrderedDict`` result
-            will be used. The interval of ``EvalHook`` should be
-            divisible of that in ``CheckpointHook``. Default: None.
+            checkpoint would be save in ``runner.meta['hook_msgs']`` to keep
+            best score value and best checkpoint path, which will be also
+            loaded when resume checkpoint. Options are the evaluation metrics
+            to the test dataset. e.g., ``bbox_mAP``, ``segm_mAP`` for bbox
+            detection and instance segmentation. ``AR@100`` for proposal
+            recall. If ``save_best`` is ``auto``, the first key of the returned
+             ``OrderedDict`` result will be used. Default: None.
         rule (str | None, optional): Comparison rule for best score. If set to
             None, it will infer a reasonable rule. Keys such as 'acc', 'top'
             .etc will be inferred by 'greater' rule. Keys contain 'loss' will
@@ -295,13 +295,13 @@ class DistEvalHook(EvalHook):
             default: True.
         save_best (str, optional): If a metric is specified, it would measure
             the best checkpoint during evaluation. The information about best
-            checkpoint would be save in ``runner.meta['hook_msgs']``.
-            Options are the evaluation metrics to the test dataset. e.g.,
-            ``bbox_mAP``, ``segm_mAP`` for bbox detection and instance
-            segmentation. ``AR@100`` for proposal recall. If ``save_best`` is
-            ``auto``, the first key of the returned ``OrderedDict`` result
-            will be used. The interval of ``EvalHook`` should depend on
-            ``CheckpointHook``. Default: None.
+            checkpoint would be save in ``runner.meta['hook_msgs']`` to keep
+            best score value and best checkpoint path, which will be also
+            loaded when resume checkpoint. Options are the evaluation metrics
+            to the test dataset. e.g., ``bbox_mAP``, ``segm_mAP`` for bbox
+            detection and instance segmentation. ``AR@100`` for proposal
+            recall. If ``save_best`` is ``auto``, the first key of the returned
+             ``OrderedDict`` result will be used. Default: None.
         rule (str | None, optional): Comparison rule for best score. If set to
             None, it will infer a reasonable rule. Keys such as 'acc', 'top'
             .etc will be inferred by 'greater' rule. Keys contain 'loss' will


### PR DESCRIPTION
This PR is to load `hook_msgs` meta information saved in checkpoint which helps to store the `best` related information for evaluation