### PR TITLE
Add custom hook by config file

### DIFF
--- a/examples/train_cifar10.py
+++ b/examples/train_cifar10.py
@@ -159,7 +159,8 @@ def main():
         lr_config=cfg.lr_config,
         optimizer_config=cfg.optimizer_config,
         checkpoint_config=cfg.checkpoint_config,
-        log_config=cfg.log_config)
+        log_config=cfg.log_config,
+        custom_hooks_config=cfg.get('custom_train_hooks', None))
     if dist:
         runner.register_hook(DistSamplerSeedHook())
 

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -481,20 +481,21 @@ class BaseRunner(metaclass=ABCMeta):
                                 custom_hooks_config=None):
         """Register default and custom hooks for training.
 
-        Default hooks include:
+        Default and custom hooks include:
 
-        - LrUpdaterHook
-        - MomentumUpdaterHook
-        - OptimizerStepperHook
-        - CheckpointSaverHook
-        - IterTimerHook
-        - LoggerHook(s)
+          Hooks                 Priority
+        - LrUpdaterHook         10
+        - MomentumUpdaterHook   30
+        - OptimizerStepperHook  50
+        - CheckpointSaverHook   70
+        - IterTimerHook         80
+        - LoggerHook(s)         90
+        - CustomHook(s)         50 (default)
         """
-        #                                                     priority
-        self.register_lr_hook(lr_config)                    # 10
-        self.register_momentum_hook(momentum_config)        # 30
-        self.register_optimizer_hook(optimizer_config)      # 50
-        self.register_checkpoint_hook(checkpoint_config)    # 70
-        self.register_timer_hook(timer_config)              # 80
-        self.register_logger_hooks(log_config)              # 90
-        self.register_custom_hooks(custom_hooks_config)     # 50 (default)
+        self.register_lr_hook(lr_config)
+        self.register_momentum_hook(momentum_config)
+        self.register_optimizer_hook(optimizer_config)
+        self.register_checkpoint_hook(checkpoint_config)
+        self.register_timer_hook(timer_config)
+        self.register_logger_hooks(log_config)
+        self.register_custom_hooks(custom_hooks_config)

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -386,7 +386,7 @@ class BaseRunner(metaclass=ABCMeta):
             hook = mmcv.build_from_cfg(lr_config, HOOKS)
         else:
             hook = lr_config
-        self.register_hook(hook)
+        self.register_hook(hook, priority=10)
 
     def register_momentum_hook(self, momentum_config):
         if momentum_config is None:
@@ -407,7 +407,7 @@ class BaseRunner(metaclass=ABCMeta):
             hook = mmcv.build_from_cfg(momentum_config, HOOKS)
         else:
             hook = momentum_config
-        self.register_hook(hook)
+        self.register_hook(hook, priority=30)
 
     def register_optimizer_hook(self, optimizer_config):
         if optimizer_config is None:
@@ -417,7 +417,7 @@ class BaseRunner(metaclass=ABCMeta):
             hook = mmcv.build_from_cfg(optimizer_config, HOOKS)
         else:
             hook = optimizer_config
-        self.register_hook(hook)
+        self.register_hook(hook, priority=50)
 
     def register_checkpoint_hook(self, checkpoint_config):
         if checkpoint_config is None:
@@ -427,7 +427,7 @@ class BaseRunner(metaclass=ABCMeta):
             hook = mmcv.build_from_cfg(checkpoint_config, HOOKS)
         else:
             hook = checkpoint_config
-        self.register_hook(hook)
+        self.register_hook(hook, priority=70)
 
     def register_logger_hooks(self, log_config):
         if log_config is None:
@@ -436,7 +436,7 @@ class BaseRunner(metaclass=ABCMeta):
         for info in log_config['hooks']:
             logger_hook = mmcv.build_from_cfg(
                 info, HOOKS, default_args=dict(interval=log_interval))
-            self.register_hook(logger_hook, priority='VERY_LOW')
+            self.register_hook(logger_hook, priority=90)
 
     def register_timer_hook(self, timer_config):
         if timer_config is None:
@@ -446,7 +446,20 @@ class BaseRunner(metaclass=ABCMeta):
             hook = mmcv.build_from_cfg(timer_config_, HOOKS)
         else:
             hook = timer_config
-        self.register_hook(hook)
+        self.register_hook(hook, priority=80)
+
+    def register_custom_hooks(self, custom_config):
+        if custom_config is None:
+            return
+
+        if not isinstance(custom_config, list):
+            custom_config = [custom_config]
+
+        for item in custom_config:
+            if isinstance(item, dict):
+                self.register_hook_from_cfg(item)
+            else:
+                self.register_hook(item, priority='NORMAL')
 
     def register_profiler_hook(self, profiler_config):
         if profiler_config is None:
@@ -464,8 +477,9 @@ class BaseRunner(metaclass=ABCMeta):
                                 checkpoint_config=None,
                                 log_config=None,
                                 momentum_config=None,
-                                timer_config=dict(type='IterTimerHook')):
-        """Register default hooks for training.
+                                timer_config=dict(type='IterTimerHook'),
+                                custom_hooks_config=None):
+        """Register default and custom hooks for training.
 
         Default hooks include:
 
@@ -476,9 +490,11 @@ class BaseRunner(metaclass=ABCMeta):
         - IterTimerHook
         - LoggerHook(s)
         """
-        self.register_lr_hook(lr_config)
-        self.register_momentum_hook(momentum_config)
-        self.register_optimizer_hook(optimizer_config)
-        self.register_checkpoint_hook(checkpoint_config)
-        self.register_timer_hook(timer_config)
-        self.register_logger_hooks(log_config)
+        #                                                     priority
+        self.register_lr_hook(lr_config)                    # 10
+        self.register_momentum_hook(momentum_config)        # 30
+        self.register_optimizer_hook(optimizer_config)      # 50
+        self.register_checkpoint_hook(checkpoint_config)    # 70
+        self.register_timer_hook(timer_config)              # 80
+        self.register_logger_hooks(log_config)              # 90
+        self.register_custom_hooks(custom_hooks_config)     # 50 (default)

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -21,10 +21,10 @@ from torch.utils.data import DataLoader
 from mmcv.runner import (CheckpointHook, EMAHook, IterTimerHook,
                          MlflowLoggerHook, PaviLoggerHook, WandbLoggerHook,
                          build_runner)
+from mmcv.runner.hooks.hook import HOOKS, Hook
 from mmcv.runner.hooks.lr_updater import (CosineRestartLrUpdaterHook,
                                           OneCycleLrUpdaterHook,
                                           StepLrUpdaterHook)
-from mmcv.runner.hooks.hook import HOOKS, Hook
 
 
 def test_checkpoint_hook():
@@ -124,8 +124,10 @@ def test_ema_hook():
 
 
 def test_custom_hook():
+
     @HOOKS.register_module()
     class ToyHook(Hook):
+
         def __init__(self, info, *args, **kwargs):
             super().__init__()
             self.info = info
@@ -856,7 +858,6 @@ def _build_demo_runner(runner_type='EpochBasedRunner',
                        max_epochs=1,
                        max_iters=None,
                        multi_optimziers=False):
-
 
     log_config = dict(
         interval=1, hooks=[


### PR DESCRIPTION
Refer to https://github.com/open-mmlab/mmcv/issues/967
I noticed that mmcv hooks already have priority. Therefore, I assign different priorities to default hooks, so that, we can use priority value to indicate when a hook should run.
For example, I add a custom hook as:
```
@HOOKS.register_module()
class CustomHook(Hook):
    def __init__(self, p) -> None:
        super().__init__()
        self.p = p

    def __repr__(self) -> str:
        return f'<CustomHook> with priority {self.p}'
```
And edit the `base_runner.call_hook` function to show the effect.
```
    def call_hook(self, fn_name):
        """Call all hooks.

        Args:
            fn_name (str): The function name in each hook to be called, such as
                "before_train_epoch".
        """
        self.logger.info('-------------------- start call hook -------------------- ')
        for hook in self._hooks:
            self.logger.info(f"{hook} call {fn_name}")
            getattr(hook, fn_name)(self)
        self.logger.info('-------------------- end call hook -------------------- ')
```
Then, we can add custom hooks by config file with:
```
custom_train_hooks = [dict(type='CustomHook', priority=1, p=1),
                      dict(type='CustomHook', priority=89, p=89)]
```
And get the result (I use mmcls to show the effect):
```
2021-04-20 10:24:08,234 - mmcls - INFO - -------------------- start call hook -------------------- 
2021-04-20 10:24:08,234 - mmcls - INFO - <CustomHook> with priority 1 call before_run
2021-04-20 10:24:08,234 - mmcls - INFO - <mmcv.runner.hooks.lr_updater.StepLrUpdaterHook object at 0x7f80bcee1550> call before_run
2021-04-20 10:24:08,234 - mmcls - INFO - <mmcv.runner.hooks.optimizer.OptimizerHook object at 0x7f80bce80ee0> call before_run
2021-04-20 10:24:08,234 - mmcls - INFO - <mmcls.core.evaluation.eval_hooks.EvalHook object at 0x7f80bceaa8e0> call before_run
2021-04-20 10:24:08,234 - mmcls - INFO - <mmcv.runner.hooks.checkpoint.CheckpointHook object at 0x7f80bce99400> call before_run
2021-04-20 10:24:08,234 - mmcls - INFO - <mmcv.runner.hooks.iter_timer.IterTimerHook object at 0x7f80bce89ca0> call before_run
2021-04-20 10:24:08,235 - mmcls - INFO - <CustomHook> with priority 89 call before_run
2021-04-20 10:24:08,235 - mmcls - INFO - <mmcv.runner.hooks.logger.text.TextLoggerHook object at 0x7f80bce89bb0> call before_run
2021-04-20 10:24:08,235 - mmcls - INFO - -------------------- end call hook -------------------- 
2021-04-20 10:24:08,235 - mmcls - INFO - -------------------- start call hook -------------------- 
2021-04-20 10:24:08,235 - mmcls - INFO - <CustomHook> with priority 1 call before_train_epoch
2021-04-20 10:24:08,235 - mmcls - INFO - <mmcv.runner.hooks.lr_updater.StepLrUpdaterHook object at 0x7f80bcee1550> call before_train_epoch
2021-04-20 10:24:08,235 - mmcls - INFO - <mmcv.runner.hooks.optimizer.OptimizerHook object at 0x7f80bce80ee0> call before_train_epoch
2021-04-20 10:24:08,235 - mmcls - INFO - <mmcls.core.evaluation.eval_hooks.EvalHook object at 0x7f80bceaa8e0> call before_train_epoch
2021-04-20 10:24:08,235 - mmcls - INFO - <mmcv.runner.hooks.checkpoint.CheckpointHook object at 0x7f80bce99400> call before_train_epoch
2021-04-20 10:24:08,235 - mmcls - INFO - <mmcv.runner.hooks.iter_timer.IterTimerHook object at 0x7f80bce89ca0> call before_train_epoch
2021-04-20 10:24:08,235 - mmcls - INFO - <CustomHook> with priority 89 call before_train_epoch
2021-04-20 10:24:08,235 - mmcls - INFO - <mmcv.runner.hooks.logger.text.TextLoggerHook object at 0x7f80bce89bb0> call before_train_epoch
2021-04-20 10:24:08,236 - mmcls - INFO - -------------------- end call hook -------------------- 
```