### PR TITLE
Incorrect citation in transformer documentation.

### DIFF
--- a/mmcv/cnn/bricks/transformer.py
+++ b/mmcv/cnn/bricks/transformer.py
@@ -208,7 +208,7 @@ class BaseTransformerLayer(BaseModule):
     named `attn_cfgs`. It is worth mentioning that it supports `prenorm`
     when you specifying `norm` as the first element of `operation_order`.
     More details about the `prenorm`: `On Layer Normalization in the
-    Transformer Architecture <https://arxiv.org/abs/2007.08103>`_ .
+    Transformer Architecture <https://arxiv.org/abs/2002.04745>`_ .
 
     Args:
         attn_cfgs (list[`mmcv.ConfigDict`] | obj:`mmcv.ConfigDict` | None )):


### PR DESCRIPTION
The original citation of the paper On Layer Normalization in the Transformer Architecture <https://arxiv.org/abs/2007.08103> is wrong.
It should be <https://arxiv.org/abs/2002.04745>