### PR TITLE
[Fix] Read in rb mode then decode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,17 +29,17 @@ repos:
         args: ["--remove"]
       - id: mixed-line-ending
         args: ["--fix=lf"]
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.4
-    hooks:
-      - id: markdownlint
-        args: ["-r", "~MD002,~MD013,~MD029,~MD033,~MD034",
-              "-t", "allow_different_nesting"]
-  - repo: https://github.com/myint/docformatter
-    rev: v1.3.1
-    hooks:
-      - id: docformatter
-        args: ["--in-place", "--wrap-descriptions", "79"]
+  # - repo: https://github.com/jumanjihouse/pre-commit-hooks
+  #   rev: 2.1.4
+  #   hooks:
+  #     - id: markdownlint
+  #       args: ["-r", "~MD002,~MD013,~MD029,~MD033,~MD034",
+  #             "-t", "allow_different_nesting"]
+  # - repo: https://github.com/myint/docformatter
+  #   rev: v1.3.1
+  #   hooks:
+  #     - id: docformatter
+  #       args: ["--in-place", "--wrap-descriptions", "79"]
   # - repo: local
   #   hooks:
   #     - id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,17 +29,17 @@ repos:
         args: ["--remove"]
       - id: mixed-line-ending
         args: ["--fix=lf"]
-  # - repo: https://github.com/jumanjihouse/pre-commit-hooks
-  #   rev: 2.1.4
-  #   hooks:
-  #     - id: markdownlint
-  #       args: ["-r", "~MD002,~MD013,~MD029,~MD033,~MD034",
-  #             "-t", "allow_different_nesting"]
-  # - repo: https://github.com/myint/docformatter
-  #   rev: v1.3.1
-  #   hooks:
-  #     - id: docformatter
-  #       args: ["--in-place", "--wrap-descriptions", "79"]
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 2.1.4
+    hooks:
+      - id: markdownlint
+        args: ["-r", "~MD002,~MD013,~MD029,~MD033,~MD034",
+              "-t", "allow_different_nesting"]
+  - repo: https://github.com/myint/docformatter
+    rev: v1.3.1
+    hooks:
+      - id: docformatter
+        args: ["--in-place", "--wrap-descriptions", "79"]
   # - repo: local
   #   hooks:
   #     - id: clang-format

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -91,7 +91,7 @@ class Config:
     @staticmethod
     def _validate_py_syntax(filename):
         with open(filename, 'r', encoding='utf-8') as f:
-            # Setting encoding explicitly help resolve some coding issue on windows
+            # Setting encoding explicitly to resolve coding issue on windows
             content = f.read()
         try:
             ast.parse(content)
@@ -111,7 +111,7 @@ class Config:
             fileBasenameNoExtension=file_basename_no_extension,
             fileExtname=file_extname)
         with open(filename, 'r', encoding='utf-8') as f:
-            # Setting encoding explicitly help resolve some coding issue on windows
+            # Setting encoding explicitly to resolve coding issue on windows
             config_file = f.read()
         for key, value in support_templates.items():
             regexp = r'\{\{\s*' + str(key) + r'\s*\}\}'

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -90,8 +90,9 @@ class Config:
 
     @staticmethod
     def _validate_py_syntax(filename):
-        with open(filename, 'r') as f:
-            content = f.read()
+        with open(filename, 'rb') as f:
+            # reading in this way help resolve some coding error on windows
+            content = f.read().decode()
         try:
             ast.parse(content)
         except SyntaxError as e:
@@ -109,8 +110,9 @@ class Config:
             fileBasename=file_basename,
             fileBasenameNoExtension=file_basename_no_extension,
             fileExtname=file_extname)
-        with open(filename, 'r') as f:
-            config_file = f.read()
+        with open(filename, 'rb') as f:
+            # reading in this way help resolve some coding error on windows
+            config_file = f.read().decode()
         for key, value in support_templates.items():
             regexp = r'\{\{\s*' + str(key) + r'\s*\}\}'
             value = value.replace('\\', '/')
@@ -159,8 +161,9 @@ class Config:
             temp_config_file.close()
 
         cfg_text = filename + '\n'
-        with open(filename, 'r') as f:
-            cfg_text += f.read()
+        with open(filename, 'rb') as f:
+            # reading in this way help resolve some coding error on windows
+            cfg_text += f.read().decode()
 
         if BASE_KEY in cfg_dict:
             cfg_dir = osp.dirname(filename)

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -162,7 +162,7 @@ class Config:
 
         cfg_text = filename + '\n'
         with open(filename, 'r', encoding='utf-8') as f:
-            # Setting encoding explicitly help resolve some coding issue on windows
+            # Setting encoding explicitly to resolve coding issue on windows
             cfg_text += f.read()
 
         if BASE_KEY in cfg_dict:

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -90,9 +90,9 @@ class Config:
 
     @staticmethod
     def _validate_py_syntax(filename):
-        with open(filename, 'rb') as f:
-            # reading in this way help resolve some coding error on windows
-            content = f.read().decode()
+        with open(filename, 'r', encoding='utf-8') as f:
+            # Setting encoding explicitly help resolve some coding issue on windows
+            content = f.read()
         try:
             ast.parse(content)
         except SyntaxError as e:
@@ -110,9 +110,9 @@ class Config:
             fileBasename=file_basename,
             fileBasenameNoExtension=file_basename_no_extension,
             fileExtname=file_extname)
-        with open(filename, 'rb') as f:
-            # reading in this way help resolve some coding error on windows
-            config_file = f.read().decode()
+        with open(filename, 'r', encoding='utf-8') as f:
+            # Setting encoding explicitly help resolve some coding issue on windows
+            config_file = f.read()
         for key, value in support_templates.items():
             regexp = r'\{\{\s*' + str(key) + r'\s*\}\}'
             value = value.replace('\\', '/')
@@ -161,9 +161,9 @@ class Config:
             temp_config_file.close()
 
         cfg_text = filename + '\n'
-        with open(filename, 'rb') as f:
-            # reading in this way help resolve some coding error on windows
-            cfg_text += f.read().decode()
+        with open(filename, 'r', encoding='utf-8') as f:
+            # Setting encoding explicitly help resolve some coding issue on windows
+            cfg_text += f.read()
 
         if BASE_KEY in cfg_dict:
             cfg_dir = osp.dirname(filename)


### PR DESCRIPTION
On Windows :

```python
with open("some_file", r) as f:
    f.read()
```

will decode the content of the file based on windows's system language setting. 

Using `rb` mode then decode within python will force using utf-8.


note: the ruby precommit hook does not work on windows and I will recover it when everything other is good before actual merge. 