### PR TITLE
Replace nn.Sequential due to parameter initialization.

### DIFF
--- a/mmcv/cnn/builder.py
+++ b/mmcv/cnn/builder.py
@@ -1,5 +1,4 @@
-import torch.nn as nn
-
+from ..runner import Sequential
 from ..utils import Registry, build_from_cfg
 
 
@@ -22,7 +21,7 @@ def build_model_from_cfg(cfg, registry, default_args=None):
         modules = [
             build_from_cfg(cfg_, registry, default_args) for cfg_ in cfg
         ]
-        return nn.Sequential(*modules)
+        return Sequential(*modules)
     else:
         return build_from_cfg(cfg, registry, default_args)
 


### PR DESCRIPTION
## Motivation
Due to parameter initialization, `mmcv.runner.Sequential` needs to be used.

refer to https://github.com/open-mmlab/mmdetection/pull/5059