### PR TITLE
Add test util for checking stand-alone python scripts

### DIFF
--- a/mmcv/utils/__init__.py
+++ b/mmcv/utils/__init__.py
@@ -11,7 +11,8 @@ from .progressbar import (ProgressBar, track_iter_progress,
                           track_parallel_progress, track_progress)
 from .testing import (assert_attrs_equal, assert_dict_contains_subset,
                       assert_dict_has_keys, assert_is_norm_layer,
-                      assert_keys_equal, assert_params_all_zeros, check_script)
+                      assert_keys_equal, assert_params_all_zeros,
+                      check_python_script)
 from .timer import Timer, TimerError, check_time
 from .version_utils import digit_version, get_git_hash
 
@@ -28,7 +29,7 @@ except ImportError:
         'Timer', 'TimerError', 'check_time', 'deprecated_api_warning',
         'digit_version', 'get_git_hash', 'import_modules_from_strings',
         'assert_dict_contains_subset', 'assert_attrs_equal',
-        'assert_dict_has_keys', 'assert_keys_equal', 'check_script'
+        'assert_dict_has_keys', 'assert_keys_equal', 'check_python_script'
     ]
 else:
     from .env import collect_env
@@ -57,5 +58,5 @@ else:
         'get_git_hash', 'import_modules_from_strings', 'jit', 'skip_no_elena',
         'assert_dict_contains_subset', 'assert_attrs_equal',
         'assert_dict_has_keys', 'assert_keys_equal', 'assert_is_norm_layer',
-        'assert_params_all_zeros', 'check_script'
+        'assert_params_all_zeros', 'check_python_script'
     ]

--- a/mmcv/utils/__init__.py
+++ b/mmcv/utils/__init__.py
@@ -11,7 +11,7 @@ from .progressbar import (ProgressBar, track_iter_progress,
                           track_parallel_progress, track_progress)
 from .testing import (assert_attrs_equal, assert_dict_contains_subset,
                       assert_dict_has_keys, assert_is_norm_layer,
-                      assert_keys_equal, assert_params_all_zeros)
+                      assert_keys_equal, assert_params_all_zeros, check_script)
 from .timer import Timer, TimerError, check_time
 from .version_utils import digit_version, get_git_hash
 
@@ -28,7 +28,7 @@ except ImportError:
         'Timer', 'TimerError', 'check_time', 'deprecated_api_warning',
         'digit_version', 'get_git_hash', 'import_modules_from_strings',
         'assert_dict_contains_subset', 'assert_attrs_equal',
-        'assert_dict_has_keys', 'assert_keys_equal'
+        'assert_dict_has_keys', 'assert_keys_equal', 'check_script'
     ]
 else:
     from .env import collect_env
@@ -57,5 +57,5 @@ else:
         'get_git_hash', 'import_modules_from_strings', 'jit', 'skip_no_elena',
         'assert_dict_contains_subset', 'assert_attrs_equal',
         'assert_dict_has_keys', 'assert_keys_equal', 'assert_is_norm_layer',
-        'assert_params_all_zeros'
+        'assert_params_all_zeros', 'check_script'
     ]

--- a/mmcv/utils/testing.py
+++ b/mmcv/utils/testing.py
@@ -7,25 +7,18 @@ from typing import Any, Dict, List
 from unittest.mock import patch
 
 
-def check_python_script(cmd, capsys=None):
+def check_python_script(cmd):
     """Run the python cmd script with `__main__`, and return the captured
     stdout as string. Currently it support two forms of cmd lines.
 
     - ./tests/data/scripts/hello.py zz
     - python tests/data/scripts/hello.py zz
     """
-    out = None
-    if capsys is not None:
-        # clear stdout and stderr
-        capsys.readouterr()
     args = split(cmd)
     if args[0] == 'python':
         args = args[1:]
     with patch.object(sys, 'argv', args):
         run_path(args[0], run_name='__main__')
-    if capsys is not None:
-        out = capsys.readouterr().out
-    return out
 
 
 def _any(judge_result):

--- a/mmcv/utils/testing.py
+++ b/mmcv/utils/testing.py
@@ -8,10 +8,9 @@ from unittest.mock import patch
 
 
 def check_python_script(cmd):
-    """Run the python cmd script with `__main__` using `runpy.run_path`.
-    Currently it support two forms of cmd lines. The difference between
+    """Run the python cmd script with `__main__`. The difference between
     `os.system` is that, this function exectues code in the current process, so
-    that it can be tracked by coverage tools.
+    that it can be tracked by coverage tools. Currently it supports two forms:
 
     - ./tests/data/scripts/hello.py zz
     - python tests/data/scripts/hello.py zz

--- a/mmcv/utils/testing.py
+++ b/mmcv/utils/testing.py
@@ -7,22 +7,25 @@ from typing import Any, Dict, List
 from unittest.mock import patch
 
 
-def check_python_script(cmd, capsys):
+def check_python_script(cmd, capsys=None):
     """Run the python cmd script with `__main__`, and return the captured
     stdout as string. Currently it support two forms of cmd lines.
 
     - ./tests/data/scripts/hello.py zz
     - python tests/data/scripts/hello.py zz
     """
-    # first clear stdout and stderr
-    capsys.readouterr()
+    out = None
+    if capsys is not None:
+        # clear stdout and stderr
+        capsys.readouterr()
     args = split(cmd)
     if args[0] == 'python':
         args = args[1:]
     with patch.object(sys, 'argv', args):
         run_path(args[0], run_name='__main__')
-    captured = capsys.readouterr().out
-    return captured
+    if capsys is not None:
+        out = capsys.readouterr().out
+    return out
 
 
 def _any(judge_result):

--- a/mmcv/utils/testing.py
+++ b/mmcv/utils/testing.py
@@ -8,8 +8,10 @@ from unittest.mock import patch
 
 
 def check_python_script(cmd):
-    """Run the python cmd script with `__main__`, and return the captured
-    stdout as string. Currently it support two forms of cmd lines.
+    """Run the python cmd script with `__main__` using `runpy.run_path`.
+    Currently it support two forms of cmd lines. The difference between
+    `os.system` is that, this function exectues code in the current process, so
+    that it can be tracked by coverage tools.
 
     - ./tests/data/scripts/hello.py zz
     - python tests/data/scripts/hello.py zz

--- a/mmcv/utils/testing.py
+++ b/mmcv/utils/testing.py
@@ -1,6 +1,22 @@
 # Copyright (c) Open-MMLab.
+import sys
 from collections.abc import Iterable
+from runpy import run_path
+from shlex import split
 from typing import Any, Dict, List
+from unittest.mock import patch
+
+
+def check_script(cmd, capsys):
+    """Run the cmd script with `__main__`, and return the captured stdout as
+    string."""
+    # first clear stdout and stderr
+    capsys.readouterr()
+    args = split(cmd)
+    with patch.object(sys, 'argv', args):
+        run_path(args[0], run_name='__main__')
+    captured = capsys.readouterr().out
+    return captured
 
 
 def _any(judge_result):

--- a/mmcv/utils/testing.py
+++ b/mmcv/utils/testing.py
@@ -7,12 +7,18 @@ from typing import Any, Dict, List
 from unittest.mock import patch
 
 
-def check_script(cmd, capsys):
-    """Run the cmd script with `__main__`, and return the captured stdout as
-    string."""
+def check_python_script(cmd, capsys):
+    """Run the python cmd script with `__main__`, and return the captured
+    stdout as string. Currently it support two forms of cmd lines.
+
+    - ./tests/data/scripts/hello.py zz
+    - python tests/data/scripts/hello.py zz
+    """
     # first clear stdout and stderr
     capsys.readouterr()
     args = split(cmd)
+    if args[0] == 'python':
+        args = args[1:]
     with patch.object(sys, 'argv', args):
         run_path(args[0], run_name='__main__')
     captured = capsys.readouterr().out

--- a/tests/data/scripts/hello.py
+++ b/tests/data/scripts/hello.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import argparse
+import warnings
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Compute the perfect recall.')
+    parser.add_argument('name', help='Path to sdk json file.')
+
+    args = parser.parse_args()
+
+    return args
+
+
+def main():
+    args = parse_args()
+    print(f'hello {args.name}!')
+    if args.name == 'lizz':
+        warnings.warn('I have a secret!')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/data/scripts/hello.py
+++ b/tests/data/scripts/hello.py
@@ -16,7 +16,7 @@ def parse_args():
 def main():
     args = parse_args()
     print(f'hello {args.name}!')
-    if args.name == 'lizz':
+    if args.name == 'agent':
         warnings.warn('I have a secret!')
 
 

--- a/tests/data/scripts/hello.py
+++ b/tests/data/scripts/hello.py
@@ -5,7 +5,7 @@ import warnings
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Compute the perfect recall.')
+    parser = argparse.ArgumentParser(description='Say hello.')
     parser.add_argument('name', help='Path to sdk json file.')
 
     args = parser.parse_args()

--- a/tests/data/scripts/hello.py
+++ b/tests/data/scripts/hello.py
@@ -6,7 +6,7 @@ import warnings
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Say hello.')
-    parser.add_argument('name', help='Path to sdk json file.')
+    parser.add_argument('name', help='To whom.')
 
     args = parser.parse_args()
 

--- a/tests/test_utils/test_testing.py
+++ b/tests/test_utils/test_testing.py
@@ -186,7 +186,7 @@ def test_check_python_script(capsys):
     mmcv.utils.check_python_script('./tests/data/scripts/hello.py zz')
     captured = capsys.readouterr().out
     assert captured == 'hello zz!\n'
-    mmcv.utils.check_python_script('./tests/data/scripts/hello.py lizz')
+    mmcv.utils.check_python_script('./tests/data/scripts/hello.py agent')
     captured = capsys.readouterr().out
     assert captured == 'hello agent!\n'
     # Make sure that wrong cmd raises an error

--- a/tests/test_utils/test_testing.py
+++ b/tests/test_utils/test_testing.py
@@ -188,6 +188,7 @@ def test_check_python_script(capsys):
     assert captured == 'hello zz!\n'
     mmcv.utils.check_python_script('./tests/data/scripts/hello.py lizz')
     captured = capsys.readouterr().out
-    assert captured == 'hello lizz!\n'
+    assert captured == 'hello agent!\n'
+    # Make sure that wrong cmd raises an error
     with pytest.raises(SystemExit):
         mmcv.utils.check_python_script('./tests/data/scripts/hello.py li zz')

--- a/tests/test_utils/test_testing.py
+++ b/tests/test_utils/test_testing.py
@@ -199,3 +199,4 @@ def test_check_python_script(capsys):
     captured = mmcv.utils.check_python_script(
         'python tests/data/scripts/hello.py lizz', capsys)
     assert captured == 'hello lizz!\n'
+    mmcv.utils.check_python_script('python tests/data/scripts/hello.py zz')

--- a/tests/test_utils/test_testing.py
+++ b/tests/test_utils/test_testing.py
@@ -182,19 +182,20 @@ def test_assert_params_all_zeros():
     assert not mmcv.assert_params_all_zeros(demo_module)
 
 
-def test_check_script(capsys):
-    captured = mmcv.utils.check_script('./tests/data/scripts/hello.py z',
-                                       capsys)
+def test_check_python_script(capsys):
+    captured = mmcv.utils.check_python_script(
+        './tests/data/scripts/hello.py z', capsys)
     assert captured == 'hello z!\n'
-    captured = mmcv.utils.check_script('./tests/data/scripts/hello.py zz',
-                                       capsys)
+    captured = mmcv.utils.check_python_script(
+        './tests/data/scripts/hello.py zz', capsys)
     assert captured == 'hello zz!\n'
     print('lalala')
-    captured = mmcv.utils.check_script('./tests/data/scripts/hello.py lizz',
-                                       capsys)
+    captured = mmcv.utils.check_python_script(
+        './tests/data/scripts/hello.py lizz', capsys)
     assert captured == 'hello lizz!\n'
     with pytest.raises(SystemExit):
-        mmcv.utils.check_script('./tests/data/scripts/hello.py li zz', capsys)
-    captured = mmcv.utils.check_script('./tests/data/scripts/hello.py lizz',
+        mmcv.utils.check_python_script('./tests/data/scripts/hello.py li zz',
                                        capsys)
+    captured = mmcv.utils.check_python_script(
+        'python tests/data/scripts/hello.py lizz', capsys)
     assert captured == 'hello lizz!\n'

--- a/tests/test_utils/test_testing.py
+++ b/tests/test_utils/test_testing.py
@@ -180,3 +180,21 @@ def test_assert_params_all_zeros():
 
     nn.init.normal_(demo_module.weight, mean=0, std=0.01)
     assert not mmcv.assert_params_all_zeros(demo_module)
+
+
+def test_check_script(capsys):
+    captured = mmcv.utils.check_script('./tests/data/scripts/hello.py z',
+                                       capsys)
+    assert captured == 'hello z!\n'
+    captured = mmcv.utils.check_script('./tests/data/scripts/hello.py zz',
+                                       capsys)
+    assert captured == 'hello zz!\n'
+    print('lalala')
+    captured = mmcv.utils.check_script('./tests/data/scripts/hello.py lizz',
+                                       capsys)
+    assert captured == 'hello lizz!\n'
+    with pytest.raises(SystemExit):
+        mmcv.utils.check_script('./tests/data/scripts/hello.py li zz', capsys)
+    captured = mmcv.utils.check_script('./tests/data/scripts/hello.py lizz',
+                                       capsys)
+    assert captured == 'hello lizz!\n'

--- a/tests/test_utils/test_testing.py
+++ b/tests/test_utils/test_testing.py
@@ -183,20 +183,11 @@ def test_assert_params_all_zeros():
 
 
 def test_check_python_script(capsys):
-    captured = mmcv.utils.check_python_script(
-        './tests/data/scripts/hello.py z', capsys)
-    assert captured == 'hello z!\n'
-    captured = mmcv.utils.check_python_script(
-        './tests/data/scripts/hello.py zz', capsys)
+    mmcv.utils.check_python_script('./tests/data/scripts/hello.py zz')
+    captured = capsys.readouterr().out
     assert captured == 'hello zz!\n'
-    print('lalala')
-    captured = mmcv.utils.check_python_script(
-        './tests/data/scripts/hello.py lizz', capsys)
+    mmcv.utils.check_python_script('./tests/data/scripts/hello.py lizz')
+    captured = capsys.readouterr().out
     assert captured == 'hello lizz!\n'
     with pytest.raises(SystemExit):
-        mmcv.utils.check_python_script('./tests/data/scripts/hello.py li zz',
-                                       capsys)
-    captured = mmcv.utils.check_python_script(
-        'python tests/data/scripts/hello.py lizz', capsys)
-    assert captured == 'hello lizz!\n'
-    mmcv.utils.check_python_script('python tests/data/scripts/hello.py zz')
+        mmcv.utils.check_python_script('./tests/data/scripts/hello.py li zz')


### PR DESCRIPTION
This function can be used to check stand-alone scripts, without tweaking `sys.path` manually. Moreover, it will increase test coverage for codes the script touches.
