### PR TITLE
[Enhance] Add step momentum updater to support MMDet3D

### DIFF
--- a/mmcv/runner/hooks/lr_updater.py
+++ b/mmcv/runner/hooks/lr_updater.py
@@ -3,7 +3,6 @@ import numbers
 from math import cos, pi
 
 import mmcv
-
 from .hook import HOOKS, Hook
 
 

--- a/mmcv/runner/hooks/lr_updater.py
+++ b/mmcv/runner/hooks/lr_updater.py
@@ -180,8 +180,7 @@ class StepLrUpdaterHook(LrUpdaterHook):
     def __init__(self, step, gamma=0.1, min_lr=None, **kwargs):
         if isinstance(step, list):
             assert mmcv.is_list_of(step, int)
-            for s in step:
-                assert s > 0
+            assert all([s > 0 for s in step])
         elif isinstance(step, int):
             assert step > 0
         else:

--- a/mmcv/runner/hooks/lr_updater.py
+++ b/mmcv/runner/hooks/lr_updater.py
@@ -194,18 +194,15 @@ class StepLrUpdaterHook(LrUpdaterHook):
         progress = runner.epoch if self.by_epoch else runner.iter
 
         if isinstance(self.step, int):
-            lr = base_lr * (self.gamma**(progress // self.step))
-            if self.min_lr is not None:
-                # clip to a minimum value
-                lr = max(lr, self.min_lr)
-            return lr
+            stage = progress // self.step
+        else:
+            stage = len(self.step)
+            for i, s in enumerate(self.step):
+                if progress < s:
+                    stage = i
+                    break
 
-        exp = len(self.step)
-        for i, s in enumerate(self.step):
-            if progress < s:
-                exp = i
-                break
-        lr = base_lr * self.gamma**exp
+        lr = base_lr * (self.gamma**stage)
         if self.min_lr is not None:
             # clip to a minimum value
             lr = max(lr, self.min_lr)

--- a/mmcv/runner/hooks/momentum_updater.py
+++ b/mmcv/runner/hooks/momentum_updater.py
@@ -470,11 +470,12 @@ class OneCycleMomentumUpdaterHook(MomentumUpdaterHook):
             end_iter = phase['end_iter']
             if curr_iter <= end_iter or i == len(self.momentum_phases) - 1:
                 pct = (curr_iter - start_iter) / (end_iter - start_iter)
-                lr = self.anneal_func(param_group[phase['start_momentum']],
-                                      param_group[phase['end_momentum']], pct)
+                momentum = self.anneal_func(
+                    param_group[phase['start_momentum']],
+                    param_group[phase['end_momentum']], pct)
                 break
             start_iter = end_iter
-        return lr
+        return momentum
 
     def get_regular_momentum(self, runner):
         if isinstance(runner.optimizer, dict):

--- a/mmcv/runner/hooks/momentum_updater.py
+++ b/mmcv/runner/hooks/momentum_updater.py
@@ -167,8 +167,7 @@ class StepMomentumUpdaterHook(MomentumUpdaterHook):
     def __init__(self, step, gamma=0.5, min_momentum=None, **kwargs):
         if isinstance(step, list):
             assert mmcv.is_list_of(step, int)
-            for s in step:
-                assert s > 0
+            assert all([s > 0 for s in step])
         elif isinstance(step, int):
             assert step > 0
         else:

--- a/mmcv/runner/hooks/momentum_updater.py
+++ b/mmcv/runner/hooks/momentum_updater.py
@@ -181,18 +181,15 @@ class StepMomentumUpdaterHook(MomentumUpdaterHook):
         progress = runner.epoch if self.by_epoch else runner.iter
 
         if isinstance(self.step, int):
-            momentum = base_momentum * (self.gamma**(progress // self.step))
-            if self.min_momentum is not None:
-                # clip to a minimum value
-                momentum = max(momentum, self.min_momentum)
-            return momentum
+            stage = progress // self.step
+        else:
+            stage = len(self.step)
+            for i, s in enumerate(self.step):
+                if progress < s:
+                    stage = i
+                    break
 
-        exp = len(self.step)
-        for i, s in enumerate(self.step):
-            if progress < s:
-                exp = i
-                break
-        momentum = base_momentum * self.gamma**exp
+        momentum = base_momentum * (self.gamma**stage)
         if self.min_momentum is not None:
             # clip to a minimum value
             momentum = max(momentum, self.min_momentum)

--- a/mmcv/runner/hooks/momentum_updater.py
+++ b/mmcv/runner/hooks/momentum_updater.py
@@ -1,5 +1,4 @@
 import mmcv
-
 from .hook import HOOKS, Hook
 from .lr_updater import annealing_cos, annealing_linear, format_param
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Similar to StepLRUpdaterHook, in 3D point cloud tasks, we also need to update the momentum of optimizers in a step manner.

## Modification
Add a `StepMomentumUpdaterHook` class.

## BC-breaking (Optional)
No.

## Use cases (Optional)
Similar to `StepLrUpdaterHook`.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
