### PR TITLE
Allow pass None to cfg in build_from_cfg

### DIFF
--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -16,6 +16,9 @@ def build_from_cfg(cfg, registry, default_args=None):
     Returns:
         object: The constructed object.
     """
+    if cfg is None:
+        cfg = dict()
+
     if not isinstance(cfg, dict):
         raise TypeError(f'cfg must be a dict, but got {type(cfg)}')
     if 'type' not in cfg:

--- a/tests/test_utils/test_registry.py
+++ b/tests/test_utils/test_registry.py
@@ -235,6 +235,12 @@ def test_build_from_cfg():
     assert isinstance(model, ResNet)
     assert model.depth == 50 and model.stages == 4
 
+    cfg = None
+    model = mmcv.build_from_cfg(
+        cfg, BACKBONES, default_args=dict(type=ResNet, depth=50))
+    assert isinstance(model, ResNet)
+    assert model.depth == 50 and model.stages == 4
+
     # not a registry
     with pytest.raises(TypeError):
         cfg = dict(type='VGG')


### PR DESCRIPTION
## Motivation
Refer to https://github.com/open-mmlab/mmcv/issues/1008.
For example, when develop a backbone, we need to provide a default configuration for a layer and allow user to override these configuration by config file as well.
```python
def build_dropout(cfg, default_args=None):
    """Builder for drop out layers."""
    return build_from_cfg(cfg, DROPOUT_LAYERS, default_args)
```
However, in many situations, we don't need users to provide detail configs of one layer unless they want to custom it.
Now, we have to pass a dict cfg as default value.
```python
class ExampleLayer(nn.Module):

    def __init__(self, dropout_cfg=None):
        super().__init__()
        default_dropout_cfg = dict(type='DropPath', drop_prob=0.)
        if dropout_cfg is not None:
            default_dropout_cfg.update(dropout_cfg)
        self.drop = build_dropout(default_dropout_cfg)
```
or set default value of cfg as an empty dict.
```python
class ExampleLayer(nn.Module):

    def __init__(self, dropout_cfg=None):
        super().__init__()
        default_dropout_cfg = dict(type='DropPath', drop_prob=0.)
        if dropout_cfg is None:
            dropout_cfg = {}
        self.drop = build_dropout(dropout_cfg, default_dropout_cfg)
```

## Modification
By allowing pass None to cfg, we can use default_args param to set default config.
```python
class ExampleLayer(nn.Module):

    def __init__(self, dropout_cfg=None):
        super().__init__()
        default_dropout_cfg = dict(type='DropPath', drop_prob=0.)
        self.drop = build_dropout(dropout_cfg, default_dropout_cfg)
```


## Checklist

✅ Pre-commit or other linting tools are used to fix the potential lint issues.
✅ The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
