### PR TITLE
Support resume for fp16 training

### DIFF
--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -324,7 +324,6 @@ class BaseRunner(metaclass=ABCMeta):
     def resume(self,
                checkpoint,
                resume_optimizer=True,
-               resume_meta=True,
                map_location='default'):
         if map_location == 'default':
             if torch.cuda.is_available():
@@ -354,8 +353,8 @@ class BaseRunner(metaclass=ABCMeta):
                 self.logger.info('the iteration number is changed due to '
                                  'change of GPU number')
 
-        if resume_meta:
-            self.meta = checkpoint['meta']
+        # resume meta information meta
+        self.meta = checkpoint['meta']
 
         if 'optimizer' in checkpoint and resume_optimizer:
             if isinstance(self.optimizer, Optimizer):

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -324,6 +324,7 @@ class BaseRunner(metaclass=ABCMeta):
     def resume(self,
                checkpoint,
                resume_optimizer=True,
+               resume_meta=True,
                map_location='default'):
         if map_location == 'default':
             if torch.cuda.is_available():
@@ -352,6 +353,9 @@ class BaseRunner(metaclass=ABCMeta):
                                  self.world_size)
                 self.logger.info('the iteration number is changed due to '
                                  'change of GPU number')
+
+        if resume_meta:
+            self.meta = checkpoint['meta']
 
         if 'optimizer' in checkpoint and resume_optimizer:
             if isinstance(self.optimizer, Optimizer):

--- a/mmcv/runner/fp16_utils.py
+++ b/mmcv/runner/fp16_utils.py
@@ -378,6 +378,29 @@ class LossScaler:
                 self.cur_scale *= self.scale_factor
         self.cur_iter += 1
 
+    def state_dict(self):
+        """Returns the state of the scaler as a :class:`dict`."""
+        return dict(
+            cur_scale=self.cur_scale,
+            cur_iter=self.cur_iter,
+            mode=self.mode,
+            last_overflow_iter=self.last_overflow_iter,
+            scale_factor=self.scale_factor,
+            scale_window=self.scale_window)
+
+    def load_state_dict(self, state_dict):
+        """Loads the loss_scaler state dict.
+
+        Args:
+           state_dict (dict): scaler state.
+        """
+        self.cur_scale = state_dict['cur_scale']
+        self.cur_iter = state_dict['cur_iter']
+        self.mode = state_dict['mode']
+        self.last_overflow_iter = state_dict['last_overflow']
+        self.scale_factor = state_dict['scale_factor']
+        self.scale_window = state_dict['scale_window']
+
     @property
     def loss_scale(self):
         return self.cur_scale

--- a/mmcv/runner/fp16_utils.py
+++ b/mmcv/runner/fp16_utils.py
@@ -397,7 +397,7 @@ class LossScaler:
         self.cur_scale = state_dict['cur_scale']
         self.cur_iter = state_dict['cur_iter']
         self.mode = state_dict['mode']
-        self.last_overflow_iter = state_dict['last_overflow']
+        self.last_overflow_iter = state_dict['last_overflow_iter']
         self.scale_factor = state_dict['scale_factor']
         self.scale_window = state_dict['scale_window']
 

--- a/mmcv/runner/fp16_utils.py
+++ b/mmcv/runner/fp16_utils.py
@@ -31,7 +31,9 @@ def cast_tensor_type(inputs, src_type, dst_type):
     Returns:
         The same type with inputs, but all contained Tensors have been cast.
     """
-    if isinstance(inputs, torch.Tensor):
+    if isinstance(inputs, nn.Module):
+        return inputs
+    elif isinstance(inputs, torch.Tensor):
         return inputs.to(dst_type)
     elif isinstance(inputs, str):
         return inputs

--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -100,8 +100,8 @@ if TORCH_VERSION != 'parrots' and TORCH_VERSION >= '1.6.0':
             # wrap model mode to fp16
             wrap_fp16_model(runner.model)
             # resume from state dict
-            if 'fp16.loss_scaler' in runner.meta:
-                scaler_state_dict = runner.meta['fp16.loss_scaler']
+            if 'fp16' in runner.meta and 'loss_scaler' in runner.meta['fp16']:
+                scaler_state_dict = runner.meta['fp16']['loss_scaler']
                 self.loss_scaler.load_state_dict(scaler_state_dict)
 
         def copy_grads_to_fp32(self, fp16_net, fp32_weights):
@@ -149,7 +149,8 @@ if TORCH_VERSION != 'parrots' and TORCH_VERSION >= '1.6.0':
             self.loss_scaler.update(self._scale_update_param)
 
             # save state_dict of loss_scaler
-            runner.meta['fp16.loss_scaler'] = self.loss_scaler.state_dict()
+            runner.meta.setdefault(
+                'fp16', {})['loss_scaler'] = self.loss_scaler.state_dict()
 else:
 
     @HOOKS.register_module()
@@ -219,8 +220,8 @@ else:
             # convert model to fp16
             wrap_fp16_model(runner.model)
             # resume from state dict
-            if 'fp16.loss_scaler' in runner.meta:
-                scaler_state_dict = runner.meta['fp16.loss_scaler']
+            if 'fp16' in runner.meta and 'loss_scaler' in runner.meta['fp16']:
+                scaler_state_dict = runner.meta['fp16']['loss_scaler']
                 self.loss_scaler.load_state_dict(scaler_state_dict)
 
         def copy_grads_to_fp32(self, fp16_net, fp32_weights):
@@ -291,4 +292,5 @@ else:
                                       f'to {self.loss_scaler.cur_scale}')
 
             # save state_dict of loss_scaler
-            runner.meta['fp16.loss_scaler'] = self.loss_scaler.state_dict()
+            runner.meta.setdefault(
+                'fp16', {})['loss_scaler'] = self.loss_scaler.state_dict()

--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -103,8 +103,6 @@ if TORCH_VERSION != 'parrots' and TORCH_VERSION >= '1.6.0':
             if 'fp16.loss_scaler' in runner.meta:
                 scaler_state_dict = runner.meta['fp16.loss_scaler']
                 self.loss_scaler.load_state_dict(scaler_state_dict)
-                # TODO: delete it.
-                self.loaded_indicator = True
 
         def copy_grads_to_fp32(self, fp16_net, fp32_weights):
             """Copy gradients from fp16 model to fp32 weight copy."""

--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -70,7 +70,7 @@ if TORCH_VERSION != 'parrots' and TORCH_VERSION >= '1.6.0':
             ...     backoff_factor=0.5,
             ...     growth_interval=2000
             ... )
-            >>> optimizer = Fp16OptimizerHook(loss_scale=loss_scale)
+            >>> optimizer_hook = Fp16OptimizerHook(loss_scale=loss_scale)
         """
 
         def __init__(self,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Sometimes the resumed fp16 training produces wired behaviors because the current fp16 training process does not save `Fp16OptimizerHook.loss_scaler` state to the checkpoint file. 
Hence in this PR, we enable resuming fp16 training by saving and loading fp16 related hook states.

## Modification
Basically, to enable resume in fp16 training, we add the following steps:
1. Save loss_scaler state_dict: at each iteration, the OptimizerHook will save its loss_scaler's state_dict to runner.meta;
2. At save time, CheckpointHook will write the recorded meta into checkpoint file.
3. When resuming, runner will recover the meta dict from the checkpoint file first.
4.  OptimizerHook.before_run will check if the runner has recorded loss_scaler state_dict in runner.meta, if so, the state_dict will be automatically loaded to re-initialize loss_scaler.
[Note that by doing so, there is no need to revise any downstream projects (e.g. You may directly use MMdetection for resuming an fp16 task without any extra code revision).

## BC-breaking (Optional)
Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
No.

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
