### PR TITLE
fix basemodule

### DIFF
--- a/mmcv/runner/base_module.py
+++ b/mmcv/runner/base_module.py
@@ -44,6 +44,9 @@ class BaseModule(nn.Module, metaclass=ABCMeta):
             if self.init_cfg:
                 initialize(self, self.init_cfg)
                 if isinstance(self.init_cfg, (dict, ConfigDict)):
+                    # Avoid the parameters of the pre-training model
+                    # being overwritten by the init_weights
+                    # of the children.
                     if self.init_cfg['type'] == 'Pretrained':
                         return
 

--- a/mmcv/runner/base_module.py
+++ b/mmcv/runner/base_module.py
@@ -4,6 +4,8 @@ from abc import ABCMeta
 
 import torch.nn as nn
 
+from mmcv import ConfigDict
+
 
 class BaseModule(nn.Module, metaclass=ABCMeta):
     """Base module for all modules in openmmlab."""
@@ -41,6 +43,10 @@ class BaseModule(nn.Module, metaclass=ABCMeta):
         if not self._is_init:
             if self.init_cfg:
                 initialize(self, self.init_cfg)
+                if isinstance(self.init_cfg, (dict, ConfigDict)):
+                    if self.init_cfg['type'] == 'Pretrained':
+                        return
+
             for m in self.children():
                 if hasattr(m, 'init_weights'):
                     m.init_weights()


### PR DESCRIPTION

## Motivation
In the original implementation, when init a module with the pre-train model,
https://github.com/open-mmlab/mmcv/blob/c77e95a65f0128c8faee15f0bc301744320d3609/mmcv/runner/base_module.py#L44
if there are children who have init_weights, the pretrain model would be overridden which is not reasonable.

## Modification
Retune when find it is loading a pre-train model.

## BC-breaking (Optional)
None


