### PR TITLE
fix softnms

### DIFF
--- a/mmcv/ops/nms.py
+++ b/mmcv/ops/nms.py
@@ -282,7 +282,7 @@ def batched_nms(boxes, scores, idxs, nms_cfg, class_agnostic=False):
         # This assumes `dets` has 5 dimensions where
         # the last dimension is score.
         # TODO: more elegant way to handle the dimension issue.
-        # Some nms would reweight the score, such as SoftNMS
+        # Some type of nms would reweight the score, such as SoftNMS
         scores = dets[:, 4]
     else:
         total_mask = scores.new_zeros(scores.size(), dtype=torch.bool)

--- a/tests/test_ops/test_nms.py
+++ b/tests/test_ops/test_nms.py
@@ -157,3 +157,22 @@ class Testnms(object):
         assert torch.equal(keep, seq_keep)
         assert torch.equal(boxes, seq_boxes)
         assert torch.equal(keep, torch.from_numpy(results['keep']))
+
+        nms_cfg = dict(type='soft_nms', iou_threshold=0.7)
+        boxes, keep = batched_nms(
+            torch.from_numpy(results['boxes']),
+            torch.from_numpy(results['scores']),
+            torch.from_numpy(results['idxs']),
+            nms_cfg,
+            class_agnostic=False)
+
+        nms_cfg.update(split_thr=100)
+        seq_boxes, seq_keep = batched_nms(
+            torch.from_numpy(results['boxes']),
+            torch.from_numpy(results['scores']),
+            torch.from_numpy(results['idxs']),
+            nms_cfg,
+            class_agnostic=False)
+
+        assert torch.equal(keep, seq_keep)
+        assert torch.equal(boxes, seq_boxes)


### PR DESCRIPTION

## Motivation
In the original implementation,
https://github.com/open-mmlab/mmcv/blob/c77e95a65f0128c8faee15f0bc301744320d3609/mmcv/ops/nms.py#L296
 Some type of nms such as softnms would reweight the score in `nms_op`, so we should use the score in `dets`  



## BC-breaking (Optional)
None
