### PR TITLE
pass more init params for logger_hooks

### DIFF
--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -437,10 +437,10 @@ class BaseRunner(metaclass=ABCMeta):
     def register_logger_hooks(self, log_config):
         if log_config is None:
             return
-        log_interval = log_config['interval']
-        for info in log_config['hooks']:
+        hooks = log_config.pop('hooks')
+        for info in hooks:
             logger_hook = mmcv.build_from_cfg(
-                info, HOOKS, default_args=dict(interval=log_interval))
+                info, HOOKS, default_args=log_config)
             self.register_hook(logger_hook, priority=90)
 
     def register_timer_hook(self, timer_config):


### PR DESCRIPTION
`mmcv.runner.register_logger_hooks`
when I wanna add a `ignore_last=False` for my logger, I find my logger still `ignore_last`.
then I locate here, the `log_config` should not only make `interval` work, right ?

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
 I wanna add a 'ignore_last=False' for my logger

## Modification
`mmcv.runner.register_logger_hooks`
line 437
see code for details, its easy


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
