### PR TITLE
add a return value in TextLoggerHook.log()

### DIFF
--- a/mmcv/runner/hooks/logger/text.py
+++ b/mmcv/runner/hooks/logger/text.py
@@ -176,3 +176,4 @@ class TextLoggerHook(LoggerHook):
 
         self._log_info(log_dict, runner)
         self._dump_log(log_dict, runner)
+        return log_dict


### PR DESCRIPTION
I need this in a subclass, but I dont want copy the whole `log()` function
