### PR TITLE
Imporve windows support for list_from_file

### DIFF
--- a/mmcv/fileio/parse.py
+++ b/mmcv/fileio/parse.py
@@ -1,5 +1,5 @@
 # Copyright (c) Open-MMLab. All rights reserved.
-def list_from_file(filename, prefix='', offset=0, max_num=0):
+def list_from_file(filename, prefix='', offset=0, max_num=0, encoding='utf-8'):
     """Load a text file and parse the content as a list of strings.
 
     Args:
@@ -8,19 +8,20 @@ def list_from_file(filename, prefix='', offset=0, max_num=0):
         offset (int): The offset of lines.
         max_num (int): The maximum number of lines to be read,
             zeros and negatives mean no limitation.
+        encoding (str): Encoding used to open the file. Default utf-8.
 
     Returns:
         list[str]: A list of strings.
     """
     cnt = 0
     item_list = []
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding=encoding) as f:
         for _ in range(offset):
             f.readline()
         for line in f:
-            if max_num > 0 and cnt >= max_num:
+            if 0 < max_num <= cnt:
                 break
-            item_list.append(prefix + line.rstrip('\n'))
+            item_list.append(prefix + line.rstrip('\n\r'))
             cnt += 1
     return item_list
 


### PR DESCRIPTION
* The default encoding in some windows machine is `'cp936'`, etc. We surely want utf-8.
* Remove \r in windows.