### PR TITLE
[Features] Support name of the base classe matching in init_cfg

### DIFF
--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -93,6 +93,10 @@ def bias_init_with_prob(prior_prob):
     return bias_init
 
 
+def _get_bases_name(m):
+    return [b.__name__ for b in m.__class__.__bases__]
+
+
 class BaseInit(object):
 
     def __init__(self, *, bias=0, bias_prob=None, layer=None):
@@ -146,7 +150,8 @@ class ConstantInit(BaseInit):
                 constant_init(m, self.val, self.bias)
             else:
                 layername = m.__class__.__name__
-                if layername in self.layer:
+                basesname = _get_bases_name(m)
+                if bool(set(self.layer) & set([layername] + basesname)):
                     constant_init(m, self.val, self.bias)
 
         module.apply(init)
@@ -183,7 +188,8 @@ class XavierInit(BaseInit):
                 xavier_init(m, self.gain, self.bias, self.distribution)
             else:
                 layername = m.__class__.__name__
-                if layername in self.layer:
+                basesname = _get_bases_name(m)
+                if bool(set(self.layer) & set([layername] + basesname)):
                     xavier_init(m, self.gain, self.bias, self.distribution)
 
         module.apply(init)
@@ -219,9 +225,9 @@ class NormalInit(BaseInit):
                 normal_init(m, self.mean, self.std, self.bias)
             else:
                 layername = m.__class__.__name__
-                for layer_ in self.layer:
-                    if layername == layer_:
-                        normal_init(m, self.mean, self.std, self.bias)
+                basesname = _get_bases_name(m)
+                if bool(set(self.layer) & set([layername] + basesname)):
+                    normal_init(m, self.mean, self.std, self.bias)
 
         module.apply(init)
 
@@ -267,10 +273,10 @@ class TruncNormalInit(BaseInit):
                                   self.bias)
             else:
                 layername = m.__class__.__name__
-                for layer_ in self.layer:
-                    if layername == layer_:
-                        trunc_normal_init(m, self.mean, self.std, self.a,
-                                          self.b, self.bias)
+                basesname = _get_bases_name(m)
+                if bool(set(self.layer) & set([layername] + basesname)):
+                    trunc_normal_init(m, self.mean, self.std, self.a, self.b,
+                                      self.bias)
 
         module.apply(init)
 
@@ -305,7 +311,8 @@ class UniformInit(BaseInit):
                 uniform_init(m, self.a, self.b, self.bias)
             else:
                 layername = m.__class__.__name__
-                if layername in self.layer:
+                basesname = _get_bases_name(m)
+                if bool(set(self.layer) & set([layername] + basesname)):
                     uniform_init(m, self.a, self.b, self.bias)
 
         module.apply(init)
@@ -359,7 +366,8 @@ class KaimingInit(BaseInit):
                              self.bias, self.distribution)
             else:
                 layername = m.__class__.__name__
-                if layername in self.layer:
+                basesname = _get_bases_name(m)
+                if bool(set(self.layer) & set([layername] + basesname)):
                     kaiming_init(m, self.a, self.mode, self.nonlinearity,
                                  self.bias, self.distribution)
 

--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -151,7 +151,7 @@ class ConstantInit(BaseInit):
             else:
                 layername = m.__class__.__name__
                 basesname = _get_bases_name(m)
-                if bool(set(self.layer) & set([layername] + basesname)):
+                if len(set(self.layer) & set([layername] + basesname)):
                     constant_init(m, self.val, self.bias)
 
         module.apply(init)
@@ -189,7 +189,7 @@ class XavierInit(BaseInit):
             else:
                 layername = m.__class__.__name__
                 basesname = _get_bases_name(m)
-                if bool(set(self.layer) & set([layername] + basesname)):
+                if len(set(self.layer) & set([layername] + basesname)):
                     xavier_init(m, self.gain, self.bias, self.distribution)
 
         module.apply(init)
@@ -226,7 +226,7 @@ class NormalInit(BaseInit):
             else:
                 layername = m.__class__.__name__
                 basesname = _get_bases_name(m)
-                if bool(set(self.layer) & set([layername] + basesname)):
+                if len(set(self.layer) & set([layername] + basesname)):
                     normal_init(m, self.mean, self.std, self.bias)
 
         module.apply(init)
@@ -274,7 +274,7 @@ class TruncNormalInit(BaseInit):
             else:
                 layername = m.__class__.__name__
                 basesname = _get_bases_name(m)
-                if bool(set(self.layer) & set([layername] + basesname)):
+                if len(set(self.layer) & set([layername] + basesname)):
                     trunc_normal_init(m, self.mean, self.std, self.a, self.b,
                                       self.bias)
 
@@ -312,7 +312,7 @@ class UniformInit(BaseInit):
             else:
                 layername = m.__class__.__name__
                 basesname = _get_bases_name(m)
-                if bool(set(self.layer) & set([layername] + basesname)):
+                if len(set(self.layer) & set([layername] + basesname)):
                     uniform_init(m, self.a, self.b, self.bias)
 
         module.apply(init)
@@ -367,7 +367,7 @@ class KaimingInit(BaseInit):
             else:
                 layername = m.__class__.__name__
                 basesname = _get_bases_name(m)
-                if bool(set(self.layer) & set([layername] + basesname)):
+                if len(set(self.layer) & set([layername] + basesname)):
                     kaiming_init(m, self.a, self.mode, self.nonlinearity,
                                  self.bias, self.distribution)
 

--- a/tests/test_cnn/test_weight_init.py
+++ b/tests/test_cnn/test_weight_init.py
@@ -134,6 +134,15 @@ def test_constaninit():
     assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 2.))
     assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, res))
 
+    # test layer key with base class name
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Conv1d(1, 2, 1))
+    func = ConstantInit(val=4., bias=5., layer='_ConvNd')
+    func(model)
+    assert torch.all(model[0].weight == 4.)
+    assert torch.all(model[2].weight == 4.)
+    assert torch.all(model[0].bias == 5.)
+    assert torch.all(model[2].bias == 5.)
+
     # test bias input type
     with pytest.raises(TypeError):
         func = ConstantInit(val=1, bias='1')
@@ -170,6 +179,22 @@ def test_xavierinit():
     assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, res))
     assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, res))
 
+    # test layer key with base class name
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Conv1d(1, 2, 1))
+    func = ConstantInit(val=4., bias=5., layer='_ConvNd')
+    func(model)
+    assert torch.all(model[0].weight == 4.)
+    assert torch.all(model[2].weight == 4.)
+    assert torch.all(model[0].bias == 5.)
+    assert torch.all(model[2].bias == 5.)
+
+    func = XavierInit(gain=100, bias_prob=0.01, layer='_ConvNd')
+    func(model)
+    assert not torch.all(model[0].weight == 4.)
+    assert not torch.all(model[2].weight == 4.)
+    assert torch.all(model[0].bias == res)
+    assert torch.all(model[2].bias == res)
+
     # test bias input type
     with pytest.raises(TypeError):
         func = XavierInit(bias='0.1', layer='Conv2d')
@@ -198,6 +223,16 @@ def test_normalinit():
     assert model[0].bias.allclose(torch.tensor(res))
     assert model[2].bias.allclose(torch.tensor(res))
 
+    # test layer key with base class name
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Conv1d(1, 2, 1))
+
+    func = NormalInit(mean=300, std=1e-5, bias_prob=0.01, layer='_ConvNd')
+    func(model)
+    assert model[0].weight.allclose(torch.tensor(300.))
+    assert model[2].weight.allclose(torch.tensor(300.))
+    assert torch.all(model[0].bias == res)
+    assert torch.all(model[2].bias == res)
+
 
 def test_truncnormalinit():
     """test TruncNormalInit class."""
@@ -225,6 +260,17 @@ def test_truncnormalinit():
     assert model[0].bias.allclose(torch.tensor(res))
     assert model[2].bias.allclose(torch.tensor(res))
 
+    # test layer key with base class name
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Conv1d(1, 2, 1))
+
+    func = TruncNormalInit(
+        mean=300, std=1e-5, a=100, b=400, bias_prob=0.01, layer='_ConvNd')
+    func(model)
+    assert model[0].weight.allclose(torch.tensor(300.))
+    assert model[2].weight.allclose(torch.tensor(300.))
+    assert torch.all(model[0].bias == res)
+    assert torch.all(model[2].bias == res)
+
 
 def test_uniforminit():
     """"test UniformInit class."""
@@ -245,6 +291,17 @@ def test_uniforminit():
     assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 10.))
     assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, 10.))
 
+    # test layer key with base class name
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Conv1d(1, 2, 1))
+
+    func = UniformInit(a=100, b=100, bias_prob=0.01, layer='_ConvNd')
+    res = bias_init_with_prob(0.01)
+    func(model)
+    assert torch.all(model[0].weight == 100.)
+    assert torch.all(model[2].weight == 100.)
+    assert torch.all(model[0].bias == res)
+    assert torch.all(model[2].bias == res)
+
 
 def test_kaiminginit():
     """test KaimingInit class."""
@@ -256,6 +313,29 @@ def test_kaiminginit():
 
     func = KaimingInit(a=100, bias=10, layer=['Conv2d', 'Linear'])
     constant_func = ConstantInit(val=0, bias=0, layer=['Conv2d', 'Linear'])
+    model.apply(constant_func)
+    assert torch.equal(model[0].weight, torch.full(model[0].weight.shape, 0.))
+    assert torch.equal(model[2].weight, torch.full(model[2].weight.shape, 0.))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 0.))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, 0.))
+
+    func(model)
+    assert not torch.equal(model[0].weight,
+                           torch.full(model[0].weight.shape, 0.))
+    assert not torch.equal(model[2].weight,
+                           torch.full(model[2].weight.shape, 0.))
+    assert torch.equal(model[0].bias, torch.full(model[0].bias.shape, 10.))
+    assert torch.equal(model[2].bias, torch.full(model[2].bias.shape, 10.))
+
+    # test layer key with base class name
+    model = nn.Sequential(nn.Conv2d(3, 1, 3), nn.ReLU(), nn.Conv1d(1, 2, 1))
+    func = KaimingInit(bias=0.1, layer='_ConvNd')
+    func(model)
+    assert torch.all(model[0].bias == 0.1)
+    assert torch.all(model[2].bias == 0.1)
+
+    func = KaimingInit(a=100, bias=10, layer='_ConvNd')
+    constant_func = ConstantInit(val=0, bias=0, layer='_ConvNd')
     model.apply(constant_func)
     assert torch.equal(model[0].weight, torch.full(model[0].weight.shape, 0.))
     assert torch.equal(model[2].weight, torch.full(model[2].weight.shape, 0.))


### PR DESCRIPTION
## Motivation

Previous ``INITIALIZERS`` only initialize the class in  ``layer`` of  ``init_cfg``. However, there is a requirement to initialize derived classes from a base class like ``_ConvNd``, ``_BatchNorm``. This pr is for matching the name of the base class, and we can specify the ``layer`` of ``init_cfg`` as the base names and initialize its derived classes.  

## Modification

1. Add ``_get_bases_name`` in mmcv/cnn/utils/weight_init.py.
2. Revise initializers to determine whether base name or class name is in ``layer`` of ``init_cfg``.
3. Add related unit tests.

