### PR TITLE
[Enhancement] Add decay to cyclic LR

### DIFF
--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -791,16 +791,20 @@ def test_cyclic_lr_update_hook(multi_optimizers, max_iters):
         CyclicLrUpdaterHook(by_epoch=True)
 
     with pytest.raises(AssertionError):
-        # target_ratio" must be either float or tuple/list of two floats
+        # target_ratio must be either float or tuple/list of two floats
         CyclicLrUpdaterHook(by_epoch=False, target_ratio=(10.0, 0.1, 0.2))
 
     with pytest.raises(AssertionError):
-        # step_ratio_up" must be in range [0,1)
+        # step_ratio_up must be in range [0,1)
         CyclicLrUpdaterHook(by_epoch=False, step_ratio_up=1.4)
 
     with pytest.raises(ValueError):
         # anneal_strategy must be one of "cos" or "linear"
         CyclicLrUpdaterHook(by_epoch=False, anneal_strategy='sin')
+
+    with pytest.raises(ValueError):
+        # gamma must be in range (0, 1]
+        CyclicLrUpdaterHook(by_epoch=False, gamma=0)
 
     sys.modules['pavi'] = MagicMock()
     loader = DataLoader(torch.ones((10, 2)))
@@ -816,7 +820,8 @@ def test_cyclic_lr_update_hook(multi_optimizers, max_iters):
         target_ratio=(10.0, 1.0),
         cyclic_times=1,
         step_ratio_up=0.5,
-        anneal_strategy='linear')
+        anneal_strategy='linear',
+        gamma=0.8)
     runner.register_hook(hook)
     runner.register_hook_from_cfg(dict(type='IterTimerHook'))
     runner.register_hook(IterTimerHook())

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -821,7 +821,7 @@ def test_cyclic_lr_update_hook(multi_optimizers, max_iters):
         cyclic_times=1,
         step_ratio_up=0.5,
         anneal_strategy='linear',
-        gamma=0.8)
+        gamma=1)
     runner.register_hook(hook)
     runner.register_hook_from_cfg(dict(type='IterTimerHook'))
     runner.register_hook(IterTimerHook())

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -802,7 +802,7 @@ def test_cyclic_lr_update_hook(multi_optimizers, max_iters):
         # anneal_strategy must be one of "cos" or "linear"
         CyclicLrUpdaterHook(by_epoch=False, anneal_strategy='sin')
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         # gamma must be in range (0, 1]
         CyclicLrUpdaterHook(by_epoch=False, gamma=0)
 


### PR DESCRIPTION
Implements CLR policy mentioned #783 

Parameter `gamma` allows to add decay to cycles of CLR. If `gamma` is set to a value between 0 and 1, each next cycle will peak at the lower value.