### PR TITLE
Save last several checkpoints by checkpoint hook

### DIFF
--- a/mmcv/runner/hooks/checkpoint.py
+++ b/mmcv/runner/hooks/checkpoint.py
@@ -26,8 +26,8 @@ class CheckpointHook(Hook):
             Default: -1, which means unlimited.
         save_last (bool): Whether to force the last several checkpoints to
             be saved regardless of interval. Default: True.
-        num_last_ckpts (int): How many last checkpoints to be saved if
-            ``save_last=True``. Default: 1.
+        num_last_ckpts (int): The number of the last several checkpoints to be
+            saved if ``save_last=True``. Default: 1.
         sync_buffer (bool): Whether to synchronize buffers in different
             gpus. Default: False.
     """

--- a/mmcv/runner/hooks/hook.py
+++ b/mmcv/runner/hooks/hook.py
@@ -65,3 +65,9 @@ class Hook:
 
     def is_last_iter(self, runner):
         return runner.iter + 1 == runner._max_iters
+
+    def near_last_epoch(self, runner, num_epochs):
+        return runner.epoch + num_epochs >= runner._max_epochs
+
+    def near_last_iter(self, runner, num_iters):
+        return runner.iter + num_iters >= runner._max_iters

--- a/mmcv/runner/hooks/hook.py
+++ b/mmcv/runner/hooks/hook.py
@@ -65,9 +65,3 @@ class Hook:
 
     def is_last_iter(self, runner):
         return runner.iter + 1 == runner._max_iters
-
-    def near_last_epoch(self, runner, num_epochs):
-        return runner.epoch + num_epochs >= runner._max_epochs
-
-    def near_last_iter(self, runner, num_iters):
-        return runner.iter + num_iters >= runner._max_iters

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -33,7 +33,7 @@ def test_checkpoint_hook():
 
     # test epoch based runner
     loader = DataLoader(torch.ones((5, 2)))
-    runner = _build_demo_runner('EpochBasedRunner', max_epochs=1)
+    runner = _build_demo_runner_without_hook('EpochBasedRunner', max_epochs=1)
     runner.meta = dict()
     checkpointhook = CheckpointHook(interval=1, by_epoch=True)
     runner.register_hook(checkpointhook)
@@ -43,7 +43,7 @@ def test_checkpoint_hook():
     shutil.rmtree(runner.work_dir)
 
     # test iter based runner
-    runner = _build_demo_runner(
+    runner = _build_demo_runner_without_hook(
         'IterBasedRunner', max_iters=1, max_epochs=None)
     runner.meta = dict()
     checkpointhook = CheckpointHook(interval=1, by_epoch=False)

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -57,7 +57,8 @@ def test_checkpoint_hook():
     # test save_last
     runner = _build_demo_runner_without_hook('EpochBasedRunner', max_epochs=3)
     runner.meta = dict()
-    checkpointhook = CheckpointHook(interval=3, by_epoch=True, save_last=2)
+    checkpointhook = CheckpointHook(
+        interval=3, by_epoch=True, save_last=True, num_last_ckpts=2)
     runner.register_hook(checkpointhook)
     runner.run([loader], [('train', 1)])
     saved_ckpts = [f for f in os.listdir(runner.work_dir) if f[:5] == 'epoch']

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -5,6 +5,7 @@ CommandLine:
     xdoctest tests/test_hooks.py zero
 """
 import logging
+import os
 import os.path as osp
 import re
 import shutil
@@ -51,6 +52,16 @@ def test_checkpoint_hook():
     runner.run([loader], [('train', 1)])
     assert runner.meta['hook_msgs']['last_ckpt'] == osp.join(
         runner.work_dir, 'iter_1.pth')
+    shutil.rmtree(runner.work_dir)
+
+    # test save_last
+    runner = _build_demo_runner_without_hook('EpochBasedRunner', max_epochs=3)
+    runner.meta = dict()
+    checkpointhook = CheckpointHook(interval=3, by_epoch=True, save_last=2)
+    runner.register_hook(checkpointhook)
+    runner.run([loader], [('train', 1)])
+    saved_ckpts = [f for f in os.listdir(runner.work_dir) if f[:5] == 'epoch']
+    assert set(saved_ckpts) == {'epoch_2.pth', 'epoch_3.pth'}
     shutil.rmtree(runner.work_dir)
 
 


### PR DESCRIPTION
## Motivation
Because of the storage limit, sometimes we cannot save every checkpoint. But we need to choose the best checkpoint in the final period or merge several last checkpoints. See #1064 

## Modification
1. Fix checkpoint hook unit test bug, should use `_build_demo_runner_without_hook`.
    Before, it uses `_build_demo_runner`, and the function will register another checkpoint hook to the runner.

2. Checkpoint hook accepts int `save_last` parameter to decide to save how many checkpoints approaching the end.
    `save_last` parameter also accepts bool as before and will be converted to int, therefore there is no BC-breaking.

## Checklist
- [ x ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ x ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure correctness.
- [ x ] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [ x ] The documentation has been modified accordingly, like docstring or example tutorials.
