### PR TITLE
[Fix] Fix the permission denied error on windows.

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -279,6 +279,8 @@ class Config:
         with tempfile.NamedTemporaryFile(
                 'w', suffix=file_format, delete=False) as temp_file:
             temp_file.write(cfg_str)
+            # on windows, previous implementation cause error
+            # see PR 1077 for detailed considerarion
         cfg = Config.fromfile(temp_file.name)
         os.remove(temp_file.name)
         return cfg

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -1,5 +1,6 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 import ast
+import os
 import os.path as osp
 import platform
 import shutil
@@ -9,7 +10,6 @@ import warnings
 from argparse import Action, ArgumentParser
 from collections import abc
 from importlib import import_module
-from os import unlink
 
 from addict import Dict
 from yapf.yapflib.yapf_api import FormatCode
@@ -280,7 +280,7 @@ class Config:
                 'w', suffix=file_format, delete=False) as temp_file:
             temp_file.write(cfg_str)
         cfg = Config.fromfile(temp_file.name)
-        unlink(temp_file.name)
+        os.unlink(temp_file.name)
         return cfg
 
     @staticmethod

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -280,7 +280,7 @@ class Config:
                 'w', suffix=file_format, delete=False) as temp_file:
             temp_file.write(cfg_str)
         cfg = Config.fromfile(temp_file.name)
-        os.unlink(temp_file.name)
+        os.remove(temp_file.name)
         return cfg
 
     @staticmethod

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -9,6 +9,7 @@ import warnings
 from argparse import Action, ArgumentParser
 from collections import abc
 from importlib import import_module
+from os import unlink
 
 from addict import Dict
 from yapf.yapflib.yapf_api import FormatCode
@@ -275,21 +276,11 @@ class Config:
             # check if users specify a wrong suffix for python
             warnings.warn(
                 'Please check "file_format", the file format may be .py')
-        if platform.system() == 'Windows':
-            # fix permission denied error.
-            from os import unlink
-            with tempfile.NamedTemporaryFile(
-                    'w', suffix=file_format, delete=False) as temp_file:
-                temp_file.write(cfg_str)
-                temp_file.close()
-                cfg = Config.fromfile(temp_file.name)
-                unlink(temp_file.name)
-        else:
-            with tempfile.NamedTemporaryFile(
-                    'w', suffix=file_format) as temp_file:
-                temp_file.write(cfg_str)
-                temp_file.flush()
-                cfg = Config.fromfile(temp_file.name)
+        with tempfile.NamedTemporaryFile(
+                'w', suffix=file_format, delete=False) as temp_file:
+            temp_file.write(cfg_str)
+        cfg = Config.fromfile(temp_file.name)
+        unlink(temp_file.name)
         return cfg
 
     @staticmethod

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -280,7 +280,7 @@ class Config:
                 'w', suffix=file_format, delete=False) as temp_file:
             temp_file.write(cfg_str)
             # on windows, previous implementation cause error
-            # see PR 1077 for detailed considerarion
+            # see PR 1077 for details
         cfg = Config.fromfile(temp_file.name)
         os.remove(temp_file.name)
         return cfg

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -278,13 +278,15 @@ class Config:
         if platform.system() == 'Windows':
             # fix permission denied error.
             from os import unlink
-            with tempfile.NamedTemporaryFile('w', suffix=file_format, delete=False) as temp_file:
+            with tempfile.NamedTemporaryFile(
+                    'w', suffix=file_format, delete=False) as temp_file:
                 temp_file.write(cfg_str)
                 temp_file.close()
                 cfg = Config.fromfile(temp_file.name)
                 unlink(temp_file.name)
         else:
-            with tempfile.NamedTemporaryFile('w', suffix=file_format) as temp_file:
+            with tempfile.NamedTemporaryFile(
+                    'w', suffix=file_format) as temp_file:
                 temp_file.write(cfg_str)
                 temp_file.flush()
                 cfg = Config.fromfile(temp_file.name)

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -275,11 +275,19 @@ class Config:
             # check if users specify a wrong suffix for python
             warnings.warn(
                 'Please check "file_format", the file format may be .py')
-
-        with tempfile.NamedTemporaryFile('w', suffix=file_format) as temp_file:
-            temp_file.write(cfg_str)
-            temp_file.flush()
-            cfg = Config.fromfile(temp_file.name)
+        if platform.system() == 'Windows':
+            # fix permission denied error.
+            from os import unlink
+            with tempfile.NamedTemporaryFile('w', suffix=file_format, delete=False) as temp_file:
+                temp_file.write(cfg_str)
+                temp_file.close()
+                cfg = Config.fromfile(temp_file.name)
+                unlink(temp_file.name)
+        else:
+            with tempfile.NamedTemporaryFile('w', suffix=file_format) as temp_file:
+                temp_file.write(cfg_str)
+                temp_file.flush()
+                cfg = Config.fromfile(temp_file.name)
         return cfg
 
     @staticmethod


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
To fix the permission denied error when using '--resuming-from' on Windows.  [[#1063](https://github.com/open-mmlab/mmcv/issues/1063)] [[#4966(mmdet)](https://github.com/open-mmlab/mmdetection/issues/4966)]
I'm not sure whether that modification will cause any problems on other platforms or not, so I add an 'if' to ensure Windows only.

## Modification
Modify the behavior of loading config on Windows:
* Temporary file now will be closed without being deleted before reading on Windows.
* When read ends, it will be deleted by `os.unlink`.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
