### PR TITLE
[Fix]: fix 'Cannot load config on windows with mmcv.Config.fromstring. ' in file: utils/config.py

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -1,5 +1,6 @@
 # Copyright (c) Open-MMLab. All rights reserved.
 import ast
+import os
 import os.path as osp
 import platform
 import shutil
@@ -276,10 +277,13 @@ class Config:
             warnings.warn(
                 'Please check "file_format", the file format may be .py')
 
-        with tempfile.NamedTemporaryFile('w', suffix=file_format) as temp_file:
+        fd, fname = tempfile.mkstemp(file_format)
+        with open(fname, 'w') as temp_file:
             temp_file.write(cfg_str)
             temp_file.flush()
             cfg = Config.fromfile(temp_file.name)
+        os.close(fd)
+        os.remove(fname)
         return cfg
 
     @staticmethod


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
make the function work on Windows platform. Related issue #1051 

## Modification
fix the bug that mmcv.Config.fromstring function cannot work on Window platform

## Checklist
1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
