### PR TITLE
Avoid bc-breaking of importing `MultiScaleDeformableAttention`

### DIFF
--- a/mmcv/cnn/bricks/transformer.py
+++ b/mmcv/cnn/bricks/transformer.py
@@ -13,13 +13,13 @@ from .registry import (ATTENTION, FEEDFORWARD_NETWORK, POSITIONAL_ENCODING,
                        TRANSFORMER_LAYER, TRANSFORMER_LAYER_SEQUENCE)
 
 
-# Avoid bc-breaking of import MultiScaleDeformableAttention
+# Avoid bc-breaking of importing MultiScaleDeformableAttention
 class MultiScaleDeformableAttention:
 
     def __init__(self, *args, **kwargs):
         raise ImportError(
             'MultiScaleDeformableAttention has been moved to'
-            '``mmcv.ops.multi_scale_deform_attn``, Please use '
+            '``mmcv.ops.multi_scale_deform_attn``. Please use '
             ' ``from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention`` '  # noqa  E501
         )
 

--- a/mmcv/cnn/bricks/transformer.py
+++ b/mmcv/cnn/bricks/transformer.py
@@ -12,16 +12,13 @@ from .drop import build_dropout
 from .registry import (ATTENTION, FEEDFORWARD_NETWORK, POSITIONAL_ENCODING,
                        TRANSFORMER_LAYER, TRANSFORMER_LAYER_SEQUENCE)
 
-
-# Avoid bc-breaking of importing MultiScaleDeformableAttention
-class MultiScaleDeformableAttention:
-
-    def __init__(self, *args, **kwargs):
-        raise ImportError(
-            'MultiScaleDeformableAttention has been moved to'
-            '``mmcv.ops.multi_scale_deform_attn``. Please use '
-            ' ``from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention`` '  # noqa  E501
-        )
+# Avoid BC-breaking of importing MultiScaleDeformableAttention
+try:
+    from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention  # noqa F401
+except ImportError:
+    warnings.warn('Fail to import ``MultiScaleDeformableAttention`` from '
+                  '``mmcv.ops.multi_scale_deform_attn``, '
+                  'You should install ``mmcv-full`` if you need this module. ')
 
 
 def build_positional_encoding(cfg, default_args=None):

--- a/mmcv/cnn/bricks/transformer.py
+++ b/mmcv/cnn/bricks/transformer.py
@@ -15,6 +15,12 @@ from .registry import (ATTENTION, FEEDFORWARD_NETWORK, POSITIONAL_ENCODING,
 # Avoid BC-breaking of importing MultiScaleDeformableAttention from this file
 try:
     from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention  # noqa F401
+    warnings.warn(
+        '``MultiScaleDeformableAttention`` has been moved to '
+        '``mmcv.ops.multi_scale_deform_attn``, please change original path '  # noqa E501
+        '``from mmcv.cnn.bricks.transformer import MultiScaleDeformableAttention`` '  # noqa E501
+        'to ``from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention`` '  # noqa E501
+    )
 
 except ImportError:
     warnings.warn('Fail to import ``MultiScaleDeformableAttention`` from '
@@ -65,9 +71,9 @@ class MultiheadAttention(BaseModule):
             when adding the shortcut.
         init_cfg (obj:`mmcv.ConfigDict`): The Config for initialization.
             Default: None.
-        batch_first (bool): Key, Query and Value are shape of
-            (batch, n, embed_dim)
-            or (n, batch, embed_dim). Default to False.
+        batch_first (bool): When it is True,  Key, Query and Value are shape of
+            (batch, n, embed_dim), otherwise (n, batch, embed_dim).
+             Default to False.
     """
 
     def __init__(self,
@@ -97,10 +103,12 @@ class MultiheadAttention(BaseModule):
         if self.batch_first:
 
             def _bnc_to_nbc(forward):
-                """This function can adjust the shape of dataflow('key',
-                'query', 'value') from batch_first (batch, num_query,
-                embed_dims) to num_query_first (num_query ,batch,
-                embed_dims)."""
+                """Because the dataflow('key', 'query', 'value') of
+                ``torch.nn.MultiheadAttention`` is (num_query, batch,
+                embed_dims), We should adjust the shape of dataflow from
+                batch_first (batch, num_query, embed_dims) to num_query_first
+                (num_query ,batch, embed_dims), and recover ``attn_output``
+                from num_query_first to batch_first."""
 
                 def forward_wrapper(**kwargs):
                     convert_keys = ('key', 'query', 'value')

--- a/mmcv/cnn/bricks/transformer.py
+++ b/mmcv/cnn/bricks/transformer.py
@@ -14,17 +14,14 @@ from .registry import (ATTENTION, FEEDFORWARD_NETWORK, POSITIONAL_ENCODING,
 
 
 # Avoid bc-breaking of import MultiScaleDeformableAttention
-class DummyMultiScaleDeformableAttention:
+class MultiScaleDeformableAttention:
 
     def __init__(self, *args, **kwargs):
         raise ImportError(
             'MultiScaleDeformableAttention has been moved to'
-            '``mmcv.ops.multi_scale_deform_attn``, Please change to '
+            '``mmcv.ops.multi_scale_deform_attn``, Please use '
             ' ``from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention`` '  # noqa  E501
         )
-
-
-MultiScaleDeformableAttention = DummyMultiScaleDeformableAttention
 
 
 def build_positional_encoding(cfg, default_args=None):

--- a/mmcv/cnn/bricks/transformer.py
+++ b/mmcv/cnn/bricks/transformer.py
@@ -12,9 +12,24 @@ from .drop import build_dropout
 from .registry import (ATTENTION, FEEDFORWARD_NETWORK, POSITIONAL_ENCODING,
                        TRANSFORMER_LAYER, TRANSFORMER_LAYER_SEQUENCE)
 
-# Avoid BC-breaking of importing MultiScaleDeformableAttention
+# Avoid BC-breaking of importing MultiScaleDeformableAttention from this file
 try:
     from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention  # noqa F401
+
+    class DummyMultiScaleDeformableAttention(MultiScaleDeformableAttention):
+
+        def __init__(self, *args, **kwargs):
+            warnings.warn(
+                ImportWarning(
+                    '``MultiScaleDeformableAttention`` has been moved to '
+                    '``mmcv.ops.multi_scale_deform_attn`` '
+                    'from ``mmcv.cnn.bricks.transformer``, you should use '
+                    '``from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention`` now. '  # noqa E501
+                ))
+            super().__init__(*args, **kwargs)
+
+    MultiScaleDeformableAttention = DummyMultiScaleDeformableAttention
+
 except ImportError:
     warnings.warn('Fail to import ``MultiScaleDeformableAttention`` from '
                   '``mmcv.ops.multi_scale_deform_attn``, '

--- a/mmcv/cnn/bricks/transformer.py
+++ b/mmcv/cnn/bricks/transformer.py
@@ -16,20 +16,6 @@ from .registry import (ATTENTION, FEEDFORWARD_NETWORK, POSITIONAL_ENCODING,
 try:
     from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention  # noqa F401
 
-    class DummyMultiScaleDeformableAttention(MultiScaleDeformableAttention):
-
-        def __init__(self, *args, **kwargs):
-            warnings.warn(
-                ImportWarning(
-                    '``MultiScaleDeformableAttention`` has been moved to '
-                    '``mmcv.ops.multi_scale_deform_attn`` '
-                    'from ``mmcv.cnn.bricks.transformer``, you should use '
-                    '``from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention`` now. '  # noqa E501
-                ))
-            super().__init__(*args, **kwargs)
-
-    MultiScaleDeformableAttention = DummyMultiScaleDeformableAttention
-
 except ImportError:
     warnings.warn('Fail to import ``MultiScaleDeformableAttention`` from '
                   '``mmcv.ops.multi_scale_deform_attn``, '

--- a/mmcv/cnn/bricks/transformer.py
+++ b/mmcv/cnn/bricks/transformer.py
@@ -16,11 +16,12 @@ from .registry import (ATTENTION, FEEDFORWARD_NETWORK, POSITIONAL_ENCODING,
 try:
     from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention  # noqa F401
     warnings.warn(
-        '``MultiScaleDeformableAttention`` has been moved to '
-        '``mmcv.ops.multi_scale_deform_attn``, please change original path '  # noqa E501
-        '``from mmcv.cnn.bricks.transformer import MultiScaleDeformableAttention`` '  # noqa E501
-        'to ``from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention`` '  # noqa E501
-    )
+        ImportWarning(
+            '``MultiScaleDeformableAttention`` has been moved to '
+            '``mmcv.ops.multi_scale_deform_attn``, please change original path '  # noqa E501
+            '``from mmcv.cnn.bricks.transformer import MultiScaleDeformableAttention`` '  # noqa E501
+            'to ``from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention`` '  # noqa E501
+        ))
 
 except ImportError:
     warnings.warn('Fail to import ``MultiScaleDeformableAttention`` from '

--- a/mmcv/cnn/bricks/transformer.py
+++ b/mmcv/cnn/bricks/transformer.py
@@ -13,6 +13,20 @@ from .registry import (ATTENTION, FEEDFORWARD_NETWORK, POSITIONAL_ENCODING,
                        TRANSFORMER_LAYER, TRANSFORMER_LAYER_SEQUENCE)
 
 
+# Avoid bc-breaking of import MultiScaleDeformableAttention
+class DummyMultiScaleDeformableAttention:
+
+    def __init__(self, *args, **kwargs):
+        raise ImportError(
+            'MultiScaleDeformableAttention has been moved to'
+            '``mmcv.ops.multi_scale_deform_attn``, Please change to '
+            ' ``from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention`` '  # noqa  E501
+        )
+
+
+MultiScaleDeformableAttention = DummyMultiScaleDeformableAttention
+
+
 def build_positional_encoding(cfg, default_args=None):
     """Builder for Position Encoding."""
     return build_from_cfg(cfg, POSITIONAL_ENCODING, default_args)

--- a/tests/test_cnn/test_transformer.py
+++ b/tests/test_cnn/test_transformer.py
@@ -4,7 +4,14 @@ import torch
 from mmcv.cnn.bricks.drop import DropPath
 from mmcv.cnn.bricks.transformer import (FFN, BaseTransformerLayer,
                                          MultiheadAttention,
+                                         MultiScaleDeformableAttention,
                                          TransformerLayerSequence)
+
+
+def test_import_multiscaledeformableattention():
+    # Avoid bc-breaking of import MultiScaleDeformableAttention
+    with pytest.raises(ImportError):
+        MultiScaleDeformableAttention()
 
 
 def test_multiheadattention():

--- a/tests/test_cnn/test_transformer.py
+++ b/tests/test_cnn/test_transformer.py
@@ -9,7 +9,7 @@ from mmcv.cnn.bricks.transformer import (FFN, BaseTransformerLayer,
 
 
 def test_import_multiscaledeformableattention():
-    # Avoid bc-breaking of import MultiScaleDeformableAttention
+    # Avoid bc-breaking of importing MultiScaleDeformableAttention
     with pytest.raises(ImportError):
         MultiScaleDeformableAttention()
 

--- a/tests/test_cnn/test_transformer.py
+++ b/tests/test_cnn/test_transformer.py
@@ -4,7 +4,13 @@ import torch
 from mmcv.cnn.bricks.drop import DropPath
 from mmcv.cnn.bricks.transformer import (FFN, BaseTransformerLayer,
                                          MultiheadAttention,
+                                         MultiScaleDeformableAttention,
                                          TransformerLayerSequence)
+
+
+def test_multiscaledeformableattention_import_dep_waring():
+    with pytest.warns(ImportWarning):
+        MultiScaleDeformableAttention()
 
 
 def test_multiheadattention():

--- a/tests/test_cnn/test_transformer.py
+++ b/tests/test_cnn/test_transformer.py
@@ -4,14 +4,7 @@ import torch
 from mmcv.cnn.bricks.drop import DropPath
 from mmcv.cnn.bricks.transformer import (FFN, BaseTransformerLayer,
                                          MultiheadAttention,
-                                         MultiScaleDeformableAttention,
                                          TransformerLayerSequence)
-
-
-def test_import_multiscaledeformableattention():
-    # Avoid bc-breaking of importing MultiScaleDeformableAttention
-    with pytest.raises(ImportError):
-        MultiScaleDeformableAttention()
 
 
 def test_multiheadattention():

--- a/tests/test_cnn/test_transformer.py
+++ b/tests/test_cnn/test_transformer.py
@@ -4,13 +4,7 @@ import torch
 from mmcv.cnn.bricks.drop import DropPath
 from mmcv.cnn.bricks.transformer import (FFN, BaseTransformerLayer,
                                          MultiheadAttention,
-                                         MultiScaleDeformableAttention,
                                          TransformerLayerSequence)
-
-
-def test_multiscaledeformableattention_import_dep_waring():
-    with pytest.warns(ImportWarning):
-        MultiScaleDeformableAttention()
 
 
 def test_multiheadattention():


### PR DESCRIPTION
## Motivation
This PR can solve the BC-breaking of importing the MultiScaleDeformableAttention from ``mmcv.cnn.bricks.transformer``.

## Modification
Add a dummy module to raise the ImportError when exactly using the module instead of when importing it.
