### PR TITLE
[Fix] Fix meta information loading in runner.resume

### DIFF
--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -358,9 +358,6 @@ class BaseRunner(metaclass=ABCMeta):
                 self.logger.info('the iteration number is changed due to '
                                  'change of GPU number')
 
-        # resume meta information meta
-        self.meta = checkpoint['meta']
-
         if 'optimizer' in checkpoint and resume_optimizer:
             if isinstance(self.optimizer, Optimizer):
                 self.optimizer.load_state_dict(checkpoint['optimizer'])


### PR DESCRIPTION
The original `runner.resume` method loads all the meta information in the checkpoint, including epoch, iter, mmcv_version, mmdet_version (optional) into `runner.meta`. And these information will wrongly override the meta in subsequent checkpoints in `runner.save_checkpoint`. See [here](https://github.com/open-mmlab/mmcv/blob/master/mmcv/runner/epoch_based_runner.py#L159).