### PR TITLE
Remove optimizer arg in val_step

### DIFF
--- a/docs/runner.md
+++ b/docs/runner.md
@@ -74,7 +74,7 @@ def val(self, data_loader, **kwargs):
     data_batch = next(data_loader)
     # it will execute all before_val_iter function in the hooks registered. You may want to watch out for the order.
     self.call_hook('before_val_iter')
-    outputs = self.model.val_step(data_batch, self.optimizer, **kwargs)
+    outputs = self.model.val_step(data_batch, **kwargs)
     self.outputs = outputs
     self.call_hook('after_val_iter')
 ```

--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -29,7 +29,7 @@ class EpochBasedRunner(BaseRunner):
             outputs = self.model.train_step(data_batch, self.optimizer,
                                             **kwargs)
         else:
-            outputs = self.model.val_step(data_batch, self.optimizer, **kwargs)
+            outputs = self.model.val_step(data_batch, **kwargs)
         if not isinstance(outputs, dict):
             raise TypeError('"batch_processor()" or "model.train_step()"'
                             'and "model.val_step()" must return a dict')

--- a/tests/test_runner/test_eval_hook.py
+++ b/tests/test_runner/test_eval_hook.py
@@ -58,7 +58,7 @@ class Model(nn.Module):
             data_batch = dict(x=data_batch)
         return data_batch
 
-    def val_step(self, x, optimizer, **kwargs):
+    def val_step(self, x, **kwargs):
         return dict(loss=self(x))
 
 

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -79,7 +79,7 @@ def test_ema_hook():
         def train_step(self, x, optimizer, **kwargs):
             return dict(loss=self(x))
 
-        def val_step(self, x, optimizer, **kwargs):
+        def val_step(self, x, **kwargs):
             return dict(loss=self(x))
 
     loader = DataLoader(torch.ones((1, 1, 1, 1)))


### PR DESCRIPTION
## Motivation
According to the discussion in PR([Fix] Fix iter base runner val step no optimizer param bug #1048 ),  the optimizer param should be removed from val_step(). And in my opinion, epoch_based_runner should be consistent with iter_based_runner (For now, epoch_based_runner's val_step has optimizer while iter_based_runner not )

## Modification
Remove optimizer arg in val_step

## BC-breaking (Optional)
Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
