### PR TITLE
Change dict update order

### DIFF
--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -149,14 +149,13 @@ class EpochBasedRunner(BaseRunner):
                 Defaults to True.
         """
         if meta is None:
-            meta = dict(epoch=self.epoch + 1, iter=self.iter)
-        elif isinstance(meta, dict):
-            meta.update(epoch=self.epoch + 1, iter=self.iter)
-        else:
+            meta = dict()
+        elif not isinstance(meta, dict):
             raise TypeError(
                 f'meta should be a dict or None, but got {type(meta)}')
         if self.meta is not None:
             meta.update(self.meta)
+        meta.update(epoch=self.epoch + 1, iter=self.iter)
 
         filename = filename_tmpl.format(self.epoch + 1)
         filepath = osp.join(out_dir, filename)

--- a/mmcv/runner/iter_based_runner.py
+++ b/mmcv/runner/iter_based_runner.py
@@ -193,14 +193,13 @@ class IterBasedRunner(BaseRunner):
                 latest checkpoint file. Defaults to True.
         """
         if meta is None:
-            meta = dict(iter=self.iter + 1, epoch=self.epoch + 1)
-        elif isinstance(meta, dict):
-            meta.update(iter=self.iter + 1, epoch=self.epoch + 1)
-        else:
+            meta = dict()
+        elif not isinstance(meta, dict):
             raise TypeError(
                 f'meta should be a dict or None, but got {type(meta)}')
         if self.meta is not None:
             meta.update(self.meta)
+        meta.update(epoch=self.epoch + 1, iter=self.iter)
 
         filename = filename_tmpl.format(self.iter + 1)
         filepath = osp.join(out_dir, filename)


### PR DESCRIPTION
## Motivation
This PR solves **_problem 2_** described here: https://github.com/open-mmlab/mmocr/issues/292: if you run training with `cfg.resume_from = 'epoch_50.pth'`, all the checkpoints created during this resumed training (e.g. `epoch_51.pth`, `epoch_52.pth`, `epoch_53.pth`) still continue to have `epoch` and `iter` equal to the values in `epoch_50.pth`.

## Modification
With this PR I fixed the dict update order. In particular, `meta.update(self.meta)` should be done before `meta.update(epoch=self.epoch + 1, iter=self.iter)` because `self.meta` contains `epoch` and `iter` from resumed checkpoint.