### PR TITLE
Missing check for dir in the 'else' clause

### DIFF
--- a/mmcv/utils/path.py
+++ b/mmcv/utils/path.py
@@ -69,8 +69,10 @@ def scandir(dir_path, suffix=None, recursive=False):
                     yield rel_path
             else:
                 if recursive:
-                    yield from _scandir(
-                        entry.path, suffix=suffix, recursive=recursive)
+                    if os.path.isdir(entry.path):
+                        yield from _scandir(entry.path, suffix=suffix, recursive=recursive)
+                    else:
+                        continue
                 else:
                     continue
 


### PR DESCRIPTION
## Motivation
Fixing issue when recursively scanning directories with filenames starting with '.'  Without this fix, the `if not entry.name.startswith('.') and entry.is_file()` logic falls through to the `else` clause which in the current code base will error out as it encounters '.' files (e.g. `.DS_Store`)

## Modification
Add a check to make sure we only recurse on directories (and ignore '.' files)

## BC-breaking (Optional)
No

## Use cases (Optional)
N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
