### PR TITLE
Fix the dimension

### DIFF
--- a/mmcv/ops/csrc/tensorrt/plugins/trt_modulated_deform_conv.cpp
+++ b/mmcv/ops/csrc/tensorrt/plugins/trt_modulated_deform_conv.cpp
@@ -65,7 +65,7 @@ nvinfer1::DimsExprs ModulatedDeformableConvPluginDynamic::getOutputDimensions(
   nvinfer1::DimsExprs ret;
   ret.nbDims = 4;
   ret.d[0] = inputs[0].d[0];
-  ret.d[1] = inputs[2].d[0];
+  ret.d[1] = inputs[3].d[0];
 
   ret.d[2] = inputs[1].d[2];
   ret.d[3] = inputs[1].d[3];


### PR DESCRIPTION
## Motivation
A bug was found while testing modulated deformconv batch inference.

## Modification
- Must use inputs[3].d[0] instead of inputs.[2].d[0] 
