### PR TITLE
[Enhancement] Support resize or rescale to multiple

### DIFF
--- a/mmcv/image/__init__.py
+++ b/mmcv/image/__init__.py
@@ -4,7 +4,8 @@ from .colorspace import (bgr2gray, bgr2hls, bgr2hsv, bgr2rgb, bgr2ycbcr,
                          rgb2bgr, rgb2gray, rgb2ycbcr, ycbcr2bgr, ycbcr2rgb)
 from .geometric import (cutout, imcrop, imflip, imflip_, impad,
                         impad_to_multiple, imrescale, imresize, imresize_like,
-                        imrotate, imshear, imtranslate, rescale_size)
+                        imresize_to_multiple, imrotate, imshear, imtranslate,
+                        rescale_size)
 from .io import imfrombytes, imread, imwrite, supported_backends, use_backend
 from .misc import tensor2imgs
 from .photometric import (adjust_brightness, adjust_color, adjust_contrast,
@@ -16,12 +17,12 @@ from .photometric import (adjust_brightness, adjust_color, adjust_contrast,
 __all__ = [
     'bgr2gray', 'bgr2hls', 'bgr2hsv', 'bgr2rgb', 'gray2bgr', 'gray2rgb',
     'hls2bgr', 'hsv2bgr', 'imconvert', 'rgb2bgr', 'rgb2gray', 'imrescale',
-    'imresize', 'imresize_like', 'rescale_size', 'imcrop', 'imflip', 'imflip_',
-    'impad', 'impad_to_multiple', 'imrotate', 'imfrombytes', 'imread',
-    'imwrite', 'supported_backends', 'use_backend', 'imdenormalize',
-    'imnormalize', 'imnormalize_', 'iminvert', 'posterize', 'solarize',
-    'rgb2ycbcr', 'bgr2ycbcr', 'ycbcr2rgb', 'ycbcr2bgr', 'tensor2imgs',
-    'imshear', 'imtranslate', 'adjust_color', 'imequalize',
+    'imresize', 'imresize_like', 'imresize_to_multiple', 'rescale_size',
+    'imcrop', 'imflip', 'imflip_', 'impad', 'impad_to_multiple', 'imrotate',
+    'imfrombytes', 'imread', 'imwrite', 'supported_backends', 'use_backend',
+    'imdenormalize', 'imnormalize', 'imnormalize_', 'iminvert', 'posterize',
+    'solarize', 'rgb2ycbcr', 'bgr2ycbcr', 'ycbcr2rgb', 'ycbcr2bgr',
+    'tensor2imgs', 'imshear', 'imtranslate', 'adjust_color', 'imequalize',
     'adjust_brightness', 'adjust_contrast', 'lut_transform', 'clahe',
     'adjust_sharpness', 'auto_contrast', 'cutout', 'adjust_lighting'
 ]

--- a/mmcv/image/geometric.py
+++ b/mmcv/image/geometric.py
@@ -4,6 +4,7 @@ import numbers
 import cv2
 import numpy as np
 
+from ..utils import to_2tuple
 from .io import imread_backend
 
 try:
@@ -137,15 +138,13 @@ def imresize_to_multiple(img,
     elif size is None and scale_factor is None:
         raise ValueError('one of size or scale_factor should be defined')
     elif size is not None:
-        if isinstance(size, int):
-            size = (size, size)
+        size = to_2tuple(size)
         if keep_ratio:
             size = rescale_size((w, h), size, return_scale=False)
     else:
         size = _scale_size((w, h), scale_factor)
 
-    if isinstance(divisor, int):
-        divisor = (divisor, divisor)
+    divisor = to_2tuple(divisor)
     size = tuple([int(np.ceil(s / d)) * d for s, d in zip(size, divisor)])
     resized_img, w_scale, h_scale = imresize(
         img,

--- a/mmcv/image/geometric.py
+++ b/mmcv/image/geometric.py
@@ -105,15 +105,16 @@ def imresize_to_multiple(img,
                          backend=None):
     """Resize image according to a given size or scale factor and then rounds
     up the the resized or rescaled image size to the nearest value that can be
-    divisible by the divisor.
+    divided by the divisor.
 
     Args:
         img (ndarray): The input image.
-        divisor (int | tuple): Resized image size will be multiple to divisor.
-            If divisor is tuple, divisor is (w_divisor, h_divisor).
+        divisor (int | tuple): Resized image size will be a multiple of
+            divisor. If divisor is a tuple, divisor should be
+            (w_divisor, h_divisor).
         size (None | int | tuple[int]): Target size (w, h). Default: None.
         scale_factor (None | float | tuple[float]): Multiplier for spatial
-            size. Has to match input size if it is a tuple and the 2D style is
+            size. Should match input size if it is a tuple and the 2D style is
             (w_scale_factor, h_scale_factor). Default: None.
         keep_ratio (bool): Whether to keep the aspect ratio when resizing the
             image. Default: False.

--- a/tests/test_image/test_geometric.py
+++ b/tests/test_image/test_geometric.py
@@ -47,15 +47,54 @@ class TestGeometric:
         with pytest.raises(ValueError):
             mmcv.imresize(self.img, (1000, 600), backend='not support')
 
-        # test divisor
-        resized_img = mmcv.imresize(self.img, (511, 513), divisor=None)
-        assert resized_img.shape == (513, 511, 3)
-
-        resized_img = mmcv.imresize(self.img, (511, 513), divisor=16)
+    def test_imresize_to_multiple(self):
+        # test size and keep_ratio = False
+        resized_img = mmcv.imresize_to_multiple(
+            self.img, divisor=16, size=(511, 513), keep_ratio=False)
         assert resized_img.shape == (528, 512, 3)
-
-        resized_img = mmcv.imresize(self.img, (511, 513), divisor=(16, 32))
+        resized_img = mmcv.imresize_to_multiple(
+            self.img, divisor=(16, 32), size=(511, 513), keep_ratio=False)
         assert resized_img.shape == (544, 512, 3)
+
+        # test size, keep_ratio = True, and return_scale
+        resized_img, w_scale, h_scale = mmcv.imresize_to_multiple(
+            self.img,
+            divisor=16,
+            size=(1000, 600),
+            keep_ratio=True,
+            return_scale=True)
+        assert resized_img.shape == (
+            608, 800, 3) and h_scale == 608 / 300 and w_scale == 800 / 400
+        resized_img, w_scale, h_scale = mmcv.imresize_to_multiple(
+            self.img,
+            divisor=(18, 16),
+            size=(1000, 600),
+            keep_ratio=True,
+            return_scale=True)
+        assert resized_img.shape == (
+            608, 810, 3) and h_scale == 608 / 300 and w_scale == 810 / 400
+
+        # test scale_factor and return_scale
+        resized_img, w_scale, h_scale = mmcv.imresize_to_multiple(
+            self.img, divisor=16, scale_factor=2, return_scale=True)
+        assert resized_img.shape == (
+            608, 800, 3) and h_scale == 608 / 300 and w_scale == 800 / 400
+        resized_img, w_scale, h_scale = mmcv.imresize_to_multiple(
+            self.img, divisor=16, scale_factor=(2, 3), return_scale=True)
+        assert resized_img.shape == (
+            912, 800, 3) and h_scale == 912 / 300 and w_scale == 800 / 400
+        resized_img, w_scale, h_scale = mmcv.imresize_to_multiple(
+            self.img, divisor=(18, 16), scale_factor=(2, 3), return_scale=True)
+        assert resized_img.shape == (
+            912, 810, 3) and h_scale == 912 / 300 and w_scale == 810 / 400
+
+        # one of size and scale_factor shuld be given
+        with pytest.raises(ValueError):
+            mmcv.imresize_to_multiple(
+                self.img, divisor=16, size=(1000, 600), scale_factor=2)
+        with pytest.raises(ValueError):
+            mmcv.imresize_to_multiple(
+                self.img, divisor=16, size=None, scale_factor=None)
 
     def test_imresize_like(self):
         a = np.zeros((100, 200, 3))
@@ -110,27 +149,6 @@ class TestGeometric:
         resized_img, scale = mmcv.imrescale(
             self.img, (180, 200), return_scale=True)
         assert resized_img.shape == (150, 200, 3) and scale == 0.5
-
-        # test divisor
-        resized_img = mmcv.imrescale(self.img, (1000, 600), divisor=None)
-        assert resized_img.shape == (600, 800, 3)
-        resized_img, scale = mmcv.imrescale(
-            self.img, (1000, 600), return_scale=True, divisor=None)
-        assert resized_img.shape == (600, 800, 3) and scale == 2.0
-
-        resized_img = mmcv.imrescale(self.img, (1000, 600), divisor=16)
-        assert resized_img.shape == (608, 800, 3)
-        resized_img, w_scale, h_scale = mmcv.imrescale(
-            self.img, (1000, 600), return_scale=True, divisor=16)
-        assert resized_img.shape == (
-            608, 800, 3) and h_scale == 608 / 300 and w_scale == 800 / 400
-
-        resized_img = mmcv.imrescale(self.img, (1000, 600), divisor=(18, 16))
-        assert resized_img.shape == (608, 810, 3)
-        resized_img, w_scale, h_scale = mmcv.imrescale(
-            self.img, (1000, 600), return_scale=True, divisor=(18, 16))
-        assert resized_img.shape == (
-            608, 810, 3) and h_scale == 608 / 300 and w_scale == 810 / 400
 
         # test exceptions
         with pytest.raises(ValueError):

--- a/tests/test_image/test_geometric.py
+++ b/tests/test_image/test_geometric.py
@@ -47,6 +47,16 @@ class TestGeometric:
         with pytest.raises(ValueError):
             mmcv.imresize(self.img, (1000, 600), backend='not support')
 
+        # test divisor
+        resized_img = mmcv.imresize(self.img, (511, 513), divisor=None)
+        assert resized_img.shape == (513, 511, 3)
+
+        resized_img = mmcv.imresize(self.img, (511, 513), divisor=16)
+        assert resized_img.shape == (528, 512, 3)
+
+        resized_img = mmcv.imresize(self.img, (511, 513), divisor=(16, 32))
+        assert resized_img.shape == (544, 512, 3)
+
     def test_imresize_like(self):
         a = np.zeros((100, 200, 3))
         resized_img = mmcv.imresize_like(self.img, a)
@@ -100,6 +110,27 @@ class TestGeometric:
         resized_img, scale = mmcv.imrescale(
             self.img, (180, 200), return_scale=True)
         assert resized_img.shape == (150, 200, 3) and scale == 0.5
+
+        # test divisor
+        resized_img = mmcv.imrescale(self.img, (1000, 600), divisor=None)
+        assert resized_img.shape == (600, 800, 3)
+        resized_img, scale = mmcv.imrescale(
+            self.img, (1000, 600), return_scale=True, divisor=None)
+        assert resized_img.shape == (600, 800, 3) and scale == 2.0
+
+        resized_img = mmcv.imrescale(self.img, (1000, 600), divisor=16)
+        assert resized_img.shape == (608, 800, 3)
+        resized_img, w_scale, h_scale = mmcv.imrescale(
+            self.img, (1000, 600), return_scale=True, divisor=16)
+        assert resized_img.shape == (
+            608, 800, 3) and h_scale == 608 / 300 and w_scale == 800 / 400
+
+        resized_img = mmcv.imrescale(self.img, (1000, 600), divisor=(18, 16))
+        assert resized_img.shape == (608, 810, 3)
+        resized_img, w_scale, h_scale = mmcv.imrescale(
+            self.img, (1000, 600), return_scale=True, divisor=(18, 16))
+        assert resized_img.shape == (
+            608, 810, 3) and h_scale == 608 / 300 and w_scale == 810 / 400
 
         # test exceptions
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Motivation
To meet the requirement of some networks that the size of the input image should be multiple to the divisor

## Modification
Add `divisor` argument to `imresize` and `imrescale` in `mmcv.image`.
This argument rounds up the resized or rescaled image size to the nearest value that can be divisible by the divisor.


