### PR TITLE
[Fix] Delete incorrect warning report when weights initialization

### DIFF
--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -115,9 +115,7 @@ class BaseInit(object):
                     but got a {type(layer)}')
         else:
             layer = []
-            warnings.warn(
-                'init_cfg without layer key, if you do not define override'
-                ' key either, this init_cfg will do nothing')
+
         if bias_prob is not None:
             self.bias = bias_init_with_prob(bias_prob)
         else:


### PR DESCRIPTION
## Motivation
+ The warning is designed to remind users that at least one of  ``layer`` and  ``override`` must have values, but it reports incorrectly when users use ``override`` key. I delete it in this PR to avoid confusing users.

## Modification
+ Delete the warning report in mmcv/mmcv/cnn/utils/weight_init.py
