### PR TITLE
[Features] Add initialization log

### DIFF
--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -96,7 +96,8 @@ def bias_init_with_prob(prior_prob):
 
 def init_log(init_name, layer_name, module_name, weight_shape, bias_shape,
              bias_value):
-    loggername = list(logger_initialized.keys())[0]
+    loggernames = list(logger_initialized.keys())
+    loggername = loggernames[0] if len(loggernames) > 0 else 'mmcv'
     print_log(
         f'    initialize weights ({weight_shape}) of {layer_name} '
         f'in {module_name} in with {init_name}',

--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -95,15 +95,14 @@ def bias_init_with_prob(prior_prob):
 
 def init_log(init_name, layer_name, module_name, weight_shape, bias_shape,
              bias_value):
-    logger = get_logger('mmcv')
     print_log(
         f'    initialize weights ({weight_shape}) of {layer_name} '
         f'in {module_name} in with {init_name}',
-        logger=logger)
+        logger='mmcv')
     print_log(
         f'    fill bias ({bias_shape}) of {layer_name} '
         f'in {module_name} with {bias_value}',
-        logger=logger)
+        logger='mmcv')
 
 
 def _get_bases_name(m):
@@ -495,10 +494,9 @@ def _initialize_override(module, override, cfg):
                 f'`override` need "type" key, but got {cp_override}')
 
         if hasattr(module, name):
-            logger = get_logger('mmcv')
             print_log(
                 f'    initialize weight and bias in {name} with {cp_override}',
-                logger=logger)
+                logger='mmcv')
             _initialize(getattr(module, name), cp_override, wholemodule=True)
         else:
             raise RuntimeError(f'module did not have attribute {name}, '

--- a/mmcv/cnn/utils/weight_init.py
+++ b/mmcv/cnn/utils/weight_init.py
@@ -8,7 +8,8 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from mmcv.utils import Registry, build_from_cfg, get_logger, print_log
+from mmcv.utils import Registry, build_from_cfg
+from mmcv.utils.logging import get_logger, logger_initialized, print_log
 
 INITIALIZERS = Registry('initializer')
 
@@ -95,14 +96,15 @@ def bias_init_with_prob(prior_prob):
 
 def init_log(init_name, layer_name, module_name, weight_shape, bias_shape,
              bias_value):
+    loggername = list(logger_initialized.keys())[0]
     print_log(
         f'    initialize weights ({weight_shape}) of {layer_name} '
         f'in {module_name} in with {init_name}',
-        logger='mmcv')
+        logger=loggername)
     print_log(
         f'    fill bias ({bias_shape}) of {layer_name} '
         f'in {module_name} with {bias_value}',
-        logger='mmcv')
+        logger=loggername)
 
 
 def _get_bases_name(m):

--- a/mmcv/runner/base_module.py
+++ b/mmcv/runner/base_module.py
@@ -5,7 +5,7 @@ from abc import ABCMeta
 import torch.nn as nn
 
 from mmcv import ConfigDict
-from mmcv.utils import get_logger, print_log
+from mmcv.utils import print_log
 
 
 class BaseModule(nn.Module, metaclass=ABCMeta):
@@ -43,10 +43,9 @@ class BaseModule(nn.Module, metaclass=ABCMeta):
         modulename = self.__class__.__name__
         if not self._is_init:
             if self.init_cfg:
-                logger = get_logger('mmcv')
                 print_log(
                     f'initialize {modulename} with init_cfg {self.init_cfg}',
-                    logger=logger)
+                    logger='mmcv')
                 initialize(self, self.init_cfg)
                 if isinstance(self.init_cfg, (dict, ConfigDict)):
                     # Avoid the parameters of the pre-training model

--- a/mmcv/runner/base_module.py
+++ b/mmcv/runner/base_module.py
@@ -5,7 +5,7 @@ from abc import ABCMeta
 import torch.nn as nn
 
 from mmcv import ConfigDict
-from mmcv.utils import print_log
+from mmcv.utils.logging import logger_initialized, print_log
 
 
 class BaseModule(nn.Module, metaclass=ABCMeta):
@@ -43,9 +43,10 @@ class BaseModule(nn.Module, metaclass=ABCMeta):
         modulename = self.__class__.__name__
         if not self._is_init:
             if self.init_cfg:
+                loggername = list(logger_initialized.keys())[0]
                 print_log(
                     f'initialize {modulename} with init_cfg {self.init_cfg}',
-                    logger='mmcv')
+                    logger=loggername)
                 initialize(self, self.init_cfg)
                 if isinstance(self.init_cfg, (dict, ConfigDict)):
                     # Avoid the parameters of the pre-training model

--- a/mmcv/runner/base_module.py
+++ b/mmcv/runner/base_module.py
@@ -43,7 +43,8 @@ class BaseModule(nn.Module, metaclass=ABCMeta):
         modulename = self.__class__.__name__
         if not self._is_init:
             if self.init_cfg:
-                loggername = list(logger_initialized.keys())[0]
+                loggernames = list(logger_initialized.keys())
+                loggername = loggernames[0] if len(loggernames) > 0 else 'mmcv'
                 print_log(
                     f'initialize {modulename} with init_cfg {self.init_cfg}',
                     logger=loggername)

--- a/mmcv/runner/base_module.py
+++ b/mmcv/runner/base_module.py
@@ -5,6 +5,7 @@ from abc import ABCMeta
 import torch.nn as nn
 
 from mmcv import ConfigDict
+from mmcv.utils import get_logger, print_log
 
 
 class BaseModule(nn.Module, metaclass=ABCMeta):
@@ -39,9 +40,13 @@ class BaseModule(nn.Module, metaclass=ABCMeta):
     def init_weights(self):
         """Initialize the weights."""
         from ..cnn import initialize
-
+        modulename = self.__class__.__name__
         if not self._is_init:
             if self.init_cfg:
+                logger = get_logger('mmcv')
+                print_log(
+                    f'initialize {modulename} with init_cfg {self.init_cfg}',
+                    logger=logger)
                 initialize(self, self.init_cfg)
                 if isinstance(self.init_cfg, (dict, ConfigDict)):
                     # Avoid the parameters of the pre-training model


### PR DESCRIPTION
## Motivation

To identify unnoticeable bug when weights initializing, I add initialization log to record this process.

## Modification

+ Call ``print_log`` in ``init_weights`` in mmcv/runner/base_module.py.
+ Add ``init_log`` function in mmcv/cnn/utils/weight_init.py.
+ Call ``init_log`` in Initializers in mmcv/cnn/utils/weight_init.py.
+ Call ``print_log`` in ``_initialize_override`` in mmcv/cnn/utils/weight_init.py.

## Use cases

Developers can check whether models' parameters have been initialized as the way they set in ``init_cfg``. 
Below is the log msg of RetinaNet initialization.
```
In [5]: net.init_weights()
2021-06-23 15:36:48,834 - mmcv - INFO - initialize ResNet with init_cfg {'type': 'Pretrained', 'checkpoint': 'torchvision://resnet50'}
2021-06-23 15:36:48,834 - mmcv - INFO - load model from: torchvision://resnet50
2021-06-23 15:36:48,834 - mmcv - INFO - Use load_from_torchvision loader
2021-06-23 15:36:49,143 - mmcv - WARNING - The model and loaded state dict do not match exactly

unexpected key in source state_dict: fc.weight, fc.bias

2021-06-23 15:36:49,145 - mmcv - INFO - initialize FPN with init_cfg {'type': 'Xavier', 'layer': 'Conv2d', 'distribution': 'uniform'}
2021-06-23 15:36:49,145 - mmcv - INFO -     initialize weights (torch.Size([256, 512, 1, 1])) of Conv2d in FPN in with XavierInit
2021-06-23 15:36:49,145 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in FPN with 0
2021-06-23 15:36:49,146 - mmcv - INFO -     initialize weights (torch.Size([256, 1024, 1, 1])) of Conv2d in FPN in with XavierInit
2021-06-23 15:36:49,146 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in FPN with 0
2021-06-23 15:36:49,147 - mmcv - INFO -     initialize weights (torch.Size([256, 2048, 1, 1])) of Conv2d in FPN in with XavierInit
2021-06-23 15:36:49,147 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in FPN with 0
2021-06-23 15:36:49,149 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in FPN in with XavierInit
2021-06-23 15:36:49,149 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in FPN with 0
2021-06-23 15:36:49,151 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in FPN in with XavierInit
2021-06-23 15:36:49,151 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in FPN with 0
2021-06-23 15:36:49,154 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in FPN in with XavierInit
2021-06-23 15:36:49,154 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in FPN with 0
2021-06-23 15:36:49,157 - mmcv - INFO -     initialize weights (torch.Size([256, 2048, 3, 3])) of Conv2d in FPN in with XavierInit
2021-06-23 15:36:49,157 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in FPN with 0
2021-06-23 15:36:49,175 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in FPN in with XavierInit
2021-06-23 15:36:49,175 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in FPN with 0
2021-06-23 15:36:49,177 - mmcv - INFO - initialize RetinaHead with init_cfg {'type': 'Normal', 'layer': 'Conv2d', 'std': 0.01, 'override': {'type': 'Normal', 'name': 'retina_cls', 'std': 0.01, 'bias_prob': 0.01}}
2021-06-23 15:36:49,178 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in RetinaHead in with NormalInit
2021-06-23 15:36:49,178 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in RetinaHead with 0
2021-06-23 15:36:49,181 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in RetinaHead in with NormalInit
2021-06-23 15:36:49,181 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in RetinaHead with 0
2021-06-23 15:36:49,185 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in RetinaHead in with NormalInit
2021-06-23 15:36:49,185 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in RetinaHead with 0
2021-06-23 15:36:49,189 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in RetinaHead in with NormalInit
2021-06-23 15:36:49,189 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in RetinaHead with 0
2021-06-23 15:36:49,193 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in RetinaHead in with NormalInit
2021-06-23 15:36:49,193 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in RetinaHead with 0
2021-06-23 15:36:49,197 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in RetinaHead in with NormalInit
2021-06-23 15:36:49,197 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in RetinaHead with 0
2021-06-23 15:36:49,201 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in RetinaHead in with NormalInit
2021-06-23 15:36:49,201 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in RetinaHead with 0
2021-06-23 15:36:49,204 - mmcv - INFO -     initialize weights (torch.Size([256, 256, 3, 3])) of Conv2d in RetinaHead in with NormalInit
2021-06-23 15:36:49,205 - mmcv - INFO -     fill bias (torch.Size([256])) of Conv2d in RetinaHead with 0
2021-06-23 15:36:49,208 - mmcv - INFO -     initialize weights (torch.Size([720, 256, 3, 3])) of Conv2d in RetinaHead in with NormalInit
2021-06-23 15:36:49,208 - mmcv - INFO -     fill bias (torch.Size([720])) of Conv2d in RetinaHead with 0
2021-06-23 15:36:49,219 - mmcv - INFO -     initialize weights (torch.Size([36, 256, 3, 3])) of Conv2d in RetinaHead in with NormalInit
2021-06-23 15:36:49,219 - mmcv - INFO -     fill bias (torch.Size([36])) of Conv2d in RetinaHead with 0
2021-06-23 15:36:49,219 - mmcv - INFO -     initialize weight and bias in retina_cls with {'type': 'Normal', 'std': 0.01, 'bias_prob': 0.01}
```