### PR TITLE
only log wandb step during training

### DIFF
--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -44,7 +44,7 @@ class WandbLoggerHook(LoggerHook):
     def log(self, runner):
         tags = self.get_loggable_tags(runner)
         if tags:
-            if self.with_step:
+            if self.with_step and self.get_mode(runner) == 'train':
                 self.wandb.log(
                     tags, step=self.get_iter(runner), commit=self.commit)
             else:

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -908,10 +908,9 @@ def test_wandb_hook():
     hook.wandb.init.assert_called_with()
     hook.wandb.log.assert_called_with({
         'learning_rate': 0.02,
-        'momentum': 0.95
-    },
-                                      step=6,
-                                      commit=True)
+        'momentum': 0.95,
+        'global_step': 6
+    }, commit=True)
     hook.wandb.join.assert_called_with()
 
 

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -906,11 +906,13 @@ def test_wandb_hook():
     shutil.rmtree(runner.work_dir)
 
     hook.wandb.init.assert_called_with()
-    hook.wandb.log.assert_called_with({
-        'learning_rate': 0.02,
-        'momentum': 0.95,
-        'global_step': 6
-    }, commit=True)
+    hook.wandb.log.assert_called_with(
+        {
+            'learning_rate': 0.02,
+            'momentum': 0.95,
+            'global_step': 6
+        },
+        commit=True)
     hook.wandb.join.assert_called_with()
 
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
When using the wandb hook, there are warnings about step increasing and lots of useful validation data being dropped. Things like val_acc and val_loss were not being stored in wandb.

## Modification
In the wandb hook, only log the step during training. A quick call to get_mode(runner) fixes this.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues. - Looks good
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness. - This is covered by tests/test_runner/test_hooks.py
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls. - this should not influence downstream projects (besides logging more information)
4. The documentation has been modified accordingly, like docstring or example tutorials. - Looks good
