### PR TITLE
Resolves the duplicate logs issue

### DIFF
--- a/mmcv/utils/logging.py
+++ b/mmcv/utils/logging.py
@@ -28,12 +28,6 @@ def get_logger(name, log_file=None, log_level=logging.INFO, file_mode='w'):
         logging.Logger: The expected logger.
     """
     logger = logging.getLogger(name)
-
-    # set the root logger's StreamHandler, if any, to log at the ERROR level
-    for handler in logger.root.handlers:
-        if type(handler) is logging.StreamHandler:
-            handler.setLevel(logging.ERROR)
-
     if name in logger_initialized:
         return logger
     # handle hierarchical names
@@ -42,6 +36,17 @@ def get_logger(name, log_file=None, log_level=logging.INFO, file_mode='w'):
     for logger_name in logger_initialized:
         if name.startswith(logger_name):
             return logger
+
+    # handle duplicate logs to the console
+    # Starting in 1.8.0, PyTorch DDP attaches a StreamHandler <stderr> (NOTSET)
+    # to the root logger. As logger.propagate is True by default, this root
+    # level handler causes logging messages from rank>0 processes to
+    # unexpectedly show up on the console, creating much unwanted clutter.
+    # To fix this issue, we set the root logger's StreamHandler, if any, to log
+    # at the ERROR level.
+    for handler in logger.root.handlers:
+        if type(handler) is logging.StreamHandler:
+            handler.setLevel(logging.ERROR)
 
     stream_handler = logging.StreamHandler()
     handlers = [stream_handler]

--- a/mmcv/utils/logging.py
+++ b/mmcv/utils/logging.py
@@ -28,7 +28,12 @@ def get_logger(name, log_file=None, log_level=logging.INFO, file_mode='w'):
         logging.Logger: The expected logger.
     """
     logger = logging.getLogger(name)
-    logger.root.handlers.clear()
+
+    # set the root logger's StreamHandler, if any, to log at the ERROR level
+    for handler in logger.root.handlers:
+        if type(handler) is logging.StreamHandler:
+            handler.setLevel(logging.ERROR)
+
     if name in logger_initialized:
         return logger
     # handle hierarchical names
@@ -93,6 +98,7 @@ def print_log(msg, logger=None, level=logging.INFO):
     elif isinstance(logger, str):
         _logger = get_logger(logger)
         _logger.log(level, msg)
+        return _logger
     else:
         raise TypeError(
             'logger should be either a logging.Logger object, str, '

--- a/mmcv/utils/logging.py
+++ b/mmcv/utils/logging.py
@@ -28,6 +28,7 @@ def get_logger(name, log_file=None, log_level=logging.INFO, file_mode='w'):
         logging.Logger: The expected logger.
     """
     logger = logging.getLogger(name)
+    logger.root.handlers.clear()
     if name in logger_initialized:
         return logger
     # handle hierarchical names

--- a/mmcv/utils/logging.py
+++ b/mmcv/utils/logging.py
@@ -98,7 +98,6 @@ def print_log(msg, logger=None, level=logging.INFO):
     elif isinstance(logger, str):
         _logger = get_logger(logger)
         _logger.log(level, msg)
-        return _logger
     else:
         raise TypeError(
             'logger should be either a logging.Logger object, str, '


### PR DESCRIPTION
## Motivation
The console handler present in the root logger leads to duplicate messages being printed on the console, creating unnecessary clutter. This has also been discussed [here](https://discuss.pytorch.org/t/distributed-1-8-0-logging-twice-in-a-single-process-same-code-works-properly-in-1-7-0/114103/6). This PR fixes this issue, and resolves #1000. 

## Modification 

In `mmcv.utils.get_logger()`, all `StreamHandler` present in the root logger are set to log at the `ERROR` level, instead of `NOTSET` which is the default.