### PR TITLE
Add MobileNetV2 pretrained weight for MMDetection

### DIFF
--- a/mmcv/model_zoo/open_mmlab.json
+++ b/mmcv/model_zoo/open_mmlab.json
@@ -45,5 +45,6 @@
   "resnest50": "https://download.openmmlab.com/pretrain/third_party/resnest50_d2-7497a55b.pth",
   "resnest101": "https://download.openmmlab.com/pretrain/third_party/resnest101_d2-f3b931b2.pth",
   "resnest200": "https://download.openmmlab.com/pretrain/third_party/resnest200_d2-ca88e41f.pth",
-  "darknet53": "https://download.openmmlab.com/pretrain/third_party/darknet53-a628ea1b.pth"
+  "darknet53": "https://download.openmmlab.com/pretrain/third_party/darknet53-a628ea1b.pth",
+  "mmdet/mobilenet_v2": "https://download.openmmlab.com/mmdetection/v2.0/third_party/mobilenet_v2_batch256_imagenet-ff34753d.pth"
 }


### PR DESCRIPTION
Add MobileNetV2 pretrained weight converted from [here](https://download.openmmlab.com/mmclassification/v0/mobilenet_v2/mobilenet_v2_batch256_imagenet_20200708-3b2dc3af.pth) because MobileNetV2 in MMDetection has different parameter keys from MMClassification.

Requested by https://github.com/open-mmlab/mmdetection/issues/5495
Related to https://github.com/open-mmlab/mmclassification/issues/246
