### PR TITLE
[Feature] Add ONNX export support to torch.roll

### DIFF
--- a/mmcv/onnx/symbolic.py
+++ b/mmcv/onnx/symbolic.py
@@ -432,8 +432,9 @@ def roll(g, input, shifts, dims):
         slice_size = g.op('Sub', slice_size, g.op('Mul', end_size, div_size))
 
         if version.parse(torch.__version__) >= version.parse('1.7.0'):
-            end_size = squeeze(g, end_size)
-            slice_size = squeeze(g, slice_size)
+            # add dim=0 for pytorch 1.9.0
+            end_size = squeeze(g, end_size, 0)
+            slice_size = squeeze(g, slice_size, 0)
         else:
             end_size = g.op('Squeeze', end_size)
             slice_size = g.op('Squeeze', slice_size)

--- a/mmcv/onnx/symbolic.py
+++ b/mmcv/onnx/symbolic.py
@@ -413,6 +413,8 @@ def roll(g, input, shifts, dims):
     input_shape = g.op('Shape', input)
 
     need_flatten = len(dims) == 0
+    # If dims is not specified, the tensor will be flattened before
+    # rolling and then restored to the original shape.
     if need_flatten:
         resize_shape = input_shape
         input = g.op('Reshape', input,

--- a/tests/test_ops/test_onnx.py
+++ b/tests/test_ops/test_onnx.py
@@ -608,11 +608,6 @@ def test_roll(shifts_dims_pair):
     from mmcv.onnx.symbolic import register_extra_symbolics
     register_extra_symbolics(opset)
 
-    from mmcv.ops import get_onnxruntime_op_path
-    ort_custom_op_path = get_onnxruntime_op_path()
-    if not os.path.exists(ort_custom_op_path):
-        pytest.skip('custom ops for onnxruntime are not compiled.')
-
     input = torch.arange(0, 4 * 5 * 6, dtype=torch.float32).view(4, 5, 6)
 
     shifts, dims = shifts_dims_pair

--- a/tests/test_ops/test_onnx.py
+++ b/tests/test_ops/test_onnx.py
@@ -14,7 +14,7 @@ onnx_file = 'tmp.onnx'
 
 
 @pytest.fixture(autouse=True)
-def clear_tmpfile_after_test():
+def run_before_and_after_test():
     # clear onnx_file before test
     if os.path.exists(onnx_file):
         os.remove(onnx_file)


### PR DESCRIPTION
## Motivation

This PR add ONNX export support to `torch.roll`. 
Related to https://github.com/open-mmlab/mmsegmentation/issues/693#issuecomment-878057857

## Modification

Add `torch.roll` symbolic file and related onnx test.
