### PR TITLE
[Fix] Fix potential interger overflow in `imequalize`.

### DIFF
--- a/mmcv/image/photometric.py
+++ b/mmcv/image/photometric.py
@@ -157,6 +157,8 @@ def imequalize(img):
             lut = (np.cumsum(histo) + (step // 2)) // step
             # Shift lut, prepending with 0.
             lut = np.concatenate([[0], lut[:-1]], 0)
+            # handle potential integer overflow
+            lut[lut > 255] = 255
         # If step is zero, return the original image.
         # Otherwise, index from lut.
         return np.where(np.equal(step, 0), im, lut[im])

--- a/tests/test_image/test_photometric.py
+++ b/tests/test_image/test_photometric.py
@@ -131,9 +131,8 @@ class TestPhotometric:
 
         # test equalize with randomly sampled image.
         for _ in range(nb_rand_test):
-            img = np.clip(
-                np.random.normal(0, 1, (1000, 1200, 3)) * 260, 0,
-                255).astype(np.uint8)
+            img = np.clip(np.random.normal(0, 1, (256, 256, 3)) * 260, 0,
+                          255).astype(np.uint8)
             equalized_img = mmcv.imequalize(img)
             assert_array_equal(equalized_img, _imequalize(img))
 


### PR DESCRIPTION
## Motivation

`imequalize` in mmcv have a potential integer overflow bug and get result like the following image:
![mmcv](https://user-images.githubusercontent.com/26739999/125424280-83fe6131-4cd6-4cce-a6f4-2560d55bfccc.png)

While in Pillow, it's right.
![Pillow](https://user-images.githubusercontent.com/26739999/125423650-fedb1093-4661-4a7c-8d28-7351059c0624.png)

## Modification

Conver all numbers in `lut` greater than 255 to 255.

## BC-breaking (Optional)
No