### PR TITLE
Prevent kernel_normalizer to change mask dtype

### DIFF
--- a/mmcv/ops/carafe.py
+++ b/mmcv/ops/carafe.py
@@ -268,7 +268,7 @@ class CARAFEPack(nn.Module):
         mask_channel = int(mask_c / float(self.up_kernel**2))
         mask = mask.view(n, mask_channel, -1, h, w)
 
-        mask = F.softmax(mask, dim=2)
+        mask = F.softmax(mask, dim=2, dtype=mask.dtype)
         mask = mask.view(n, mask_c, h, w).contiguous()
 
         return mask


### PR DESCRIPTION
## Motivation

When training fpn_carafe neck in mmdet with feature of dtype torch.half, the execution fails with:
_RuntimeError: expected scalar type Half but found Float_
at mmcv/ops/carafe.py l130

The code works with features of dtype torch.float

## Modification

The issue arise from  mismatch in dtype between features and masks. This difference is created in the 'kernel_normalizer' function (carafe.py l263) where F.softmax returns by default results of dtype torch.float.

By setting the dtype argument to mask.dtype, F.softmax forwards the correct dtype.

## BC-breaking (Optional)

No
