### PR TITLE
[WIP] Accelerate training by replacing DataContainer object scatter

### DIFF
--- a/mmcv/parallel/_functions.py
+++ b/mmcv/parallel/_functions.py
@@ -17,7 +17,12 @@ def scatter(input, devices, streams=None):
         ]
         return outputs
     elif isinstance(input, torch.Tensor):
-        output = comm.scatter(input, devices, None, 0, streams)[0]
+        if devices != [-1]:
+            output = comm.scatter(input, devices, None, 0, streams)[0]
+        else:
+            # unsqueeze the first dimension thus the tensor's shape is the
+            # same as those scattered with GPU.
+            output = input.contiguous().unsqueeze(0)
         return output
     else:
         raise Exception(f'Unknown type {type(input)}.')

--- a/mmcv/parallel/scatter_gather.py
+++ b/mmcv/parallel/scatter_gather.py
@@ -24,7 +24,14 @@ def scatter(inputs, target_gpus, dim=0):
             if obj.cpu_only:
                 return obj.data
             else:
-                return Scatter.forward(target_gpus, obj.data)
+                data = obj.data
+                if isinstance(data, torch.Tensor):
+                    return OrigScatter.apply(target_gpus, None, dim, data)
+                elif isinstance(data, list):
+                    out = list(map(list, zip(*map(scatter_map, data))))[0]
+                    return out
+                else:
+                    raise Exception(f'Unknown type {type(data)}.')
         if isinstance(obj, tuple) and len(obj) > 0:
             return list(zip(*map(scatter_map, obj)))
         if isinstance(obj, list) and len(obj) > 0:

--- a/mmcv/parallel/scatter_gather.py
+++ b/mmcv/parallel/scatter_gather.py
@@ -24,14 +24,7 @@ def scatter(inputs, target_gpus, dim=0):
             if obj.cpu_only:
                 return obj.data
             else:
-                data = obj.data
-                if isinstance(data, torch.Tensor):
-                    return OrigScatter.apply(target_gpus, None, dim, data)
-                elif isinstance(data, list):
-                    out = list(map(list, zip(*map(scatter_map, data))))[0]
-                    return out
-                else:
-                    raise Exception(f'Unknown type {type(data)}.')
+                return Scatter.forward(target_gpus, obj.data)
         if isinstance(obj, tuple) and len(obj) > 0:
             return list(zip(*map(scatter_map, obj)))
         if isinstance(obj, list) and len(obj) > 0:


### PR DESCRIPTION
## Motivation

During the YOLOX reproduction process, we found that the `scatter` process of DataContainer will significantly increase the training time. The practice has shown that replacing the custom scatter can reduce the training time by about half. 

## Modification

Replace the custom scatter of the DataContainer object with the scatter of PyTorch.

## BC-breaking

None

## Use cases
I only tested MMDetection, the other frameworks did not test.

## Note

I need to experiment and compare the training and inference speed.