### PR TITLE
[Fix] Fix the bug that the training log and evaluating log are mixed

### DIFF
--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -455,6 +455,11 @@ class DistEvalHook(EvalHook):
             # the log has been printed, so it will not cause any problem.
             # more details at
             # https://github.com/open-mmlab/mmsegmentation/issues/694
+            if not self.by_epoch:
+                for hook in runner._hooks:
+                    if isinstance(hook, LoggerHook):
+                        hook.after_train_iter(runner)
+
             print('\n')
             runner.log_buffer.output['eval_iter_num'] = len(self.dataloader)
             key_score = self.evaluate(runner, results)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix the bug that the training log and evaluating log are mixed.

Because the priority of EvalHook is higher than LoggerHook, the training log and the evaluating log are mixed. Therefore, we need to dump the training log and clear it before evaluating log is generated. In addition, this problem will only appear in `IterBasedRunner`, because `EpochBasedRunner` calls `_do_evaluate` in `after_train_epoch` stage, and at this stage the log has been printed, so it will not cause any problem.

more details
- #1248 
- https://github.com/open-mmlab/mmsegmentation/issues/694

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
