### PR TITLE
[Feature] Add RandomFlip

### DIFF
--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -4,10 +4,9 @@ import mmcv
 
 
 class RandomFlip:
-    """Random Flip.
-    If the input dict contains the key "flip", then the flag will be used,
-    otherwise it will be randomly decided by a ratio specified in the init
-    method.
+    """Random Flip. If the input dict contains the key "flip", then the flag
+    will be used, otherwise it will be randomly decided by a ratio specified in
+    the init method.
 
     When random flip is enabled, ``prob``/``direction`` can either be a
     float/string or tuple of float/string. There are 3 flip modes:
@@ -100,6 +99,7 @@ class RandomFlip:
 
     def bbox_flip(self, results, key, direction):
         """Flip bboxes.
+
         Args:
             results (dict): Result dict from loading pipeline.
             key (str): Key for the necessary data.
@@ -151,6 +151,7 @@ class RandomFlip:
     def __call__(self, results):
         """Call function to flip bounding boxes, masks, semantic segmentation
         maps.
+
         Args:
             results (dict): Result dict from loading pipeline.
         Returns:

--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -44,8 +44,8 @@ class RandomFlip:
 
     # `_flip_functions_map` contain the map between the field name (key) and
     # the name of flip function (value).
-    # If a flied name is not in this map, we will directly use `img_flip`
-    # flip function.
+    # If a field name is not in this map, we will directly use `img_flip`
+    # as the flip function.
     _flip_functions_map = dict(
         img='img_flip', bbox='bbox_flip', seg='img_flip', mask='img_flip')
 

--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -90,7 +90,7 @@ class RandomFlip:
         if isinstance(self.prob, list):
             non_flip_prob = 1 - sum(self.prob)
             self.prob_list = self.prob + [non_flip_prob]
-        else:
+        elif self.prob is not None:
             non_flip_prob = 1 - self.prob
             # exclude non-flip
             single_ratio = self.prob / (len(self.direction_list) - 1)
@@ -122,15 +122,15 @@ class RandomFlip:
             h = img_shape[0]
             flipped[..., 1::4] = h - bboxes[..., 3::4]
             flipped[..., 3::4] = h - bboxes[..., 1::4]
-        elif direction == 'diagonal':
+        # direction == 'diagonal'
+        else:
             w = img_shape[1]
             h = img_shape[0]
             flipped[..., 0::4] = w - bboxes[..., 2::4]
             flipped[..., 1::4] = h - bboxes[..., 3::4]
             flipped[..., 2::4] = w - bboxes[..., 0::4]
             flipped[..., 3::4] = h - bboxes[..., 1::4]
-        else:
-            raise ValueError(f"Invalid flipping direction '{direction}'")
+
         return flipped
 
     def img_flip(self, results, key, direction):
@@ -181,9 +181,9 @@ class RandomFlip:
                                              results['flip_direction'])
 
                 # the field name may be the key of the data
-                if key in results and 'img_fields' not in results:
-                    results[key] = flip_func(results, key,
-                                             results['flip_direction'])
+                if field in results and f'{field}_fields' not in results:
+                    results[field] = flip_func(results, field,
+                                               results['flip_direction'])
 
         return results
 

--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -1,0 +1,190 @@
+import numpy as np
+
+import mmcv
+
+
+class RandomFlip:
+    """Random Flip.
+    If the input dict contains the key "flip", then the flag will be used,
+    otherwise it will be randomly decided by a ratio specified in the init
+    method.
+
+    When random flip is enabled, ``prob``/``direction`` can either be a
+    float/string or tuple of float/string. There are 3 flip modes:
+    - ``prob`` is float, ``direction`` is string: the image will be
+        ``direction``ly flipped with probability of ``prob`` .
+        E.g., ``prob=0.5``, ``direction='horizontal'``,
+        then image will be horizontally flipped with probability of 0.5.
+    - ``prob`` is float, ``direction`` is list of string: the image wil
+        be ``direction[i]``ly flipped with probability of
+        ``prob/len(direction)``.
+        E.g., ``prob=0.5``, ``direction=['horizontal', 'vertical']``,
+        then image will be horizontally flipped with probability of 0.25,
+        vertically with probability of 0.25.
+    - ``prob`` is list of float, ``direction`` is list of string:
+        given ``len(prob) == len(direction)``, the image wil
+        be ``direction[i]``ly flipped with probability of ``prob[i]``.
+        E.g., ``prob=[0.3, 0.5]``, ``direction=['horizontal',
+        'vertical']``, then image will be horizontally flipped with probability
+        of 0.3, vertically with probability of 0.5.
+
+    Args:
+        prob (float | list[float], optional): The flipping probability.
+            Default: None.
+        direction(str | list[str], optional): The flipping direction. Options
+            are 'horizontal', 'vertical', 'diagonal'. Default: 'horizontal'.
+            If input is a list, the length must equal ``prob``. Each
+            element in ``prob`` indicates the flip probability of
+            corresponding direction. Default: 'horizontal'.
+        flip_fields (str | list[str] | None, optional): The name list of data
+            fields that need flip. If given ``None``, we adopt all of the
+            pre-defined names in ``_flip_functions_map``. If the name is not
+            in ``_flip_functions_map``, we will adopt the `img_flip` function
+            to flip the data. Default: None.
+    """
+
+    # `_flip_functions_map` contain the map between the field name (key) and
+    # the name of flip function (value).
+    # If a flied name is not in this map, we will directly use `img_flip`
+    # flip function.
+    _flip_functions_map = dict(
+        img='img_flip', bbox='bbox_flip', seg='img_flip', mask='img_flip')
+
+    def __init__(self, prob=None, direction='horizontal', flip_fields=None):
+        if isinstance(prob, list):
+            assert mmcv.is_list_of(prob, float)
+            assert 0 <= sum(prob) <= 1
+        elif isinstance(prob, float):
+            assert 0 <= prob <= 1
+        elif prob is None:
+            pass
+        else:
+            raise ValueError('probs must be None, float, ' 'or list of float')
+
+        self.prob = prob
+
+        valid_directions = ['horizontal', 'vertical', 'diagonal']
+        if isinstance(direction, str):
+            assert direction in valid_directions
+        elif isinstance(direction, list):
+            assert mmcv.is_list_of(direction, str)
+            assert set(direction).issubset(set(valid_directions))
+        else:
+            raise ValueError('direction must be either str or list of str')
+        self.direction = direction
+
+        if isinstance(prob, list):
+            assert len(self.prob) == len(self.direction)
+
+        # set flip_fields
+        self.flip_fields = flip_fields or list(self._flip_functions_map.keys())
+
+        # set direction list with None
+        if isinstance(self.direction, list):
+            # None means non-flip
+            self.direction_list = self.direction + [None]
+        else:
+            # None means non-flip
+            self.direction_list = [self.direction, None]
+
+        # set prob list with non_flip_prob
+        if isinstance(self.prob, list):
+            non_flip_prob = 1 - sum(self.prob)
+            self.prob_list = self.prob + [non_flip_prob]
+        else:
+            non_flip_prob = 1 - self.prob
+            # exclude non-flip
+            single_ratio = self.prob / (len(self.direction_list) - 1)
+            self.prob_list = [single_ratio] * (len(self.direction_list) -
+                                               1) + [non_flip_prob]
+
+    def bbox_flip(self, results, key, direction):
+        """Flip bboxes.
+        Args:
+            results (dict): Result dict from loading pipeline.
+            key (str): Key for the necessary data.
+            direction (str): Flip direction. Options are 'horizontal',
+                'vertical'.
+        Returns:
+            numpy.ndarray: Flipped bounding boxes.
+        """
+
+        bboxes = results[key]
+        img_shape = results['img_shape']
+
+        assert bboxes.shape[-1] % 4 == 0
+        flipped = bboxes.copy()
+        if direction == 'horizontal':
+            w = img_shape[1]
+            flipped[..., 0::4] = w - bboxes[..., 2::4]
+            flipped[..., 2::4] = w - bboxes[..., 0::4]
+        elif direction == 'vertical':
+            h = img_shape[0]
+            flipped[..., 1::4] = h - bboxes[..., 3::4]
+            flipped[..., 3::4] = h - bboxes[..., 1::4]
+        elif direction == 'diagonal':
+            w = img_shape[1]
+            h = img_shape[0]
+            flipped[..., 0::4] = w - bboxes[..., 2::4]
+            flipped[..., 1::4] = h - bboxes[..., 3::4]
+            flipped[..., 2::4] = w - bboxes[..., 0::4]
+            flipped[..., 3::4] = h - bboxes[..., 1::4]
+        else:
+            raise ValueError(f"Invalid flipping direction '{direction}'")
+        return flipped
+
+    def img_flip(self, results, key, direction):
+        """Flip an image.
+        Args:
+            results (dict): Result dict from loading pipeline.
+            key (str): Key for the necessary data.
+            direction (str): The flip direction, either "horizontal" or
+                "vertical" or "diagonal".
+
+        Returns:
+            ndarray: The flipped image.
+        """
+        img = results[key]
+        # use copy() to make numpy stride positive
+        return mmcv.imflip(img, direction).copy()
+
+    def __call__(self, results):
+        """Call function to flip bounding boxes, masks, semantic segmentation
+        maps.
+        Args:
+            results (dict): Result dict from loading pipeline.
+        Returns:
+            dict: Flipped results, 'flip', 'flip_direction' keys are added \
+                into result dict.
+        """
+
+        if 'flip' not in results:
+            cur_dir = np.random.choice(self.direction_list, p=self.prob_list)
+
+            results['flip'] = cur_dir is not None
+
+        if 'flip_direction' not in results:
+            results['flip_direction'] = cur_dir
+
+        if results['flip']:
+            for field in self.flip_fields:
+                # get flip function for the `field`
+                if field in self._flip_functions_map:
+                    flip_func = getattr(self, self._flip_functions_map[field])
+                else:
+                    flip_func = self.img_flip
+
+                # a data field may contain a list of keys
+                for key in results.get(field + '_fields', []):
+                    results[key] = flip_func(results, key,
+                                             results['flip_direction'])
+
+                # the field name may be the key of the data
+                if key in results and 'img_fields' not in results:
+                    results[key] = flip_func(results, key,
+                                             results['flip_direction'])
+
+        return results
+
+    def __repr__(self):
+        return self.__class__.__name__ + f'(prob={self.prob})'

--- a/tests/test_dataset/test_randomflip.py
+++ b/tests/test_dataset/test_randomflip.py
@@ -10,10 +10,24 @@ from mmcv.datasets.pipelines.transforms import RandomFlip
 
 class TestRandomFlip:
 
+    @classmethod
+    def setup_class(cls):
+        cls.color_img = mmcv.imread(
+            osp.join(osp.dirname(__file__), '../data/color.jpg'), 'color')
+
+        bbox_det = np.array([[10, 20, 40, 50], [20, 20, 70, 100]],
+                            dtype=np.int32)
+        cls.results_bbox = dict(
+            img_shape=(256, 256), bbox_fields=['bbox_det'], bbox_det=bbox_det)
+
     def test_randomflip(self):
         # test assertion for invalid prob
         with pytest.raises(AssertionError):
             RandomFlip(prob=1.5)
+
+        with pytest.raises(ValueError):
+            RandomFlip(prob='str')
+
         # test assertion for 0 <= sum(prob) <= 1
         with pytest.raises(AssertionError):
             RandomFlip(prob=[0.7, 0.8], direction=['horizontal', 'vertical'])
@@ -26,11 +40,13 @@ class TestRandomFlip:
         with pytest.raises(AssertionError):
             RandomFlip(prob=[0.7, 0.1], direction=['horizontal', 'vertica'])
 
+        with pytest.raises(ValueError):
+            RandomFlip(prob=[0.7, 0.1], direction=1)
+
         flip_module = RandomFlip(prob=1.)
 
         results = dict()
-        img = mmcv.imread(
-            osp.join(osp.dirname(__file__), '../data/color.jpg'), 'color')
+        img = self.color_img
         original_img = copy.deepcopy(img)
         results['img'] = img
         results['img2'] = copy.deepcopy(img)
@@ -44,6 +60,25 @@ class TestRandomFlip:
         results = flip_module(results)
         assert np.equal(results['img'], results['img2']).all()
 
+        flip_module = RandomFlip(prob=None)
+
+        results = dict()
+        img = self.color_img
+        original_img = copy.deepcopy(img)
+        results['img'] = img
+        results['img2'] = copy.deepcopy(img)
+        results['img_shape'] = img.shape
+        results['ori_shape'] = img.shape
+        # Set initial values for default meta_keys
+        results['pad_shape'] = img.shape
+        results['scale_factor'] = 1.0
+        results['img_fields'] = ['img', 'img2']
+        results['flip'] = True
+        results['flip_direction'] = 'horizontal'
+
+        results = flip_module(results)
+        assert np.equal(results['img'], results['img2']).all()
+
         results = flip_module(results)
         assert np.equal(results['img'], results['img2']).all()
         assert np.equal(original_img, results['img']).all()
@@ -53,8 +88,7 @@ class TestRandomFlip:
             prob=0.9, direction=['horizontal', 'vertical', 'diagonal'])
 
         results = dict()
-        img = mmcv.imread(
-            osp.join(osp.dirname(__file__), '../data/color.jpg'), 'color')
+        img = self.color_img
         original_img = copy.deepcopy(img)
         results['img'] = img
         results['img_shape'] = img.shape
@@ -77,8 +111,7 @@ class TestRandomFlip:
             direction=['horizontal', 'vertical', 'diagonal'])
 
         results = dict()
-        img = mmcv.imread(
-            osp.join(osp.dirname(__file__), '../data/color.jpg'), 'color')
+        img = self.color_img
         original_img = copy.deepcopy(img)
         results['img'] = img
         results['img_shape'] = img.shape
@@ -94,3 +127,58 @@ class TestRandomFlip:
                 results['img'])
         else:
             assert np.array_equal(original_img, results['img'])
+
+        # test bbox flip
+        flip_module = RandomFlip(prob=1., flip_fields=['bbox'])
+        results = copy.deepcopy(self.results_bbox)
+
+        results = flip_module(results)
+        bbox_horizontal = np.array([[246, 20, 216, 50], [236, 20, 186, 100]],
+                                   dtype=np.int32)
+        np.array_equal(results['bbox_det'], bbox_horizontal)
+
+        flip_module = RandomFlip(
+            prob=1., direction='vertical', flip_fields=['bbox'])
+        results = copy.deepcopy(self.results_bbox)
+
+        results = flip_module(results)
+        bbox_vertical = np.array([[10, 236, 40, 210], [20, 236, 70, 156]],
+                                 dtype=np.int32)
+        np.array_equal(results['bbox_det'], bbox_vertical)
+
+        flip_module = RandomFlip(
+            prob=1., direction='diagonal', flip_fields=['bbox'])
+        results = copy.deepcopy(self.results_bbox)
+
+        results = flip_module(results)
+        bbox_diagonal = np.array([[246, 236, 216, 210], [236, 236, 186, 156]],
+                                 dtype=np.int32)
+        np.array_equal(results['bbox_det'], bbox_diagonal)
+
+        # test the name not in the pre-defined list
+        flip_module = RandomFlip(prob=1., flip_fields=['img1', 'img2'])
+
+        results = dict()
+        img = self.color_img
+        original_img = copy.deepcopy(img)
+        results['img1'] = img
+        results['img2'] = copy.deepcopy(img)
+        results['img_shape'] = img.shape
+        results['ori_shape'] = img.shape
+        # Set initial values for default meta_keys
+        results['pad_shape'] = img.shape
+        results['scale_factor'] = 1.0
+        results['img_fields'] = ['img1', 'img2']
+
+        results = flip_module(results)
+        assert np.equal(results['img1'], results['img2']).all()
+
+        if results['flip']:
+            assert np.array_equal(
+                mmcv.imflip(original_img, results['flip_direction']),
+                results['img1'])
+        else:
+            assert np.array_equal(original_img, results['img'])
+
+        assert str(
+            flip_module) == flip_module.__class__.__name__ + f'(prob={1.})'

--- a/tests/test_dataset/test_randomflip.py
+++ b/tests/test_dataset/test_randomflip.py
@@ -1,0 +1,96 @@
+import copy
+import os.path as osp
+
+import numpy as np
+import pytest
+
+import mmcv
+from mmcv.datasets.pipelines.transforms import RandomFlip
+
+
+class TestRandomFlip:
+
+    def test_randomflip(self):
+        # test assertion for invalid prob
+        with pytest.raises(AssertionError):
+            RandomFlip(prob=1.5)
+        # test assertion for 0 <= sum(prob) <= 1
+        with pytest.raises(AssertionError):
+            RandomFlip(prob=[0.7, 0.8], direction=['horizontal', 'vertical'])
+
+        # test assertion for mismatch between number of prob and direction
+        with pytest.raises(AssertionError):
+            RandomFlip(prob=[0.7, 0.1], direction=['vertical'])
+
+        # test assertion for invalid direction
+        with pytest.raises(AssertionError):
+            RandomFlip(prob=[0.7, 0.1], direction=['horizontal', 'vertica'])
+
+        flip_module = RandomFlip(prob=1.)
+
+        results = dict()
+        img = mmcv.imread(
+            osp.join(osp.dirname(__file__), '../data/color.jpg'), 'color')
+        original_img = copy.deepcopy(img)
+        results['img'] = img
+        results['img2'] = copy.deepcopy(img)
+        results['img_shape'] = img.shape
+        results['ori_shape'] = img.shape
+        # Set initial values for default meta_keys
+        results['pad_shape'] = img.shape
+        results['scale_factor'] = 1.0
+        results['img_fields'] = ['img', 'img2']
+
+        results = flip_module(results)
+        assert np.equal(results['img'], results['img2']).all()
+
+        results = flip_module(results)
+        assert np.equal(results['img'], results['img2']).all()
+        assert np.equal(original_img, results['img']).all()
+
+        # test prob is float, direction is list
+        flip_module = RandomFlip(
+            prob=0.9, direction=['horizontal', 'vertical', 'diagonal'])
+
+        results = dict()
+        img = mmcv.imread(
+            osp.join(osp.dirname(__file__), '../data/color.jpg'), 'color')
+        original_img = copy.deepcopy(img)
+        results['img'] = img
+        results['img_shape'] = img.shape
+        results['ori_shape'] = img.shape
+        # Set initial values for default meta_keys
+        results['pad_shape'] = img.shape
+        results['scale_factor'] = 1.0
+        results['img_fields'] = ['img']
+        results = flip_module(results)
+        if results['flip']:
+            assert np.array_equal(
+                mmcv.imflip(original_img, results['flip_direction']),
+                results['img'])
+        else:
+            assert np.array_equal(original_img, results['img'])
+
+        # test prob is list, direction is list
+        flip_module = RandomFlip(
+            prob=[0.3, 0.3, 0.2],
+            direction=['horizontal', 'vertical', 'diagonal'])
+
+        results = dict()
+        img = mmcv.imread(
+            osp.join(osp.dirname(__file__), '../data/color.jpg'), 'color')
+        original_img = copy.deepcopy(img)
+        results['img'] = img
+        results['img_shape'] = img.shape
+        results['ori_shape'] = img.shape
+        # Set initial values for default meta_keys
+        results['pad_shape'] = img.shape
+        results['scale_factor'] = 1.0
+        results['img_fields'] = ['img']
+        results = flip_module(results)
+        if results['flip']:
+            assert np.array_equal(
+                mmcv.imflip(original_img, results['flip_direction']),
+                results['img'])
+        else:
+            assert np.array_equal(original_img, results['img'])


### PR DESCRIPTION
## Motivation

In this PR, we unify the implementation of RandomFlip functions from `MMDet`, `MMSeg`, and `MMCls`. Hope that other downstream tasks can start using this unified API in their data pipeline.

## Modification

1. Add `flip_fileds` arguments to indicate the fileds/data that needs to be flipped.
2. Use `prob` the probability to perform the flip operation while it is `flip_ratio` in `MMDet`.

## BC-breaking (Optional)

1. We directly remove `flip_ratio` while MMDet still keeps this argument.

## Use cases (Optional)

```python
# flip img tensor
dict(prob=0.5)

# flip multiple fields
dict(prob=0.5, flip_fields=['img', 'bbox'])

# flip multiple fileds with multiple directions
dict(prob=[0.5, 0.2], direction=['horizontal', 'vertical'], flip_fields=['img', 'bbox'])
```
