### PR TITLE
[Enhancement] Add build_func for UPSAMPLE_LAYERS

### DIFF
--- a/mmcv/cnn/bricks/registry.py
+++ b/mmcv/cnn/bricks/registry.py
@@ -1,17 +1,58 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import torch.nn as nn
+
 from mmcv.utils import Registry
-from .upsample import build_upsample_layer
 
 CONV_LAYERS = Registry('conv layer')
 NORM_LAYERS = Registry('norm layer')
 ACTIVATION_LAYERS = Registry('activation layer')
 PADDING_LAYERS = Registry('padding layer')
-UPSAMPLE_LAYERS = Registry('upsample layer', build_func=build_upsample_layer)
 PLUGIN_LAYERS = Registry('plugin layer')
-
 DROPOUT_LAYERS = Registry('drop out layers')
 POSITIONAL_ENCODING = Registry('position encoding')
 ATTENTION = Registry('attention')
 FEEDFORWARD_NETWORK = Registry('feed-forward Network')
 TRANSFORMER_LAYER = Registry('transformerLayer')
 TRANSFORMER_LAYER_SEQUENCE = Registry('transformer-layers sequence')
+
+
+def build_upsample_layer_from_cfg(cfg, registry, *args, **kwargs):
+    """Build upsample layer.
+
+    Args:
+        cfg (dict): The upsample layer config, which should contain:
+
+            - type (str): Layer type.
+            - scale_factor (int): Upsample ratio, which is not applicable to
+                deconv.
+            - layer args: Args needed to instantiate a upsample layer.
+        registry (:obj:`Registry`): A registry the module belongs to.
+        args (argument list): Arguments passed to the ``__init__``
+            method of the corresponding conv layer.
+        kwargs (keyword arguments): Keyword arguments passed to the
+            ``__init__`` method of the corresponding conv layer.
+
+    Returns:
+        nn.Module: Created upsample layer.
+    """
+    if not isinstance(cfg, dict):
+        raise TypeError(f'cfg must be a dict, but got {type(cfg)}')
+    if 'type' not in cfg:
+        raise KeyError(
+            f'the cfg dict must contain the key "type", but got {cfg}')
+    cfg_ = cfg.copy()
+
+    layer_type = cfg_.pop('type')
+    if layer_type not in registry:
+        raise KeyError(f'Unrecognized upsample type {layer_type}')
+    else:
+        upsample = registry.get(layer_type)
+
+    if upsample is nn.Upsample:
+        cfg_['mode'] = layer_type
+    layer = upsample(*args, **kwargs, **cfg_)
+    return layer
+
+
+UPSAMPLE_LAYERS = Registry(
+    'upsample layer', build_func=build_upsample_layer_from_cfg)

--- a/mmcv/cnn/bricks/registry.py
+++ b/mmcv/cnn/bricks/registry.py
@@ -3,18 +3,6 @@ import torch.nn as nn
 
 from mmcv.utils import Registry
 
-CONV_LAYERS = Registry('conv layer')
-NORM_LAYERS = Registry('norm layer')
-ACTIVATION_LAYERS = Registry('activation layer')
-PADDING_LAYERS = Registry('padding layer')
-PLUGIN_LAYERS = Registry('plugin layer')
-DROPOUT_LAYERS = Registry('drop out layers')
-POSITIONAL_ENCODING = Registry('position encoding')
-ATTENTION = Registry('attention')
-FEEDFORWARD_NETWORK = Registry('feed-forward Network')
-TRANSFORMER_LAYER = Registry('transformerLayer')
-TRANSFORMER_LAYER_SEQUENCE = Registry('transformer-layers sequence')
-
 
 def build_upsample_layer_from_cfg(cfg, registry, *args, **kwargs):
     """Build upsample layer.
@@ -54,5 +42,16 @@ def build_upsample_layer_from_cfg(cfg, registry, *args, **kwargs):
     return layer
 
 
+CONV_LAYERS = Registry('conv layer')
+NORM_LAYERS = Registry('norm layer')
+ACTIVATION_LAYERS = Registry('activation layer')
+PADDING_LAYERS = Registry('padding layer')
+PLUGIN_LAYERS = Registry('plugin layer')
 UPSAMPLE_LAYERS = Registry(
     'upsample layer', build_func=build_upsample_layer_from_cfg)
+DROPOUT_LAYERS = Registry('drop out layers')
+POSITIONAL_ENCODING = Registry('position encoding')
+ATTENTION = Registry('attention')
+FEEDFORWARD_NETWORK = Registry('feed-forward Network')
+TRANSFORMER_LAYER = Registry('transformerLayer')
+TRANSFORMER_LAYER_SEQUENCE = Registry('transformer-layers sequence')

--- a/mmcv/cnn/bricks/registry.py
+++ b/mmcv/cnn/bricks/registry.py
@@ -1,11 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from mmcv.utils import Registry
+from .upsample import build_upsample_layer
 
 CONV_LAYERS = Registry('conv layer')
 NORM_LAYERS = Registry('norm layer')
 ACTIVATION_LAYERS = Registry('activation layer')
 PADDING_LAYERS = Registry('padding layer')
-UPSAMPLE_LAYERS = Registry('upsample layer')
+UPSAMPLE_LAYERS = Registry('upsample layer', build_func=build_upsample_layer)
 PLUGIN_LAYERS = Registry('plugin layer')
 
 DROPOUT_LAYERS = Registry('drop out layers')

--- a/mmcv/cnn/bricks/upsample.py
+++ b/mmcv/cnn/bricks/upsample.py
@@ -5,7 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from ..utils import xavier_init
-from .registry import UPSAMPLE_LAYERS
+from .registry import UPSAMPLE_LAYERS, build_upsample_layer_from_cfg
 
 UPSAMPLE_LAYERS.register_module('nearest', module=nn.Upsample)
 UPSAMPLE_LAYERS.register_module('bilinear', module=nn.Upsample)
@@ -69,7 +69,7 @@ def build_upsample_layer(cfg, *args, **kwargs):
     Returns:
         nn.Module: Created upsample layer.
     """
-    from .registry import build_upsample_layer_from_cfg
+
     warnings.warn(
         ImportWarning(
             '``build_upsample_layer(cfg, *args, **kwargs)`` will be '

--- a/mmcv/cnn/bricks/upsample.py
+++ b/mmcv/cnn/bricks/upsample.py
@@ -76,5 +76,4 @@ def build_upsample_layer(cfg, *args, **kwargs):
             'deprecated. Please use '
             '``UPSAMPLE_LAYERS.build(cfg, *args, **kwargs)`` instead.'))
 
-    return build_upsample_layer_from_cfg(
-        cfg, *args, **kwargs, registry=UPSAMPLE_LAYERS)
+    return build_upsample_layer_from_cfg(cfg, UPSAMPLE_LAYERS, *args, **kwargs)


### PR DESCRIPTION
## Motivation

Add `build_func` for `UPSAMPLE_LAYERS`

## Modification

UPSAMPLE_LAYERS

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
Not sure.

## Use cases

- Before the PR

```python
from mmcv.cnn import build_upsample_layer
build_upsample_layer(cfg, *args, **kwargs)

```

- After the PR
```python
from mmcv.cnn.bricks.registry import UPSAMPLE_LAYERS
UPSAMPLE_LAYERS.build(cfg, *args, **kwargs)
```