### PR TITLE
[WIP] Add `LoadImageFromFile` transform

### DIFF
--- a/mmcv/datasets/__init__.py
+++ b/mmcv/datasets/__init__.py
@@ -1,4 +1,5 @@
 from .builder import PIPELINES
+from .pipelines.loading import LoadImageFromFile
 from .pipelines.transforms import Normalize
 
-__all__ = ['PIPELINES', 'Normalize']
+__all__ = ['PIPELINES', 'Normalize', 'LoadImageFromFile']

--- a/mmcv/datasets/__init__.py
+++ b/mmcv/datasets/__init__.py
@@ -1,0 +1,4 @@
+from .builder import PIPELINES
+from .pipelines.transforms import Normalize
+
+__all__ = ['PIPELINES', 'Normalize']

--- a/mmcv/datasets/builder.py
+++ b/mmcv/datasets/builder.py
@@ -1,3 +1,3 @@
-from ..utils import Registry
+from ..utils.registry import Registry
 
 PIPELINES = Registry('pipeline')

--- a/mmcv/datasets/builder.py
+++ b/mmcv/datasets/builder.py
@@ -1,3 +1,3 @@
-from ..utils import Registry
+from mmcv.utils import Registry
 
 PIPELINES = Registry('pipeline')

--- a/mmcv/datasets/builder.py
+++ b/mmcv/datasets/builder.py
@@ -1,3 +1,3 @@
-from mmcv.utils import Registry
+from ..utils import Registry
 
 PIPELINES = Registry('pipeline')

--- a/mmcv/datasets/builder.py
+++ b/mmcv/datasets/builder.py
@@ -1,0 +1,3 @@
+from ..utils import Registry
+
+PIPELINES = Registry('pipeline')

--- a/mmcv/datasets/pipelines/__init__.py
+++ b/mmcv/datasets/pipelines/__init__.py
@@ -1,0 +1,3 @@
+from .transforms import Normalize
+
+__all__ = ['Normalize']

--- a/mmcv/datasets/pipelines/__init__.py
+++ b/mmcv/datasets/pipelines/__init__.py
@@ -1,3 +1,4 @@
+from .loading import LoadImageFromFile
 from .transforms import Normalize
 
-__all__ = ['Normalize']
+__all__ = ['Normalize', 'LoadImageFromFile']

--- a/mmcv/datasets/pipelines/loading.py
+++ b/mmcv/datasets/pipelines/loading.py
@@ -10,13 +10,6 @@ from ..builder import PIPELINES
 class LoadImageFromFile:
     """Load an image from file.
 
-    Required keys are "img_prefix" (optional) and "filename".
-
-    Added keys are "ori_filename", "img_fields", "img", "img_shape",
-    "ori_shape" (same as "img_shape"), "height" and "width".
-
-    Updated keys is "filename".
-
     Args:
         to_float32 (bool): Whether to convert the loaded image to a float32
             numpy array. If set to False, the loaded image is an uint8 array.
@@ -28,6 +21,26 @@ class LoadImageFromFile:
         file_client_args (dict): Arguments to instantiate a FileClient.
             See :class:`mmcv.fileio.FileClient` for details.
             Defaults to ``dict(backend='disk')``.
+
+    Example:
+        >>> from mmcv.datasets.pipelines import LoadImageFromFile
+        >>> transform = LoadImageFromFile()
+        >>> input_dict = {
+        ...     'img_prefix': '/home/xxx/datasets/train',
+        ...     'filename': 'first.png'
+        ... }
+        >>> output_dict = transform(input_dict)
+        >>> for k, v in output_dict.items():
+        ...     print(k, type(v))
+        img_prefix <class 'str'>
+        filename <class 'str'>
+        img_fields <class 'list'>
+        ori_filename <class 'str'>
+        img <class 'numpy.ndarray'>
+        img_shape <class 'tuple'>
+        ori_shape <class 'tuple'>
+        height <class 'int'>
+        width <class 'int'>
     """
 
     def __init__(self,
@@ -42,6 +55,20 @@ class LoadImageFromFile:
         self.file_client = None
 
     def __call__(self, results: dict) -> dict:
+        """Call function to load image from file.
+
+        Args:
+            results (dict): Required keys are 'img_prefix' (optional) and
+                'filename'.
+
+        Returns:
+            dict: Image loading results.
+
+            - Added keys are "ori_filename", "img_fields", "img",
+              "img_shape", "ori_shape" (same as "img_shape"),
+              "height" and "width".
+            - Updated key is "filename".
+        """
         if self.file_client is None:
             self.file_client = mmcv.FileClient(**self.file_client_args)
 

--- a/mmcv/datasets/pipelines/loading.py
+++ b/mmcv/datasets/pipelines/loading.py
@@ -1,0 +1,77 @@
+import os.path as osp
+
+import numpy as np
+
+import mmcv
+from ..builder import PIPELINES
+
+
+@PIPELINES.register_module()
+class LoadImageFromFile:
+    """Load an image from file.
+
+    Required keys are "img_prefix" (optional) and "filename".
+
+    Added keys are "ori_filename", "img_fields", "img", "img_shape",
+    "ori_shape" (same as "img_shape"), "height" and "width".
+
+    Updated keys is "filename".
+
+    Args:
+        to_float32 (bool): Whether to convert the loaded image to a float32
+            numpy array. If set to False, the loaded image is an uint8 array.
+            Defaults to False.
+        color_type (str): The flag argument for :func:`mmcv.imfrombytes()`.
+            Defaults to 'color'.
+        imdecode_backend (str): The backend argument for
+            :func:`mmcv.imfrombytes()`. Defaults to 'cv2'.
+        file_client_args (dict): Arguments to instantiate a FileClient.
+            See :class:`mmcv.fileio.FileClient` for details.
+            Defaults to ``dict(backend='disk')``.
+    """
+
+    def __init__(self,
+                 to_float32: bool = False,
+                 color_type: str = 'color',
+                 imdecode_backend: str = 'cv2',
+                 file_client_args: dict = dict(backend='disk')):
+        self.to_float32 = to_float32
+        self.color_type = color_type
+        self.imdecode_backend = imdecode_backend
+        self.file_client_args = file_client_args.copy()
+        self.file_client = None
+
+    def __call__(self, results: dict) -> dict:
+        if self.file_client is None:
+            self.file_client = mmcv.FileClient(**self.file_client_args)
+
+        assert 'filename' in results, 'LoadImageFromFile requires key '\
+            '"filename". Please check your pipelines.'
+        if results.get('img_prefix', None) is not None:
+            filename = osp.join(results['img_prefix'], results['filename'])
+        else:
+            filename = results['filename']
+
+        img_bytes = self.file_client.get(filename)
+        img = mmcv.imfrombytes(
+            img_bytes, flag=self.color_type, backend=self.imdecode_backend)
+        if self.to_float32:
+            img = img.astype(np.float32)
+
+        results['img_fields'] = ['img']
+        results['ori_filename'] = results['filename']
+        results['filename'] = filename
+        results['img'] = img
+        results['img_shape'] = img.shape
+        results['ori_shape'] = img.shape
+        results['height'] = img.shape[0]
+        results['width'] = img.shape[1]
+        return results
+
+    def __repr__(self):
+        repr_str = (f'{self.__class__.__name__}('
+                    f'to_float32={self.to_float32}, '
+                    f"color_type='{self.color_type}', "
+                    f"imdecode_backend='{self.imdecode_backend}', "
+                    f'file_client_args={self.file_client_args})')
+        return repr_str

--- a/mmcv/datasets/pipelines/loading.py
+++ b/mmcv/datasets/pipelines/loading.py
@@ -74,7 +74,7 @@ class LoadImageFromFile:
 
         assert 'filename' in results, 'LoadImageFromFile requires key '\
             '"filename". Please check your pipelines.'
-        if results.get('img_prefix', None) is not None:
+        if results.get('img_prefix') is not None:
             filename = osp.join(results['img_prefix'], results['filename'])
         else:
             filename = results['filename']

--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -10,13 +10,31 @@ from ..builder import PIPELINES
 class Normalize:
     """Normalize the image.
 
-    Added key is 'img_norm_cfg'.
+    `results` is the input of `__call__()`. The required key of `results` is
+    `img_fields`, which is a list of string. Every item of it is also the key
+    of `results`, whose value is an image. After invoking the `__call__()`, the
+    return results will add an another key `img_norm_cfg`.
 
     Args:
         mean (sequence): Mean values of 3 channels.
         std (sequence): Std values of 3 channels.
         to_rgb (bool): Whether to convert the image from BGR to RGB,
             default is true.
+
+    Example:
+        >>> from mmcv.image.io import imread
+        >>> from mmcv.datasets.pipelines import Normalize
+        >>> cfg = {
+        ...     'mean': [123.675, 116.28, 103.53],
+        ...     'std': [58.395, 57.12, 57.375]
+        ... }
+        >>> img = imread('img_path')  # img_path is the path of image
+        >>> results = {
+        ...     'img': img,
+        ...     'img_fields': ['img']
+        ... }
+        >>> normalize = Normalize(*cfg)
+        >>> results = normalize(results)
     """
 
     def __init__(self, mean: Sequence, std: Sequence, to_rgb: bool = True):
@@ -28,8 +46,8 @@ class Normalize:
         """Call function to normalize images.
 
         Args:
-            results (dict): Result dict from loading pipeline. Required key of
-                results is 'img_fields'.
+            results (dict): Result dict from loading pipeline. Required key is
+                'img_fields'.
 
         Returns:
             dict: Normalized results, 'img_norm_cfg' key is added into

--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -33,7 +33,7 @@ class Normalize:
         ...     'img': img,
         ...     'img_fields': ['img']
         ... }
-        >>> normalize = Normalize(*cfg)
+        >>> normalize = Normalize(**cfg)
         >>> results = normalize(results)
     """
 

--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -28,13 +28,17 @@ class Normalize:
         """Call function to normalize images.
 
         Args:
-            results (dict): Result dict from loading pipeline.
+            results (dict): Result dict from loading pipeline. Required key of
+                results is 'img_fields'.
 
         Returns:
             dict: Normalized results, 'img_norm_cfg' key is added into
                 result dict.
         """
-        for key in results.get('img_fields', ['img']):
+        assert 'img_fields' in results, \
+            '"img_fields" is a required key of results'
+
+        for key in results['img_fields']:
             results[key] = mmcv.imnormalize(results[key], self.mean, self.std,
                                             self.to_rgb)
         results['img_norm_cfg'] = dict(

--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -1,0 +1,47 @@
+from collections.abc import Sequence
+
+import numpy as np
+
+import mmcv
+from ..builder import PIPELINES
+
+
+@PIPELINES.register_module()
+class Normalize:
+    """Normalize the image.
+
+    Added key is 'img_norm_cfg'.
+
+    Args:
+        mean (sequence): Mean values of 3 channels.
+        std (sequence): Std values of 3 channels.
+        to_rgb (bool): Whether to convert the image from BGR to RGB,
+            default is true.
+    """
+
+    def __init__(self, mean: Sequence, std: Sequence, to_rgb: bool = True):
+        self.mean = np.array(mean, dtype=np.float32)
+        self.std = np.array(std, dtype=np.float32)
+        self.to_rgb = to_rgb
+
+    def __call__(self, results: dict) -> dict:
+        """Call function to normalize images.
+
+        Args:
+            results (dict): Result dict from loading pipeline.
+
+        Returns:
+            dict: Normalized results, 'img_norm_cfg' key is added into
+                result dict.
+        """
+        for key in results.get('img_fields', ['img']):
+            results[key] = mmcv.imnormalize(results[key], self.mean, self.std,
+                                            self.to_rgb)
+        results['img_norm_cfg'] = dict(
+            mean=self.mean, std=self.std, to_rgb=self.to_rgb)
+        return results
+
+    def __repr__(self):
+        repr_str = self.__class__.__name__
+        repr_str += f'(mean={self.mean}, std={self.std}, to_rgb={self.to_rgb})'
+        return repr_str

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,6 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = pkg_resources,setuptools,logging,os,warnings,abc
 known_first_party = mmcv
-known_third_party = addict,cv2,m2r,numpy,onnx,onnxruntime,packaging,pytest,recommonmark,scipy,tensorrt,torch,torchvision,yaml,yapf
+known_third_party = PIL,addict,cv2,m2r,numpy,onnx,onnxruntime,packaging,pytest,recommonmark,scipy,tensorrt,torch,torchvision,yaml,yapf
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY

--- a/tests/test_data/test_pipelines/test_loading.py
+++ b/tests/test_data/test_pipelines/test_loading.py
@@ -1,0 +1,76 @@
+import os.path as osp
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from mmcv.datasets import PIPELINES
+
+
+class TestLoading(object):
+
+    @classmethod
+    def setup_class(cls):
+        cls.data_prefix = osp.join(osp.dirname(__file__), '../../data')
+
+    def test_load_img(self):
+        # test load
+        data_info = dict(img_prefix=self.data_prefix, filename='color.jpg')
+        transform_cfg = dict(type='LoadImageFromFile')
+        transform = PIPELINES.build(transform_cfg)
+        results = transform(data_info)
+        assert results['img_fields'] == ['img']
+        assert results['filename'] == osp.join(self.data_prefix, 'color.jpg')
+        assert results['ori_filename'] == 'color.jpg'
+        assert results['img'].shape == (300, 400, 3)
+        assert results['img'].dtype == np.uint8
+        assert results['img_shape'] == (300, 400, 3)
+        assert results['ori_shape'] == (300, 400, 3)
+        assert results['height'] == 300
+        assert results['width'] == 400
+
+        # test without filename
+        with pytest.raises(AssertionError):
+            data_info = dict(img_prefix=self.data_prefix)
+            transform(data_info)
+
+        # test without img_prefix
+        file_path = osp.join(self.data_prefix, 'color.jpg')
+        data_info = dict(filename=file_path)
+        transform_cfg = dict(type='LoadImageFromFile')
+        transform = PIPELINES.build(transform_cfg)
+        results = transform(data_info)
+        assert results['filename'] == file_path
+        assert results['img'].shape == (300, 400, 3)
+
+        # test to_float32
+        transform_cfg = dict(type='LoadImageFromFile', to_float32=True)
+        transform = PIPELINES.build(transform_cfg)
+        results = transform(data_info)
+        assert results['img'].dtype == np.float32
+
+        # test gray image
+        data_info = dict(img_prefix=self.data_prefix, filename='grayscale.jpg')
+        transform_cfg = dict(type='LoadImageFromFile')
+        transform = PIPELINES.build(transform_cfg)
+        results = transform(data_info)
+        assert results['img'].shape == (300, 400, 3)
+        assert results['img'].dtype == np.uint8
+
+        # test color_type
+        data_info = dict(img_prefix=self.data_prefix, filename='grayscale.jpg')
+        transform_cfg = dict(type='LoadImageFromFile', color_type='unchanged')
+        transform = PIPELINES.build(transform_cfg)
+        results = transform(data_info)
+        assert results['img'].shape == (300, 400)
+        assert results['img'].dtype == np.uint8
+
+        # test imdecode_backend
+        data_info = dict(img_prefix=self.data_prefix, filename='color.jpg')
+        transform_cfg = dict(
+            type='LoadImageFromFile', imdecode_backend='pillow')
+        transform = PIPELINES.build(transform_cfg)
+        results = transform(data_info)
+        pil_img = Image.open(results['filename'])
+        pil_img = np.array(pil_img)[:, :, ::-1]
+        assert np.allclose(results['img'], pil_img)

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -4,8 +4,8 @@ import os.path as osp
 import numpy as np
 import pytest
 
-import mmcv
 from mmcv.datasets.builder import PIPELINES
+from mmcv.image import imread
 from mmcv.utils import build_from_cfg
 
 
@@ -16,7 +16,7 @@ def test_normalize(to_rgb):
         std=[58.395, 57.12, 57.375],
         to_rgb=to_rgb)
     results = dict()
-    img = mmcv.imread(
+    img = imread(
         osp.join(osp.dirname(__file__), '../../../data/color.jpg'), 'color')
     original_img = copy.deepcopy(img)
     results['img'] = img

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -1,0 +1,37 @@
+import copy
+import os.path as osp
+
+import numpy as np
+
+import mmcv
+from mmcv.datasets.builder import PIPELINES
+from mmcv.utils import build_from_cfg
+
+
+def test_normalize():
+    img_norm_cfg = dict(
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        to_rgb=True)
+    transform_cfg = dict(type='Normalize', **img_norm_cfg)
+    transform = build_from_cfg(transform_cfg, PIPELINES)
+    results = dict()
+    img = mmcv.imread(
+        osp.join(osp.dirname(__file__), '../../../data/color.jpg'), 'color')
+    original_img = copy.deepcopy(img)
+    results['img'] = img
+    results['img2'] = copy.deepcopy(img)
+    results['img_shape'] = img.shape
+    results['ori_shape'] = img.shape
+    # Set initial values for default meta_keys
+    results['pad_shape'] = img.shape
+    results['scale_factor'] = 1.0
+    results['img_fields'] = ['img', 'img2']
+
+    results = transform(results)
+    assert np.equal(results['img'], results['img2']).all()
+
+    mean = np.array(img_norm_cfg['mean'])
+    std = np.array(img_norm_cfg['std'])
+    converted_img = (original_img[..., ::-1] - mean) / std
+    assert np.allclose(results['img'], converted_img)

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -4,9 +4,9 @@ import os.path as osp
 import numpy as np
 import pytest
 
-from mmcv.datasets import PIPELINES
-from mmcv.image import imread
-from mmcv.utils import build_from_cfg
+from mmcv.datasets.builder import PIPELINES
+from mmcv.image.io import imread
+from mmcv.utils.registry import build_from_cfg
 
 
 @pytest.mark.parametrize('to_rgb', [True, False])

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -21,11 +21,6 @@ def test_normalize(to_rgb):
     original_img = copy.deepcopy(img)
     results['img'] = img
     results['img2'] = copy.deepcopy(img)
-    results['img_shape'] = img.shape
-    results['ori_shape'] = img.shape
-    # Set initial values for default meta_keys
-    results['pad_shape'] = img.shape
-    results['scale_factor'] = 1.0
 
     transform_cfg = dict(type='Normalize', **img_norm_cfg)
     transform = build_from_cfg(transform_cfg, PIPELINES)

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -2,19 +2,19 @@ import copy
 import os.path as osp
 
 import numpy as np
+import pytest
 
 import mmcv
 from mmcv.datasets.builder import PIPELINES
 from mmcv.utils import build_from_cfg
 
 
-def test_normalize():
+@pytest.mark.parametrize('to_rgb', [True, False])
+def test_normalize(to_rgb):
     img_norm_cfg = dict(
         mean=[123.675, 116.28, 103.53],
         std=[58.395, 57.12, 57.375],
-        to_rgb=True)
-    transform_cfg = dict(type='Normalize', **img_norm_cfg)
-    transform = build_from_cfg(transform_cfg, PIPELINES)
+        to_rgb=to_rgb)
     results = dict()
     img = mmcv.imread(
         osp.join(osp.dirname(__file__), '../../../data/color.jpg'), 'color')
@@ -26,12 +26,21 @@ def test_normalize():
     # Set initial values for default meta_keys
     results['pad_shape'] = img.shape
     results['scale_factor'] = 1.0
-    results['img_fields'] = ['img', 'img2']
 
+    transform_cfg = dict(type='Normalize', **img_norm_cfg)
+    transform = build_from_cfg(transform_cfg, PIPELINES)
+
+    with pytest.raises(AssertionError):
+        # Required key of results is 'img_fields'
+        results = transform(results)
+
+    results['img_fields'] = ['img', 'img2']
     results = transform(results)
     assert np.equal(results['img'], results['img2']).all()
 
     mean = np.array(img_norm_cfg['mean'])
     std = np.array(img_norm_cfg['std'])
-    converted_img = (original_img[..., ::-1] - mean) / std
+    if to_rgb:
+        original_img = original_img[..., ::-1]
+    converted_img = (original_img - mean) / std
     assert np.allclose(results['img'], converted_img)

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -4,7 +4,7 @@ import os.path as osp
 import numpy as np
 import pytest
 
-from mmcv.datasets.builder import PIPELINES
+from mmcv.datasets import PIPELINES
 from mmcv.image import imread
 from mmcv.utils import build_from_cfg
 


### PR DESCRIPTION
## Motivation

Add `LoadImageFromFile` transform.

Refers to https://github.com/open-mmlab/mmclassification/blob/ade7b80e443e77cc318be10b601543e8afbba412/mmcls/datasets/pipelines/loading.py#L10 and https://github.com/open-mmlab/mmsegmentation/blob/6eff94165c93705d1ef59f5742e8f4fb906451f7/mmseg/datasets/pipelines/loading.py#L10

## Modification

As the title


## Use cases (Optional)
```python
>>> from mmcv.datasets.pipelines import LoadImageFromFile
>>> transform = LoadImageFromFile()
>>> input_dict = {
...     'img_prefix': '/home/xxx/datasets/train',
...     'filename': 'first.png'
... }
>>> output_dict = transform(input_dict)
>>> for k, v in output_dict.items():
...     print(k, type(v))
img_prefix <class 'str'>
filename <class 'str'>
img_fields <class 'list'>
ori_filename <class 'str'>
img <class 'numpy.ndarray'>
img_shape <class 'tuple'>
ori_shape <class 'tuple'>
height <class 'int'>
width <class 'int'>
```

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
