### PR TITLE
[WIP] Add `ToTensor` and `ImageToTensor` transforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run unittests and generate coverage report
         run: |
           pip install -r requirements/test.txt
-          pytest tests/ --ignore=tests/test_runner --ignore=tests/test_optimizer.py --ignore=tests/test_cnn --ignore=tests/test_parallel.py --ignore=tests/test_ops --ignore=tests/test_load_model_zoo.py --ignore=tests/test_utils/test_logging.py --ignore=tests/test_image/test_io.py --ignore=tests/test_utils/test_registry.py --ignore=tests/test_utils/test_parrots_jit.py --ignore=tests/test_utils/test_trace.py
+          pytest tests/ --ignore=tests/test_runner --ignore=tests/test_optimizer.py --ignore=tests/test_cnn --ignore=tests/test_parallel.py --ignore=tests/test_ops --ignore=tests/test_load_model_zoo.py --ignore=tests/test_utils/test_logging.py --ignore=tests/test_image/test_io.py --ignore=tests/test_utils/test_registry.py --ignore=tests/test_utils/test_parrots_jit.py --ignore=tests/test_utils/test_trace.py --ignore=tests/test_data/test_pipelines/test_formatting.py
 
   build_without_ops:
     runs-on: ubuntu-18.04

--- a/mmcv/datasets/__init__.py
+++ b/mmcv/datasets/__init__.py
@@ -1,4 +1,5 @@
 from .builder import PIPELINES
+from .pipelines.formatting import ToTensor
 from .pipelines.transforms import Normalize
 
-__all__ = ['PIPELINES', 'Normalize']
+__all__ = ['PIPELINES', 'Normalize', 'ToTensor']

--- a/mmcv/datasets/__init__.py
+++ b/mmcv/datasets/__init__.py
@@ -1,0 +1,4 @@
+from .builder import PIPELINES
+from .pipelines.transforms import Normalize
+
+__all__ = ['PIPELINES', 'Normalize']

--- a/mmcv/datasets/__init__.py
+++ b/mmcv/datasets/__init__.py
@@ -1,5 +1,13 @@
+# flake8: noqa
+# Copyright (c) OpenMMLab. All rights reserved.
 from .builder import PIPELINES
-from .pipelines.formatting import ImageToTensor, ToTensor
 from .pipelines.transforms import Normalize
 
-__all__ = ['PIPELINES', 'Normalize', 'ToTensor', 'ImageToTensor']
+__all__ = ['PIPELINES', 'Normalize']
+try:
+    import torch
+except ImportError:
+    pass
+else:
+    from .pipelines.formatting import ImageToTensor, ToTensor
+    __all__ += ['ImageToTensor', 'ToTensor']

--- a/mmcv/datasets/__init__.py
+++ b/mmcv/datasets/__init__.py
@@ -1,5 +1,5 @@
 from .builder import PIPELINES
-from .pipelines.formatting import ToTensor
+from .pipelines.formatting import ImageToTensor, ToTensor
 from .pipelines.transforms import Normalize
 
-__all__ = ['PIPELINES', 'Normalize', 'ToTensor']
+__all__ = ['PIPELINES', 'Normalize', 'ToTensor', 'ImageToTensor']

--- a/mmcv/datasets/builder.py
+++ b/mmcv/datasets/builder.py
@@ -1,3 +1,3 @@
-from ..utils import Registry
+from ..utils.registry import Registry
 
 PIPELINES = Registry('pipeline')

--- a/mmcv/datasets/builder.py
+++ b/mmcv/datasets/builder.py
@@ -1,3 +1,3 @@
-from ..utils import Registry
+from mmcv.utils import Registry
 
 PIPELINES = Registry('pipeline')

--- a/mmcv/datasets/builder.py
+++ b/mmcv/datasets/builder.py
@@ -1,3 +1,3 @@
-from mmcv.utils import Registry
+from ..utils import Registry
 
 PIPELINES = Registry('pipeline')

--- a/mmcv/datasets/builder.py
+++ b/mmcv/datasets/builder.py
@@ -1,0 +1,3 @@
+from ..utils import Registry
+
+PIPELINES = Registry('pipeline')

--- a/mmcv/datasets/pipelines/__init__.py
+++ b/mmcv/datasets/pipelines/__init__.py
@@ -1,0 +1,3 @@
+from .transforms import Normalize
+
+__all__ = ['Normalize']

--- a/mmcv/datasets/pipelines/__init__.py
+++ b/mmcv/datasets/pipelines/__init__.py
@@ -1,3 +1,4 @@
+from .formatting import ToTensor
 from .transforms import Normalize
 
-__all__ = ['Normalize']
+__all__ = ['Normalize', 'ToTensor']

--- a/mmcv/datasets/pipelines/__init__.py
+++ b/mmcv/datasets/pipelines/__init__.py
@@ -1,4 +1,13 @@
-from .formatting import ImageToTensor, ToTensor
+# flake8: noqa
+# Copyright (c) OpenMMLab. All rights reserved.
 from .transforms import Normalize
 
-__all__ = ['Normalize', 'ToTensor', 'ImageToTensor']
+__all__ = ['Normalize']
+
+try:
+    import torch
+except ImportError:
+    pass
+else:
+    from .formatting import ImageToTensor, ToTensor
+    __all__ += ['ImageToTensor', 'ToTensor']

--- a/mmcv/datasets/pipelines/__init__.py
+++ b/mmcv/datasets/pipelines/__init__.py
@@ -1,4 +1,4 @@
-from .formatting import ToTensor
+from .formatting import ImageToTensor, ToTensor
 from .transforms import Normalize
 
-__all__ = ['Normalize', 'ToTensor']
+__all__ = ['Normalize', 'ToTensor', 'ImageToTensor']

--- a/mmcv/datasets/pipelines/formatting.py
+++ b/mmcv/datasets/pipelines/formatting.py
@@ -1,0 +1,74 @@
+from collections.abc import Sequence
+from typing import Callable, Dict
+
+import numpy as np
+import torch
+
+import mmcv
+from ..builder import PIPELINES
+
+
+def to_tensor(data):
+    """Convert objects of various python types to :obj:`torch.Tensor`.
+
+    Supported types are: :class:`numpy.ndarray`, :class:`torch.Tensor`,
+    :class:`Sequence`, :class:`int` and :class:`float`.
+
+    Args:
+        data (torch.Tensor | numpy.ndarray | Sequence | int | float): Data to
+            be converted.
+    """
+    if isinstance(data, torch.Tensor):
+        return data
+    elif isinstance(data, np.ndarray):
+        return torch.from_numpy(data)
+    elif isinstance(data, Sequence) and not mmcv.is_str(data):
+        return torch.tensor(data)
+    elif isinstance(data, int):
+        return torch.LongTensor([data])
+    elif isinstance(data, float):
+        return torch.FloatTensor([data])
+    else:
+        raise TypeError(
+            f'Type {type(data)} cannot be converted to tensor.'
+            'Supported types are: `numpy.ndarray`, `torch.Tensor`, '
+            '`Sequence`, `int` and `float`')
+
+
+def apply(container: Dict, key: str, operator: Callable):
+    """Apply operator to key-value in a container dict.
+
+    Args:
+        container (Dict): A nested dict.
+        key (str): A sequence of keys joined by `.`
+        operator (Callable): The operator that applied to the value of key.
+    """
+    nested_keys = key.split('.')
+    final_key = nested_keys.pop(-1)
+    for key in nested_keys:
+        container = container[key]
+    container[final_key] = operator(container[final_key])
+
+
+@PIPELINES.register_module()
+class ToTensor(object):
+    """Convert some results to :obj:`torch.Tensor` by given keys.
+
+    Args:
+        keys (Sequence[str]): Keys that need to be converted to Tensor.
+
+    Notes:
+        Each key in keys can be a sequence of keys joined by `.`.
+        For example, 'ann.gt_label' means results['ann']['gt_label'].
+    """
+
+    def __init__(self, keys):
+        self.keys = keys
+
+    def __call__(self, results):
+        for key in self.keys:
+            apply(results, key, to_tensor)
+        return results
+
+    def __repr__(self):
+        return self.__class__.__name__ + f'(keys={self.keys})'

--- a/mmcv/datasets/pipelines/formatting.py
+++ b/mmcv/datasets/pipelines/formatting.py
@@ -1,5 +1,4 @@
-from collections.abc import Sequence
-from typing import Callable, Dict
+from typing import Callable, Sequence, Union
 
 import numpy as np
 import torch
@@ -8,7 +7,7 @@ import mmcv
 from ..builder import PIPELINES
 
 
-def to_tensor(data):
+def to_tensor(data: Union[torch.Tensor, np.ndarray, Sequence, int, float]):
     """Convert objects of various python types to :obj:`torch.Tensor`.
 
     Supported types are: :class:`numpy.ndarray`, :class:`torch.Tensor`,
@@ -35,12 +34,12 @@ def to_tensor(data):
             '`Sequence`, `int` and `float`')
 
 
-def apply(container: Dict, key: str, operator: Callable):
+def apply(container: dict, key: str, operator: Callable):
     """Apply operator to key-value in a container dict.
 
     Args:
-        container (Dict): A nested dict.
-        key (str): A sequence of keys joined by `.`
+        container (dict): A nested dict.
+        key (str): A sequence of keys joined by `.`.
         operator (Callable): The operator that applied to the value of key.
     """
     nested_keys = key.split('.')
@@ -62,13 +61,42 @@ class ToTensor(object):
         For example, 'ann.gt_label' means results['ann']['gt_label'].
     """
 
-    def __init__(self, keys):
+    def __init__(self, keys: Sequence[str]):
         self.keys = keys
 
-    def __call__(self, results):
+    def __call__(self, results: dict):
         for key in self.keys:
             apply(results, key, to_tensor)
         return results
 
     def __repr__(self):
         return self.__class__.__name__ + f'(keys={self.keys})'
+
+
+@PIPELINES.register_module()
+class ImageToTensor:
+    """Convert image to :obj:`torch.Tensor` by given keys.
+
+    Required keys is `img_fields`.
+
+    Updated keys are all keys in `img_fields`.
+
+    Notes:
+        The dimension order of input image is (H, W, C). The pipeline will
+        convert it to (C, H, W). If only 2 dimension (H, W) is given, the
+        output would be (1, H, W).
+    """
+
+    def __call__(self, results: dict):
+        assert 'img_fields' in results, 'ImageToTensor requires key '\
+            '"img_fields", Please check your pipelines.'
+
+        for key in results['img_fields']:
+            img = results[key]
+            if len(img.shape) < 3:
+                img = np.expand_dims(img, -1)
+            results[key] = to_tensor(img.transpose(2, 0, 1))
+        return results
+
+    def __repr__(self):
+        return self.__class__.__name__

--- a/mmcv/datasets/pipelines/formatting.py
+++ b/mmcv/datasets/pipelines/formatting.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 from typing import Callable, Sequence, Union
 
 import numpy as np

--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -10,13 +10,31 @@ from ..builder import PIPELINES
 class Normalize:
     """Normalize the image.
 
-    Added key is 'img_norm_cfg'.
+    `results` is the input of `__call__()`. The required key of `results` is
+    `img_fields`, which is a list of string. Every item of it is also the key
+    of `results`, whose value is an image. After invoking the `__call__()`, the
+    return results will add an another key `img_norm_cfg`.
 
     Args:
         mean (sequence): Mean values of 3 channels.
         std (sequence): Std values of 3 channels.
         to_rgb (bool): Whether to convert the image from BGR to RGB,
             default is true.
+
+    Example:
+        >>> from mmcv.image.io import imread
+        >>> from mmcv.datasets.pipelines import Normalize
+        >>> cfg = {
+        ...     'mean': [123.675, 116.28, 103.53],
+        ...     'std': [58.395, 57.12, 57.375]
+        ... }
+        >>> img = imread('img_path')  # img_path is the path of image
+        >>> results = {
+        ...     'img': img,
+        ...     'img_fields': ['img']
+        ... }
+        >>> normalize = Normalize(*cfg)
+        >>> results = normalize(results)
     """
 
     def __init__(self, mean: Sequence, std: Sequence, to_rgb: bool = True):
@@ -28,8 +46,8 @@ class Normalize:
         """Call function to normalize images.
 
         Args:
-            results (dict): Result dict from loading pipeline. Required key of
-                results is 'img_fields'.
+            results (dict): Result dict from loading pipeline. Required key is
+                'img_fields'.
 
         Returns:
             dict: Normalized results, 'img_norm_cfg' key is added into

--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -33,7 +33,7 @@ class Normalize:
         ...     'img': img,
         ...     'img_fields': ['img']
         ... }
-        >>> normalize = Normalize(*cfg)
+        >>> normalize = Normalize(**cfg)
         >>> results = normalize(results)
     """
 

--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -28,13 +28,17 @@ class Normalize:
         """Call function to normalize images.
 
         Args:
-            results (dict): Result dict from loading pipeline.
+            results (dict): Result dict from loading pipeline. Required key of
+                results is 'img_fields'.
 
         Returns:
             dict: Normalized results, 'img_norm_cfg' key is added into
                 result dict.
         """
-        for key in results.get('img_fields', ['img']):
+        assert 'img_fields' in results, \
+            '"img_fields" is a required key of results'
+
+        for key in results['img_fields']:
             results[key] = mmcv.imnormalize(results[key], self.mean, self.std,
                                             self.to_rgb)
         results['img_norm_cfg'] = dict(

--- a/mmcv/datasets/pipelines/transforms.py
+++ b/mmcv/datasets/pipelines/transforms.py
@@ -1,0 +1,47 @@
+from collections.abc import Sequence
+
+import numpy as np
+
+import mmcv
+from ..builder import PIPELINES
+
+
+@PIPELINES.register_module()
+class Normalize:
+    """Normalize the image.
+
+    Added key is 'img_norm_cfg'.
+
+    Args:
+        mean (sequence): Mean values of 3 channels.
+        std (sequence): Std values of 3 channels.
+        to_rgb (bool): Whether to convert the image from BGR to RGB,
+            default is true.
+    """
+
+    def __init__(self, mean: Sequence, std: Sequence, to_rgb: bool = True):
+        self.mean = np.array(mean, dtype=np.float32)
+        self.std = np.array(std, dtype=np.float32)
+        self.to_rgb = to_rgb
+
+    def __call__(self, results: dict) -> dict:
+        """Call function to normalize images.
+
+        Args:
+            results (dict): Result dict from loading pipeline.
+
+        Returns:
+            dict: Normalized results, 'img_norm_cfg' key is added into
+                result dict.
+        """
+        for key in results.get('img_fields', ['img']):
+            results[key] = mmcv.imnormalize(results[key], self.mean, self.std,
+                                            self.to_rgb)
+        results['img_norm_cfg'] = dict(
+            mean=self.mean, std=self.std, to_rgb=self.to_rgb)
+        return results
+
+    def __repr__(self):
+        repr_str = self.__class__.__name__
+        repr_str += f'(mean={self.mean}, std={self.std}, to_rgb={self.to_rgb})'
+        return repr_str

--- a/tests/test_data/test_pipelines/test_formatting.py
+++ b/tests/test_data/test_pipelines/test_formatting.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 import copy
 import os.path as osp
 

--- a/tests/test_data/test_pipelines/test_formatting.py
+++ b/tests/test_data/test_pipelines/test_formatting.py
@@ -2,8 +2,10 @@ import copy
 import os.path as osp
 
 import numpy as np
+import pytest
 import torch
 
+import mmcv
 from mmcv.datasets import PIPELINES
 
 
@@ -60,3 +62,30 @@ class TestFormatting:
         assert torch.allclose(results['img'], torch.tensor([1, 2]))
         assert isinstance(results['ann']['label'], torch.Tensor)
         assert torch.allclose(results['ann']['label'], torch.tensor([1, 2]))
+
+    def test_image_to_tensor(self):
+        img = mmcv.imread(osp.join(self.data_prefix, 'color.jpg'))
+        transform_cfg = dict(type='ImageToTensor')
+        transform = PIPELINES.build(transform_cfg)
+
+        # test basic function
+        data_info = dict(img=img, img_fields=['img'])
+        results = transform(copy.deepcopy(data_info))
+        assert isinstance(results['img'], torch.Tensor)
+        assert torch.allclose(results['img'],
+                              torch.from_numpy(img).permute([2, 0, 1]))
+
+        # test multi img_fields
+        data_info = dict(img1=img, img2=img, img_fields=['img1', 'img2'])
+        results = transform(copy.deepcopy(data_info))
+        assert isinstance(results['img1'], torch.Tensor)
+        assert torch.allclose(results['img1'],
+                              torch.from_numpy(img).permute([2, 0, 1]))
+        assert isinstance(results['img2'], torch.Tensor)
+        assert torch.allclose(results['img2'],
+                              torch.from_numpy(img).permute([2, 0, 1]))
+
+        # test without img_fields
+        with pytest.raises(AssertionError):
+            data_info = dict(img=img)
+            transform(copy.deepcopy(data_info))

--- a/tests/test_data/test_pipelines/test_formatting.py
+++ b/tests/test_data/test_pipelines/test_formatting.py
@@ -1,0 +1,62 @@
+import copy
+import os.path as osp
+
+import numpy as np
+import torch
+
+from mmcv.datasets import PIPELINES
+
+
+class TestFormatting:
+
+    @classmethod
+    def setup_class(cls):
+        cls.data_prefix = osp.join(osp.dirname(__file__), '../../data')
+
+    def test_to_tensor(self):
+        # test all convert types
+        transform_cfg = dict(type='ToTensor', keys=['label'])
+        transform = PIPELINES.build(transform_cfg)
+        # Tensor
+        data_info = dict(label=torch.tensor([1, 2]))
+        results = transform(copy.deepcopy(data_info))
+        assert isinstance(results['label'], torch.Tensor)
+        assert torch.allclose(results['label'], torch.tensor([1, 2]))
+
+        # np.ndarray
+        data_info = dict(label=np.array([1, 2]).astype(np.float32))
+        results = transform(copy.deepcopy(data_info))
+        assert isinstance(results['label'], torch.Tensor)
+        assert torch.allclose(results['label'], torch.FloatTensor([1., 2.]))
+
+        # int
+        data_info = dict(label=1)
+        results = transform(copy.deepcopy(data_info))
+        assert isinstance(results['label'], torch.LongTensor)
+        assert torch.allclose(results['label'], torch.tensor([1]))
+
+        # float
+        data_info = dict(label=1.)
+        results = transform(copy.deepcopy(data_info))
+        assert isinstance(results['label'], torch.FloatTensor)
+        assert torch.allclose(results['label'], torch.tensor([1.]))
+
+        # tuple or list
+        transform_cfg = dict(type='ToTensor', keys=['label1', 'label2'])
+        transform = PIPELINES.build(transform_cfg)
+        data_info = dict(label1=[1, 2], label2=(1., 2.))
+        results = transform(copy.deepcopy(data_info))
+        assert isinstance(results['label1'], torch.Tensor)
+        assert torch.allclose(results['label1'], torch.tensor([1, 2]))
+        assert isinstance(results['label2'], torch.Tensor)
+        assert torch.allclose(results['label2'], torch.tensor([1., 2.]))
+
+        # test nested keys
+        transform_cfg = dict(type='ToTensor', keys=['img', 'ann.label'])
+        transform = PIPELINES.build(transform_cfg)
+        data_info = dict(img=[1, 2], ann=dict(label=np.array([1, 2])))
+        results = transform(copy.deepcopy(data_info))
+        assert isinstance(results['img'], torch.Tensor)
+        assert torch.allclose(results['img'], torch.tensor([1, 2]))
+        assert isinstance(results['ann']['label'], torch.Tensor)
+        assert torch.allclose(results['ann']['label'], torch.tensor([1, 2]))

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -4,8 +4,8 @@ import os.path as osp
 import numpy as np
 import pytest
 
-import mmcv
 from mmcv.datasets.builder import PIPELINES
+from mmcv.image import imread
 from mmcv.utils import build_from_cfg
 
 
@@ -16,7 +16,7 @@ def test_normalize(to_rgb):
         std=[58.395, 57.12, 57.375],
         to_rgb=to_rgb)
     results = dict()
-    img = mmcv.imread(
+    img = imread(
         osp.join(osp.dirname(__file__), '../../../data/color.jpg'), 'color')
     original_img = copy.deepcopy(img)
     results['img'] = img

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -1,0 +1,37 @@
+import copy
+import os.path as osp
+
+import numpy as np
+
+import mmcv
+from mmcv.datasets.builder import PIPELINES
+from mmcv.utils import build_from_cfg
+
+
+def test_normalize():
+    img_norm_cfg = dict(
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        to_rgb=True)
+    transform_cfg = dict(type='Normalize', **img_norm_cfg)
+    transform = build_from_cfg(transform_cfg, PIPELINES)
+    results = dict()
+    img = mmcv.imread(
+        osp.join(osp.dirname(__file__), '../../../data/color.jpg'), 'color')
+    original_img = copy.deepcopy(img)
+    results['img'] = img
+    results['img2'] = copy.deepcopy(img)
+    results['img_shape'] = img.shape
+    results['ori_shape'] = img.shape
+    # Set initial values for default meta_keys
+    results['pad_shape'] = img.shape
+    results['scale_factor'] = 1.0
+    results['img_fields'] = ['img', 'img2']
+
+    results = transform(results)
+    assert np.equal(results['img'], results['img2']).all()
+
+    mean = np.array(img_norm_cfg['mean'])
+    std = np.array(img_norm_cfg['std'])
+    converted_img = (original_img[..., ::-1] - mean) / std
+    assert np.allclose(results['img'], converted_img)

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -4,9 +4,9 @@ import os.path as osp
 import numpy as np
 import pytest
 
-from mmcv.datasets import PIPELINES
-from mmcv.image import imread
-from mmcv.utils import build_from_cfg
+from mmcv.datasets.builder import PIPELINES
+from mmcv.image.io import imread
+from mmcv.utils.registry import build_from_cfg
 
 
 @pytest.mark.parametrize('to_rgb', [True, False])

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -21,11 +21,6 @@ def test_normalize(to_rgb):
     original_img = copy.deepcopy(img)
     results['img'] = img
     results['img2'] = copy.deepcopy(img)
-    results['img_shape'] = img.shape
-    results['ori_shape'] = img.shape
-    # Set initial values for default meta_keys
-    results['pad_shape'] = img.shape
-    results['scale_factor'] = 1.0
 
     transform_cfg = dict(type='Normalize', **img_norm_cfg)
     transform = build_from_cfg(transform_cfg, PIPELINES)

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -2,19 +2,19 @@ import copy
 import os.path as osp
 
 import numpy as np
+import pytest
 
 import mmcv
 from mmcv.datasets.builder import PIPELINES
 from mmcv.utils import build_from_cfg
 
 
-def test_normalize():
+@pytest.mark.parametrize('to_rgb', [True, False])
+def test_normalize(to_rgb):
     img_norm_cfg = dict(
         mean=[123.675, 116.28, 103.53],
         std=[58.395, 57.12, 57.375],
-        to_rgb=True)
-    transform_cfg = dict(type='Normalize', **img_norm_cfg)
-    transform = build_from_cfg(transform_cfg, PIPELINES)
+        to_rgb=to_rgb)
     results = dict()
     img = mmcv.imread(
         osp.join(osp.dirname(__file__), '../../../data/color.jpg'), 'color')
@@ -26,12 +26,21 @@ def test_normalize():
     # Set initial values for default meta_keys
     results['pad_shape'] = img.shape
     results['scale_factor'] = 1.0
-    results['img_fields'] = ['img', 'img2']
 
+    transform_cfg = dict(type='Normalize', **img_norm_cfg)
+    transform = build_from_cfg(transform_cfg, PIPELINES)
+
+    with pytest.raises(AssertionError):
+        # Required key of results is 'img_fields'
+        results = transform(results)
+
+    results['img_fields'] = ['img', 'img2']
     results = transform(results)
     assert np.equal(results['img'], results['img2']).all()
 
     mean = np.array(img_norm_cfg['mean'])
     std = np.array(img_norm_cfg['std'])
-    converted_img = (original_img[..., ::-1] - mean) / std
+    if to_rgb:
+        original_img = original_img[..., ::-1]
+    converted_img = (original_img - mean) / std
     assert np.allclose(results['img'], converted_img)

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -4,7 +4,7 @@ import os.path as osp
 import numpy as np
 import pytest
 
-from mmcv.datasets.builder import PIPELINES
+from mmcv.datasets import PIPELINES
 from mmcv.image import imread
 from mmcv.utils import build_from_cfg
 


### PR DESCRIPTION
## Motivation

Add `ToTensor` and `ImageToTensor` transforms.

Because both transforms are similar and share the same helper function, merge them into one PR.

Refers to https://github.com/open-mmlab/mmclassification/blob/master/mmcls/datasets/pipelines/formating.py

## Modification

As the title


## Use cases (Optional)
For `ToTensor`:
```python
>>> from mmcv.datasets.pipelines import ToTensor
>>> transform = ToTensor(keys=['img', 'ann.label'])
>>> input_dict = {'img': [1, 2], 'ann': {'label': 1}}
>>> output_dict = transform(input_dict)
>>> print(output_dict)
{'img': tensor([1, 2]), 'ann': {'label': tensor([1])}}
```

For `ImageToTensor`:
```python
>>> import numpy as np
>>> from mmcv.datasets.pipelines import ImageToTensor
>>> transform = ImageToTensor()
>>> input_dict = {'img': np.zeros([16, 16, 3]), 'img_fields': ['img']}
>>> output_dict = transform(input_dict)
>>> print(output_dict['img'].shape)
torch.Size([3, 16, 16])
```

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
