### PR TITLE
Support deprecation info in Config

### DIFF
--- a/docs/understand_mmcv/config.md
+++ b/docs/understand_mmcv/config.md
@@ -177,3 +177,24 @@ item1 = 'a'
 item2 = dict(item3='b')
 item = dict(a='a', b='b')
 ```
+
+### Add deprecation information in configs
+
+Deprecation information can be added into a config file, which will trigger a `UserWarning` when this config file is loaded.
+
+`deprecated_cfg.py`
+
+```python
+_base_ = 'expected_cfg.py'
+
+_deprecation_ = dict(
+    expected = 'expected_cfg.py',  # optional to show expected config path in the warning information
+    reference = 'url to related PR'  # optional to show reference link in the warning information
+)
+```
+
+```python
+>>> cfg = Config.fromfile('./deprecated_cfg.py')
+
+UserWarning: The config file deprecated.py will be deprecated in the future. Please use expected_cfg.py instead. More information can be found at https://github.com/open-mmlab/mmcv/pull/1275
+```

--- a/docs/understand_mmcv/config.md
+++ b/docs/understand_mmcv/config.md
@@ -180,7 +180,7 @@ item = dict(a='a', b='b')
 
 ### Add deprecation information in configs
 
-Deprecation information can be added into a config file, which will trigger a `UserWarning` when this config file is loaded.
+Deprecation information can be added in a config file, which will trigger a `UserWarning` when this config file is loaded.
 
 `deprecated_cfg.py`
 

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -226,6 +226,9 @@ class Config:
             if 'expected' in deprecation_info:
                 warning_msg += f' Please use {deprecation_info["expected"]} ' \
                     'instead.'
+            if 'reference' in deprecation_info:
+                warning_msg += ' More information can be found at ' \
+                    f'{deprecation_info["reference"]}'
             warnings.warn(warning_msg)
 
         cfg_text = filename + '\n'

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -26,6 +26,7 @@ else:
 
 BASE_KEY = '_base_'
 DELETE_KEY = '_delete_'
+DEPRECATION_KEY = '_deprecation_'
 RESERVED_KEYS = ['filename', 'text', 'pretty_text']
 
 
@@ -216,6 +217,16 @@ class Config:
                 cfg_dict = mmcv.load(temp_config_file.name)
             # close temp file
             temp_config_file.close()
+
+        # check deprecation information
+        if DEPRECATION_KEY in cfg_dict:
+            deprecation_info = cfg_dict.pop(DEPRECATION_KEY)
+            warning_msg = f'The config file {filename} will be deprecated ' \
+                'in the future.'
+            if 'expected' in deprecation_info:
+                warning_msg += f' Please use {deprecation_info["expected"]} ' \
+                    'instead.'
+            warnings.warn(warning_msg)
 
         cfg_text = filename + '\n'
         with open(filename, 'r', encoding='utf-8') as f:

--- a/tests/data/config/deprecated.py
+++ b/tests/data/config/deprecated.py
@@ -1,0 +1,3 @@
+_base_ = './expected.py'
+
+_deprecation_ = dict(expected='tests/data/config/expected.py')

--- a/tests/data/config/deprecated.py
+++ b/tests/data/config/deprecated.py
@@ -1,3 +1,5 @@
 _base_ = './expected.py'
 
-_deprecation_ = dict(expected='tests/data/config/expected.py')
+_deprecation_ = dict(
+    expected='tests/data/config/expected.py',
+    reference='https://github.com/open-mmlab/mmcv/pull/1275')

--- a/tests/data/config/deprecated_as_base.py
+++ b/tests/data/config/deprecated_as_base.py
@@ -1,0 +1,1 @@
+_base_ = './deprecated.py'

--- a/tests/data/config/expected.py
+++ b/tests/data/config/expected.py
@@ -1,0 +1,1 @@
+item1 = 'expected'

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -513,3 +513,11 @@ def test_pickle_support():
         pkl_cfg = load(pkl_cfg_filename)
 
     assert pkl_cfg._cfg_dict == cfg._cfg_dict
+
+
+def test_deprecation():
+    deprecated_cfg_files = osp.join(data_path, 'config/deprecated.py')
+    with pytest.warns(UserWarning):
+        cfg = Config.fromfile(deprecated_cfg_files)
+
+    assert cfg.item1 == 'expected'

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -516,8 +516,12 @@ def test_pickle_support():
 
 
 def test_deprecation():
-    deprecated_cfg_files = osp.join(data_path, 'config/deprecated.py')
-    with pytest.warns(UserWarning):
-        cfg = Config.fromfile(deprecated_cfg_files)
+    deprecated_cfg_files = [
+        osp.join(data_path, 'config/deprecated.py'),
+        osp.join(data_path, 'config/deprecated_as_base.py')
+    ]
 
-    assert cfg.item1 == 'expected'
+    for cfg_file in deprecated_cfg_files:
+        with pytest.warns(UserWarning):
+            cfg = Config.fromfile(cfg_file)
+        assert cfg.item1 == 'expected'


### PR DESCRIPTION
## Motivation

Support deprecation information in Config. Users can add a field `_deprecation_` into a config file, which will trigger a deprecation warning during calling `Config.fromfile`. Optionally, the warning information can include a path to the expected config file to replace the deprecated one.

## Modification

- Add deprecation information support in `config.py`
- Add unittest

## Use cases (Optional)

For example, if a config file `old_config.py` has been renamed to `new_config.py`. To avoid bc-breaking, we can create an `old_config.py` file with deprecation information as following:

```python
_base_ = './new_config.py'
_deprecation_ = dict(expected='configs/new_config.py')

```
