### PR TITLE
[Docs] Remove the _static in docs_zh_CN

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -5,3 +5,4 @@ Community
    :maxdepth: 2
 
    community/contributing.md
+   community/pr.md

--- a/docs_zh_CN/_static
+++ b/docs_zh_CN/_static
@@ -1,1 +1,0 @@
-../docs/_static

--- a/docs_zh_CN/community.rst
+++ b/docs_zh_CN/community.rst
@@ -5,3 +5,4 @@
    :maxdepth: 2
 
    community/contributing.md
+   community/pr.md

--- a/docs_zh_CN/community/pr.md
+++ b/docs_zh_CN/community/pr.md
@@ -20,7 +20,7 @@
 1. 获取最新的代码库
     + 当你第一次提 PR 时
         - 复刻 OpenMMLab 原代码库，点击 GitHub 页面右上角的 **Fork** 按钮即可
-        ![avatar](../_static/community/1.png)
+        ![avatar](../../docs/_static/community/1.png)
 
         - 克隆复刻的代码库到本地
             ```bash
@@ -58,13 +58,13 @@
         ```
 
     + 创建一个`拉取请求`
-    ![avatar](../_static/community/2.png)
+    ![avatar](../../docs/_static/community/2.png)
 
     + 修改`拉取请求`信息模板，描述修改原因和修改内容。还可以在 PR 描述中，手动关联到相关的`议题` (issue),（更多细节，请参考[官方文档](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)）。
 
 5. 讨论并评审你的代码
     + 创建`拉取请求`时，可以关联给相关人员进行评审
-    ![avatar](../_static/community/3.png)
+    ![avatar](../../docs/_static/community/3.png)
 
     + 根据评审人员的意见修改代码，并推送修改
 

--- a/docs_zh_CN/conf.py
+++ b/docs_zh_CN/conf.py
@@ -102,7 +102,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ['../docs/_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs_zh_CN/understand_mmcv/data_process.md
+++ b/docs_zh_CN/understand_mmcv/data_process.md
@@ -252,7 +252,7 @@ flow = mmcv.flowread('compressed.jpg', quantize=True, concat_axis=1)
 mmcv.flowshow(flow)
 ```
 
-![progress](../_static/flow_visualization.png)
+![progress](../../docs/_static/flow_visualization.png)
 
 3. 流变换
 
@@ -264,12 +264,12 @@ warpped_img2 = mmcv.flow_warp(img1, flow)
 
 img1 (左) and img2 (右)
 
-![raw images](../_static/flow_raw_images.png)
+![raw images](../../docs/_static/flow_raw_images.png)
 
 光流 (img2 -> img1)
 
-![optical flow](../_static/flow_img2toimg1.png)
+![optical flow](../../docs/_static/flow_img2toimg1.png)
 
 变换后的图像和真实图像的差异
 
-![warpped image](../_static/flow_warp_diff.png)
+![warpped image](../../docs/_static/flow_warp_diff.png)

--- a/mmcv/image/photometric.py
+++ b/mmcv/image/photometric.py
@@ -240,7 +240,7 @@ def auto_contrast(img, cutoff=0):
 
     This function maximize (normalize) image contrast by first removing cutoff
     percent of the lightest and darkest pixels from the histogram and remapping
-     the image so that the darkest pixel becomes black (0), and the lightest
+    the image so that the darkest pixel becomes black (0), and the lightest
     becomes white (255).
 
     Args:

--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -38,7 +38,7 @@ class EvalHook(Hook):
             on the test dataset. e.g., ``bbox_mAP``, ``segm_mAP`` for bbox
             detection and instance segmentation. ``AR@100`` for proposal
             recall. If ``save_best`` is ``auto``, the first key of the returned
-             ``OrderedDict`` result will be used. Default: None.
+            ``OrderedDict`` result will be used. Default: None.
         rule (str | None, optional): Comparison rule for best score. If set to
             None, it will infer a reasonable rule. Keys such as 'acc', 'top'
             .etc will be inferred by 'greater' rule. Keys contain 'loss' will
@@ -361,7 +361,7 @@ class DistEvalHook(EvalHook):
             on the test dataset. e.g., ``bbox_mAP``, ``segm_mAP`` for bbox
             detection and instance segmentation. ``AR@100`` for proposal
             recall. If ``save_best`` is ``auto``, the first key of the returned
-             ``OrderedDict`` result will be used. Default: None.
+            ``OrderedDict`` result will be used. Default: None.
         rule (str | None, optional): Comparison rule for best score. If set to
             None, it will infer a reasonable rule. Keys such as 'acc', 'top'
             .etc will be inferred by 'greater' rule. Keys contain 'loss' will


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Remove the `_static` directory in docs_zh_CN because it is a symbolic link of `mmcv/docs/_static` and a symbolic link can not be shown in Github.

- Before the PR
  https://github.com/open-mmlab/mmcv/blob/v1.3.11/docs_zh_CN/community/pr.md
- After the PR
  https://github.com/zhouzaida/mmcv/blob/fix-docs/docs_zh_CN/community/pr.md
  https://mmcv-pr1277.readthedocs.io/en/latest/community/pr.html


## Modification

- Delete `_static `in docs_zh_CN
- Replace `../_static` with `../../docs/_static`
- Fix sphinx warning like indent error

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
