### PR TITLE
Remove extra dim in cpu mode at scatter

### DIFF
--- a/mmcv/parallel/_functions.py
+++ b/mmcv/parallel/_functions.py
@@ -22,10 +22,6 @@ def scatter(input, devices, streams=None):
         if devices != [-1]:
             with torch.cuda.device(devices[0]), torch.cuda.stream(stream):
                 output = output.cuda(devices[0], non_blocking=True)
-        else:
-            # unsqueeze the first dimension thus the tensor's shape is the
-            # same as those scattered with GPU.
-            output = output.unsqueeze(0)
         return output
     else:
         raise Exception(f'Unknown type {type(input)}.')


### PR DESCRIPTION
## Motivation

Currently the cpu version of scatter will add an extra dim for tensors, which causes problems such as in https://github.com/open-mmlab/mmocr/pull/327

## Modification

Remove the extra dim

## BC-breaking (Optional)

YES

Downstream repos might be affected. Please check mmdet, mmaction2 and mmpose before merge. Please check their tests and also demos in cpu mode.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
