### PR TITLE
[Fix] Fix missing `state_dict._metadata` when saving and loading checkpoints.

### DIFF
--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -520,9 +520,16 @@ def load_checkpoint(model,
         state_dict = checkpoint['state_dict']
     else:
         state_dict = checkpoint
+
     # strip prefix of state_dict
+    metadata = getattr(state_dict, '_metadata', None)
     for p, r in revise_keys:
-        state_dict = {re.sub(p, r, k): v for k, v in state_dict.items()}
+        state_dict = OrderedDict(
+            {re.sub(p, r, k): v
+             for k, v in state_dict.items()})
+    # Keep metadata in state_dict
+    state_dict._metadata = metadata
+
     # load state_dict
     load_state_dict(model, state_dict, strict, logger)
     return checkpoint
@@ -540,6 +547,8 @@ def weights_to_cpu(state_dict):
     state_dict_cpu = OrderedDict()
     for key, val in state_dict.items():
         state_dict_cpu[key] = val.cpu()
+    # Keep metadata in state_dict
+    state_dict_cpu._metadata = getattr(state_dict, '_metadata', dict())
     return state_dict_cpu
 
 

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -522,7 +522,7 @@ def load_checkpoint(model,
         state_dict = checkpoint
 
     # strip prefix of state_dict
-    metadata = getattr(state_dict, '_metadata', None)
+    metadata = getattr(state_dict, '_metadata', OrderedDict())
     for p, r in revise_keys:
         state_dict = OrderedDict(
             {re.sub(p, r, k): v
@@ -548,7 +548,7 @@ def weights_to_cpu(state_dict):
     for key, val in state_dict.items():
         state_dict_cpu[key] = val.cpu()
     # Keep metadata in state_dict
-    state_dict_cpu._metadata = getattr(state_dict, '_metadata', dict())
+    state_dict_cpu._metadata = getattr(state_dict, '_metadata', OrderedDict())
     return state_dict_cpu
 
 

--- a/tests/test_runner/test_checkpoint.py
+++ b/tests/test_runner/test_checkpoint.py
@@ -221,6 +221,77 @@ def test_load_checkpoint():
     os.remove(checkpoint_path)
 
 
+def test_load_checkpoint_metadata():
+    import os
+    import tempfile
+
+    from mmcv.runner import load_checkpoint, save_checkpoint
+
+    class ModelV1(nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.block = Block()
+            self.conv1 = nn.Conv2d(3, 3, 1)
+            self.conv2 = nn.Conv2d(3, 3, 1)
+            nn.init.normal_(self.conv1.weight)
+            nn.init.normal_(self.conv2.weight)
+
+    class ModelV2(nn.Module):
+        _version = 2
+
+        def __init__(self):
+            super().__init__()
+            self.block = Block()
+            self.conv0 = nn.Conv2d(3, 3, 1)
+            self.conv1 = nn.Conv2d(3, 3, 1)
+            nn.init.normal_(self.conv0.weight)
+            nn.init.normal_(self.conv1.weight)
+
+        def _load_from_state_dict(self, state_dict, prefix, local_metadata,
+                                  *args, **kwargs):
+            """load checkpoints."""
+
+            # Names of some parameters in has been changed.
+            version = local_metadata.get('version', None)
+            if version is None or version < 2:
+                state_dict_keys = list(state_dict.keys())
+                for k in state_dict_keys:
+                    convert_map = {'conv1': 'conv0', 'conv2': 'conv1'}
+                    for ori_pattern, convert_pattern in convert_map.items():
+                        if k.startswith(prefix + ori_pattern):
+                            convert_key = k.replace(ori_pattern,
+                                                    convert_pattern)
+                            state_dict[convert_key] = state_dict[k]
+                            del state_dict[k]
+
+            super()._load_from_state_dict(state_dict, prefix, local_metadata,
+                                          *args, **kwargs)
+
+    model_v1 = ModelV1()
+    model_v1_conv0_weight = model_v1.conv1.weight.detach()
+    model_v1_conv1_weight = model_v1.conv2.weight.detach()
+    model_v2 = ModelV2()
+    model_v2_conv0_weight = model_v2.conv0.weight.detach()
+    model_v2_conv1_weight = model_v2.conv1.weight.detach()
+    ckpt_v1_path = os.path.join(tempfile.gettempdir(), 'checkpoint_v1.pth')
+    ckpt_v2_path = os.path.join(tempfile.gettempdir(), 'checkpoint_v2.pth')
+
+    # Save checkpoint
+    save_checkpoint(model_v1, ckpt_v1_path)
+    save_checkpoint(model_v2, ckpt_v2_path)
+
+    # test load v1 model
+    load_checkpoint(model_v2, ckpt_v1_path)
+    assert torch.allclose(model_v2.conv0.weight, model_v1_conv0_weight)
+    assert torch.allclose(model_v2.conv1.weight, model_v1_conv1_weight)
+
+    # test load v2 model
+    load_checkpoint(model_v2, ckpt_v2_path)
+    assert torch.allclose(model_v2.conv0.weight, model_v2_conv0_weight)
+    assert torch.allclose(model_v2.conv1.weight, model_v2_conv1_weight)
+
+
 def test_load_classes_name():
     import os
 

--- a/tests/test_runner/test_checkpoint.py
+++ b/tests/test_runner/test_checkpoint.py
@@ -256,13 +256,12 @@ def test_load_checkpoint_metadata():
             version = local_metadata.get('version', None)
             if version is None or version < 2:
                 state_dict_keys = list(state_dict.keys())
+                convert_map = {'conv1': 'conv0', 'conv2': 'conv1'}
                 for k in state_dict_keys:
-                    convert_map = {'conv1': 'conv0', 'conv2': 'conv1'}
-                    for ori_pattern, convert_pattern in convert_map.items():
-                        if k.startswith(prefix + ori_pattern):
-                            convert_key = k.replace(ori_pattern,
-                                                    convert_pattern)
-                            state_dict[convert_key] = state_dict[k]
+                    for ori_str, new_str in convert_map.items():
+                        if k.startswith(prefix + ori_str):
+                            new_key = k.replace(ori_str, new_str)
+                            state_dict[new_key] = state_dict[k]
                             del state_dict[k]
 
             super()._load_from_state_dict(state_dict, prefix, local_metadata,


### PR DESCRIPTION
## Motivation

PyTorch provides `_version` in `nn.Module` to support backward compatibility. However, because of some modifications in saving & loading in mmcv, when overriding the `_load_from_state_dict` in a module, the `local_metadata` is empty dict now.

## Modification

Modify some code in saving and loading to keep `state_dict._metadata`.

## BC-breaking (Optional)

No, it should be beneficial for backward compatibility, because downstream repos, like `mmdet`, are using these metadata to support old version checkpoints, and this function is not available now.

## Use cases (Optional)

```python
>>> import torch
>>> import torch.nn as nn
>>> from mmcv.runner import save_checkpoint
>>> 
>>> class ModelV2(nn.Module):
...     _version = 2
... 
...     def __init__(self):
...         super().__init__()
...         self.conv = nn.Conv2d(3, 3, 1)
...
>>> save_checkpoint(ModelV2(), 'test.pth')
>>> model = torch.load('test.pth')
>>> print(model['state_dict']._metadata)
OrderedDict([('', {'version': 2}), ('conv', {'version': 1})])
```

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
