### PR TITLE
add iter and epoch info in loggable_tags

### DIFF
--- a/mmcv/runner/hooks/logger/base.py
+++ b/mmcv/runner/hooks/logger/base.py
@@ -126,6 +126,8 @@ class LoggerHook(Hook):
             if add_mode:
                 var = f'{self.get_mode(runner)}/{var}'
             tags[var] = val
+        tags['iter'] = self.get_iter(runner)
+        tags['epoch'] = self.get_epoch(runner)
         tags.update(self.get_lr_tags(runner))
         tags.update(self.get_momentum_tags(runner))
         return tags

--- a/mmcv/runner/hooks/logger/neptune.py
+++ b/mmcv/runner/hooks/logger/neptune.py
@@ -74,7 +74,6 @@ class NeptuneLoggerHook(LoggerHook):
                     self.run[tag_name].log(
                         tag_value, step=self.get_iter(runner))
                 else:
-                    tags['global_step'] = self.get_iter(runner)
                     self.run[tag_name].log(tags)
 
     @master_only

--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -48,7 +48,6 @@ class WandbLoggerHook(LoggerHook):
                 self.wandb.log(
                     tags, step=self.get_iter(runner), commit=self.commit)
             else:
-                tags['global_step'] = self.get_iter(runner)
                 self.wandb.log(tags, commit=self.commit)
 
     @master_only


### PR DESCRIPTION
add iter and epoch info in loggable_tags, so we can remove global steps in wandb and neptune log

## Motivation

 See #1300 

## Modification

add iter and epoch in tags when we call get_loggable_tags func