### PR TITLE
Add case case_sensitive in scandir

### DIFF
--- a/mmcv/utils/path.py
+++ b/mmcv/utils/path.py
@@ -36,7 +36,7 @@ def symlink(src, dst, overwrite=True, **kwargs):
     os.symlink(src, dst, **kwargs)
 
 
-def scandir(dir_path, suffix=None, recursive=False, case_insensitive=False):
+def scandir(dir_path, suffix=None, recursive=False, case_sensitive=True):
     """Scan a directory to find the interested files.
 
     Args:
@@ -59,25 +59,25 @@ def scandir(dir_path, suffix=None, recursive=False, case_insensitive=False):
     if (suffix is not None) and not isinstance(suffix, (str, tuple)):
         raise TypeError('"suffix" must be a string or tuple of strings')
 
-    if suffix is not None and case_insensitive:
+    if suffix is not None and not case_sensitive:
         suffix = suffix.lower() if isinstance(suffix, str) else tuple(
             item.lower() for item in suffix)
 
     root = dir_path
 
-    def _scandir(dir_path, suffix, recursive, case_insensitive):
+    def _scandir(dir_path, suffix, recursive, case_sensitive):
         for entry in os.scandir(dir_path):
             if not entry.name.startswith('.') and entry.is_file():
                 rel_path = osp.relpath(entry.path, root)
-                _rel_path = rel_path.lower() if case_insensitive else rel_path
+                _rel_path = rel_path if case_sensitive else rel_path.lower()
                 if suffix is None or _rel_path.endswith(suffix):
                     yield rel_path
             elif recursive and os.path.isdir(entry.path):
                 # scan recursively if entry.path is a directory
                 yield from _scandir(entry.path, suffix, recursive,
-                                    case_insensitive)
+                                    case_sensitive)
 
-    return _scandir(dir_path, suffix, recursive, case_insensitive)
+    return _scandir(dir_path, suffix, recursive, case_sensitive)
 
 
 def find_vcs_root(path, markers=('.git', )):

--- a/mmcv/utils/path.py
+++ b/mmcv/utils/path.py
@@ -69,8 +69,8 @@ def scandir(dir_path, suffix=None, recursive=False, case_insensitive=False):
         for entry in os.scandir(dir_path):
             if not entry.name.startswith('.') and entry.is_file():
                 rel_path = osp.relpath(entry.path, root)
-                rel_path_ = rel_path.lower() if case_insensitive else rel_path
-                if suffix is None or rel_path_.endswith(suffix):
+                _rel_path = rel_path.lower() if case_insensitive else rel_path
+                if suffix is None or _rel_path.endswith(suffix):
                     yield rel_path
             elif recursive and os.path.isdir(entry.path):
                 # scan recursively if entry.path is a directory

--- a/mmcv/utils/path.py
+++ b/mmcv/utils/path.py
@@ -45,8 +45,8 @@ def scandir(dir_path, suffix=None, recursive=False, case_sensitive=True):
             interested in. Default: None.
         recursive (bool, optional): If set to True, recursively scan the
             directory. Default: False.
-        case_insensitive (bool, optional) : If set to True, ignore the case of
-            suffix. Default: False.
+        case_sensitive (bool, optional) : If set to False, ignore the case of
+            suffix. Default: True.
 
     Returns:
         A generator for all the interested files with relative paths.

--- a/tests/test_utils/test_path.py
+++ b/tests/test_utils/test_path.py
@@ -27,7 +27,7 @@ def test_check_file_exist():
 
 def test_scandir():
     folder = osp.join(osp.dirname(osp.dirname(__file__)), 'data/for_scan')
-    filenames = ['a.bin', '1.txt', '2.txt', '1.json', '2.json']
+    filenames = ['a.bin', '1.txt', '2.txt', '1.json', '2.json', '3.TXT']
     assert set(mmcv.scandir(folder)) == set(filenames)
     assert set(mmcv.scandir(Path(folder))) == set(filenames)
     assert set(mmcv.scandir(folder, '.txt')) == set(
@@ -41,7 +41,7 @@ def test_scandir():
     # path of sep is `\\` in windows but `/` in linux, so osp.join should be
     # used to join string for compatibility
     filenames_recursive = [
-        'a.bin', '1.txt', '2.txt', '1.json', '2.json',
+        'a.bin', '1.txt', '2.txt', '1.json', '2.json', '3.TXT',
         osp.join('sub', '1.json'),
         osp.join('sub', '1.txt'), '.file'
     ]
@@ -54,6 +54,19 @@ def test_scandir():
         filename for filename in filenames_recursive
         if filename.endswith('.txt')
     ])
+    assert set(
+        mmcv.scandir(folder, '.TXT', recursive=True,
+                     case_insensitive=True)) == set([
+                         filename for filename in filenames_recursive
+                         if filename.endswith(('.txt', '.TXT'))
+                     ])
+    assert set(
+        mmcv.scandir(
+            folder, ('.TXT', '.JSON'), recursive=True,
+            case_insensitive=True)) == set([
+                filename for filename in filenames_recursive
+                if filename.endswith(('.txt', '.json', '.TXT'))
+            ])
     with pytest.raises(TypeError):
         list(mmcv.scandir(123))
     with pytest.raises(TypeError):

--- a/tests/test_utils/test_path.py
+++ b/tests/test_utils/test_path.py
@@ -56,14 +56,14 @@ def test_scandir():
     ])
     assert set(
         mmcv.scandir(folder, '.TXT', recursive=True,
-                     case_insensitive=True)) == set([
+                     case_sensitive=False)) == set([
                          filename for filename in filenames_recursive
                          if filename.endswith(('.txt', '.TXT'))
                      ])
     assert set(
         mmcv.scandir(
             folder, ('.TXT', '.JSON'), recursive=True,
-            case_insensitive=True)) == set([
+            case_sensitive=False)) == set([
                 filename for filename in filenames_recursive
                 if filename.endswith(('.txt', '.json', '.TXT'))
             ])


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Some file suffixs are case-insensitive, such as ".JPG" and ".jpg", so add `case_sensitive` option in scandir. Default True, behave as before. 
For example, `scandir(root, suffix='JPG', case_sensitive=False)` can find pictures with  suffix of both ".JPG" and ".jpg" , while`scandir(root, suffix='JPG')` can  only find pictures with suffix of ".JPG" .

## Modification

Add case_sensitive option in scandir. Default True, behave as before.
if set  case_sensitive to False, ignore the case of suffix.


## BC-breaking (Optional)

No.


## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
