### PR TITLE
Fixed logging bug for object detection with validation set

### DIFF
--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -45,8 +45,20 @@ class WandbLoggerHook(LoggerHook):
         tags = self.get_loggable_tags(runner)
         if tags:
             if self.with_step:
+                temp_iter = self.get_iter(runner)
+                #for object detection, the validation is done in 2 steps:
+                #validation Ap metric 
+                #validation Loss
+                # the problem is that they are reported separately to wandb, with the same iter number, so
+                #wandb will ignore the second one (loss) 
+                for key in tags:
+                    if "val/loss" in key: # if currently reporting the loss metric
+                        temp_iter = temp_iter+1 # so the second does not have the same iter number
+                        break
                 self.wandb.log(
-                    tags, step=self.get_iter(runner), commit=self.commit)
+                    tags, step=temp_iter, commit=self.commit)
+
+
             else:
                 tags['global_step'] = self.get_iter(runner)
                 self.wandb.log(tags, commit=self.commit)


### PR DESCRIPTION

## Motivation

for object detection, the validation is done in 2 steps:
- validation bounding box Ap metric 
- validation Loss
the problem is that they are reported *separately* to wandb, with the *same* iter number, so wandb will ignore the second one (loss metric ) (undesired).

## Modification

This fix increment the iter number when reporting validation loss

## BC-breaking (Optional)

My fix might not be the best approach if the user is not using this lib for object detection, but should still work (untested in this case) (I tested only with MMdetection)
