### PR TITLE
add world_size in if clause in load_from_http

### DIFF
--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -278,12 +278,7 @@ def load_from_http(filename, map_location=None, model_dir=None):
         dict or OrderedDict: The loaded checkpoint.
     """
     rank, world_size = get_dist_info()
-    rank = int(os.environ.get('LOCAL_RANK', rank))
-    # If LOCAL_RANK is set before ddp is initialized, the if condition
-    # 'if dist.is_available() and dist.is_initialized()' in get_dist_info will
-    # fail and lead to world_size = 1 while rank > 0 for non-master processes.
-    # Thus, check if either rank == 0 or world_size == 1 here.
-    if rank == 0 or world_size == 1:
+    if rank == 0:
         checkpoint = model_zoo.load_url(
             filename, model_dir=model_dir, map_location=map_location)
     if world_size > 1:

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -279,7 +279,7 @@ def load_from_http(filename, map_location=None, model_dir=None):
     """
     rank, world_size = get_dist_info()
     rank = int(os.environ.get('LOCAL_RANK', rank))
-    if rank == 0:
+    if rank == 0 or world_size == 1:
         checkpoint = model_zoo.load_url(
             filename, model_dir=model_dir, map_location=map_location)
     if world_size > 1:

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -279,6 +279,10 @@ def load_from_http(filename, map_location=None, model_dir=None):
     """
     rank, world_size = get_dist_info()
     rank = int(os.environ.get('LOCAL_RANK', rank))
+    # If LOCAL_RANK is set before ddp is initialized, the if condition
+    # 'if dist.is_available() and dist.is_initialized()' in get_dist_info will
+    # fail and lead to world_size = 1 while rank > 0 for non-master processes.
+    # Thus, check if either rank == 0 or world_size == 1 here.
     if rank == 0 or world_size == 1:
         checkpoint = model_zoo.load_url(
             filename, model_dir=model_dir, map_location=map_location)


### PR DESCRIPTION
## Motivation

I'm using mmcv within another codebase and i have issues with loading a checkpoint from http in multi-GPU setting. 
Specifically i get the error: 

```
File "/mmcv/runner/checkpoint.py", line 290, in load_from_http
return checkpoint
UnboundLocalError: local variable 'checkpoint' referenced before assignment
```

This is because get_dist_info does not correctly get world_size in L280, but rank is correctly inferred via L281. Hence, the variable checkpoint will not be defined on return (rank > 0 but world_size == 1).

## Modification

I can mitigate the problem by modifying this line:
https://github.com/open-mmlab/mmcv/blob/f22c9eb4a409470b7e645f17fa1997fe85e27909/mmcv/runner/checkpoint.py#L282

to 

`if rank == 0 or world_size == 1:`

