### PR TITLE
[Fix] Print a warning log when eval_res is an empty dict

### DIFF
--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -241,7 +241,9 @@ class EvalHook(Hook):
         results = self.test_fn(runner.model, self.dataloader)
         runner.log_buffer.output['eval_iter_num'] = len(self.dataloader)
         key_score = self.evaluate(runner, results)
-        if self.save_best:
+        # the key_score may be `None` so it needs to skip the action to save
+        # the best checkpoint
+        if self.save_best and key_score:
             self._save_ckpt(runner, key_score)
 
     def _should_evaluate(self, runner):
@@ -324,13 +326,21 @@ class EvalHook(Hook):
         eval_res = self.dataloader.dataset.evaluate(
             results, logger=runner.logger, **self.eval_kwargs)
 
-        assert eval_res, '`eval_res` should not be a null dict.'
-
         for name, val in eval_res.items():
             runner.log_buffer.output[name] = val
         runner.log_buffer.ready = True
 
         if self.save_best is not None:
+            # If the performance of model is pool, the `eval_res` may be an
+            # empty dict and it will raise exception when `self.save_best` is
+            # not None. More details at
+            # https://github.com/open-mmlab/mmdetection/issues/6265.
+            if not eval_res:
+                warnings.warn(
+                    'Since `eval_res` is an empty dict, the behavior to save '
+                    'the best checkpoint will be skipped in this evaluation.')
+                return None
+
             if self.key_indicator == 'auto':
                 # infer from eval_results
                 self._init_rule(self.rule, list(eval_res.keys())[0])
@@ -448,6 +458,7 @@ class DistEvalHook(EvalHook):
             print('\n')
             runner.log_buffer.output['eval_iter_num'] = len(self.dataloader)
             key_score = self.evaluate(runner, results)
-
-            if self.save_best:
+            # the key_score may be `None` so it needs to skip the action to
+            # save the best checkpoint
+            if self.save_best and key_score:
                 self._save_ckpt(runner, key_score)

--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -323,6 +323,9 @@ class EvalHook(Hook):
         """
         eval_res = self.dataloader.dataset.evaluate(
             results, logger=runner.logger, **self.eval_kwargs)
+
+        assert eval_res, '`eval_res` should not be a null dict.'
+
         for name, val in eval_res.items():
             runner.log_buffer.output[name] = val
         runner.log_buffer.ready = True

--- a/tests/test_runner/test_eval_hook.py
+++ b/tests/test_runner/test_eval_hook.py
@@ -125,8 +125,9 @@ def test_eval_hook():
         data_loader = DataLoader(test_dataset)
         EvalHook(data_loader, save_best='auto', rule='unsupport')
 
-    with pytest.raises(AssertionError):
-        # eval_res returned by `dataset.evaluate()` should not be a null dict
+    # if eval_res is an empty dict, print a warning information
+    with pytest.warns(UserWarning) as record_warnings:
+
         class _EvalDataset(ExampleDataset):
 
             def evaluate(self, results, logger=None):
@@ -134,10 +135,20 @@ def test_eval_hook():
 
         test_dataset = _EvalDataset()
         data_loader = DataLoader(test_dataset)
-        eval_hook = EvalHook(data_loader)
+        eval_hook = EvalHook(data_loader, save_best='auto')
         runner = _build_epoch_runner()
         runner.register_hook(eval_hook)
         runner.run([data_loader], [('train', 1)], 1)
+    # Since there will be many warnings thrown, we just need to check if the
+    # expected exceptions are thrown
+    expected_message = ('Since `eval_res` is an empty dict, the behavior to '
+                        'save the best checkpoint will be skipped in this '
+                        'evaluation.')
+    for warning in record_warnings:
+        if str(warning.message) == expected_message:
+            break
+    else:
+        assert False
 
     test_dataset = ExampleDataset()
     loader = DataLoader(test_dataset)

--- a/tests/test_runner/test_eval_hook.py
+++ b/tests/test_runner/test_eval_hook.py
@@ -121,9 +121,23 @@ def test_eval_hook():
 
     with pytest.raises(KeyError):
         # rule must be in keys of rule_map
-        test_dataset = Model()
+        test_dataset = ExampleDataset()
         data_loader = DataLoader(test_dataset)
         EvalHook(data_loader, save_best='auto', rule='unsupport')
+
+    with pytest.raises(AssertionError):
+        # eval_res returned by `dataset.evaluate()` should not be a null dict
+        class _EvalDataset(ExampleDataset):
+
+            def evaluate(self, results, logger=None):
+                return {}
+
+        test_dataset = _EvalDataset()
+        data_loader = DataLoader(test_dataset)
+        eval_hook = EvalHook(data_loader)
+        runner = _build_epoch_runner()
+        runner.register_hook(eval_hook)
+        runner.run([data_loader], [('train', 1)], 1)
 
     test_dataset = ExampleDataset()
     loader = DataLoader(test_dataset)
@@ -417,7 +431,7 @@ def test_logger(runner, by_epoch, eval_hook_priority):
 
         path = osp.join(tmpdir, next(scandir(tmpdir, '.json')))
         with open(path) as fr:
-            fr.readline()  # skip first line which is hook_msg
+            fr.readline()  # skip the first line which is `hook_msg`
             train_log = json.loads(fr.readline())
             assert train_log['mode'] == 'train' and 'time' in train_log
             val_log = json.loads(fr.readline())


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Related Issue: https://github.com/open-mmlab/mmdetection/issues/6265

Raise AssertionError when `eval_res` returned by `dataset.evaluate()` is a null `dict` which may occur when training loss is nan.

https://github.com/open-mmlab/mmcv/blob/f22c9eb4a409470b7e645f17fa1997fe85e27909/mmcv/runner/hooks/evaluation.py#L317-L336

## Modification

Add an Assert clause to check whether `eval_res` is a null `dict`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
