### PR TITLE
[Fix] Reduce ms_deformable_attn test memory usage

### DIFF
--- a/tests/test_ops/test_ms_deformable_attn.py
+++ b/tests/test_ops/test_ms_deformable_attn.py
@@ -114,7 +114,7 @@ def test_gradient_numerical(channels,
 
     N, M, _ = 1, 2, 2
     Lq, L, P = 2, 2, 2
-    shapes = torch.as_tensor([(6, 4), (3, 2)], dtype=torch.long).cuda()
+    shapes = torch.as_tensor([(3, 2), (2, 1)], dtype=torch.long).cuda()
     level_start_index = torch.cat((shapes.new_zeros(
         (1, )), shapes.prod(1).cumsum(0)[:-1]))
     S = sum([(H * W).item() for H, W in shapes])


### PR DESCRIPTION

## Motivation

ms_deformable_attn test uses a lot of memory.

## Modification

Use small `shape` input.