### PR TITLE
Fix config parsing error caused by non-ascii characters

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -121,7 +121,7 @@ class Config:
             regexp = r'\{\{\s*' + str(key) + r'\s*\}\}'
             value = value.replace('\\', '/')
             config_file = re.sub(regexp, value, config_file)
-        with open(temp_config_name, 'w') as tmp_config_file:
+        with open(temp_config_name, 'w', encoding='utf-8') as tmp_config_file:
             tmp_config_file.write(config_file)
 
     @staticmethod
@@ -139,7 +139,7 @@ class Config:
             base_var_dict[randstr] = base_var
             regexp = r'\{\{\s*' + BASE_KEY + r'\.' + base_var + r'\s*\}\}'
             config_file = re.sub(regexp, f'"{randstr}"', config_file)
-        with open(temp_config_name, 'w') as tmp_config_file:
+        with open(temp_config_name, 'w', encoding='utf-8') as tmp_config_file:
             tmp_config_file.write(config_file)
         return base_var_dict
 
@@ -353,7 +353,8 @@ class Config:
             warnings.warn(
                 'Please check "file_format", the file format may be .py')
         with tempfile.NamedTemporaryFile(
-                'w', suffix=file_format, delete=False) as temp_file:
+                'w', encoding='utf-8', suffix=file_format,
+                delete=False) as temp_file:
             temp_file.write(cfg_str)
             # on windows, previous implementation cause error
             # see PR 1077 for details
@@ -536,7 +537,7 @@ class Config:
             if file is None:
                 return self.pretty_text
             else:
-                with open(file, 'w') as f:
+                with open(file, 'w', encoding='utf-8') as f:
                     f.write(self.pretty_text)
         else:
             import mmcv


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This PR fixes the issue that config parsing may fail when the config file contains non-ascii characters in some environment.

## Modification

- `utils/config.py`: explicitly set encoding as 'utf-8' when writing to files.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
