### PR TITLE
[Doc] Fix invalid symbols in docstring

### DIFF
--- a/mmcv/ops/correlation.py
+++ b/mmcv/ops/correlation.py
@@ -118,20 +118,20 @@ class Correlation(nn.Module):
 
     There are two batched tensors with shape :math:`(N, C, H, W)`,
     and the correlation output's shape is
-    :math:`(N, \text{max_displacement} \times 2+1,
-    \text{max_displacement} \times 2+1,
+    :math:`(N, \text{max\_displacement} \times 2+1,
+    \text{max\_displacement} \times 2+1,
     H_{out}, W_{out})`
 
     where
 
     .. math::
         H_{out} = \left\lfloor\frac{H_{in}  + 2 \times \text{padding} -
-                \text{dilation} \times (\text{kernel_size} - 1) - 1}
+                \text{dilation} \times (\text{kernel\_size} - 1) - 1}
                 {\text{stride}} + 1\right\rfloor
 
     .. math::
         W_{out} = \left\lfloor\frac{W_{in}  + 2 \times \text{padding} -
-            \text{dilation} \times (\text{kernel_size} - 1) - 1}
+            \text{dilation} \times (\text{kernel\_size} - 1) - 1}
             {\text{stride}} + 1\right\rfloor
 
     the correlation item :math:`(N_i, dy, dx)` is formed by taking the sliding

--- a/mmcv/ops/correlation.py
+++ b/mmcv/ops/correlation.py
@@ -117,22 +117,20 @@ class Correlation(nn.Module):
     This correlation operator works for optical flow correlation computation.
 
     There are two batched tensors with shape :math:`(N, C, H, W)`,
-    and the correlation output's shape is
-    :math:`(N, \text{max\_displacement} \times 2+1,
-    \text{max\_displacement} \times 2+1,
-    H_{out}, W_{out})`
+    and the correlation output's shape is :math:`(N, max\_displacement \times
+    2 + 1, max\_displacement * 2 + 1, H_{out}, W_{out})`
 
     where
 
     .. math::
-        H_{out} = \left\lfloor\frac{H_{in}  + 2 \times \text{padding} -
-                \text{dilation} \times (\text{kernel\_size} - 1) - 1}
-                {\text{stride}} + 1\right\rfloor
+        H_{out} = \left\lfloor\frac{H_{in}  + 2 \times padding -
+            dilation \times (kernel\_size - 1) - 1}
+            {stride} + 1\right\rfloor
 
     .. math::
-        W_{out} = \left\lfloor\frac{W_{in}  + 2 \times \text{padding} -
-            \text{dilation} \times (\text{kernel\_size} - 1) - 1}
-            {\text{stride}} + 1\right\rfloor
+        W_{out} = \left\lfloor\frac{W_{in}  + 2 \times padding - dilation
+            \times (kernel\_size - 1) - 1}
+            {stride} + 1\right\rfloor
 
     the correlation item :math:`(N_i, dy, dx)` is formed by taking the sliding
     window convolution between input1 and shifted input2,
@@ -146,8 +144,8 @@ class Correlation(nn.Module):
     where :math:`\star` is the valid 2d sliding window convolution operator,
     and :math:`\mathcal{S}` means shifting the input features (auto-complete
     zero marginal), and :math:`dx, dy` are shifting distance, :math:`dx, dy \in
-    [-\text{max\_displacement} \times \text{dilation\_patch},
-    \text{max\_displacement} \times \text{dilation\_patch}]`.
+    [-max\_displacement \times dilation\_patch, max\_displacement \times
+    dilation\_patch]`.
 
     Args:
         kernel_size (int): The size of sliding window i.e. local neighborhood

--- a/mmcv/ops/group_points.py
+++ b/mmcv/ops/group_points.py
@@ -71,7 +71,7 @@ class QueryAndGroup(nn.Module):
             center_xyz (Tensor): (B, npoint, 3) coordinates of the centriods.
             features (Tensor): (B, C, N) Descriptors of the features.
 
-        Return:
+        Returns:
             Tensor: (B, 3 + C, npoint, sample_num) Grouped feature.
         """
         # if self.max_radius is None, we will perform kNN instead of ball query
@@ -152,7 +152,7 @@ class GroupAll(nn.Module):
             new_xyz (Tensor): new xyz coordinates of the features.
             features (Tensor): (B, C, N) features to group.
 
-        Return:
+        Returns:
             Tensor: (B, C + 3, 1, N) Grouped feature.
         """
         grouped_xyz = xyz.transpose(1, 2).unsqueeze(2)

--- a/mmcv/ops/group_points.py
+++ b/mmcv/ops/group_points.py
@@ -71,7 +71,7 @@ class QueryAndGroup(nn.Module):
             center_xyz (Tensor): (B, npoint, 3) coordinates of the centriods.
             features (Tensor): (B, C, N) Descriptors of the features.
 
-        Return：
+        Return:
             Tensor: (B, 3 + C, npoint, sample_num) Grouped feature.
         """
         # if self.max_radius is None, we will perform kNN instead of ball query

--- a/mmcv/ops/points_sampler.py
+++ b/mmcv/ops/points_sampler.py
@@ -95,7 +95,7 @@ class PointsSampler(nn.Module):
             points_xyz (Tensor): (B, N, 3) xyz coordinates of the features.
             features (Tensor): (B, C, N) Descriptors of the features.
 
-        Return：
+        Return:
             Tensor: (B, npoint, sample_num) Indices of sampled points.
         """
         indices = []
@@ -166,7 +166,7 @@ class FSSampler(nn.Module):
         super().__init__()
 
     def forward(self, points, features, npoint):
-        """Sampling points with FS_Sampling."""
+        r"""Sampling points with FS\_Sampling."""
         assert features is not None, \
             'feature input to FS_Sampler should not be None'
         ffps_sampler = FFPSSampler()

--- a/mmcv/ops/points_sampler.py
+++ b/mmcv/ops/points_sampler.py
@@ -166,7 +166,7 @@ class FSSampler(nn.Module):
         super().__init__()
 
     def forward(self, points, features, npoint):
-        r"""Sampling points with FS\_Sampling."""
+        """Sampling points with FS_Sampling."""
         assert features is not None, \
             'feature input to FS_Sampler should not be None'
         ffps_sampler = FFPSSampler()

--- a/mmcv/ops/points_sampler.py
+++ b/mmcv/ops/points_sampler.py
@@ -95,7 +95,7 @@ class PointsSampler(nn.Module):
             points_xyz (Tensor): (B, N, 3) xyz coordinates of the features.
             features (Tensor): (B, C, N) Descriptors of the features.
 
-        Return:
+        Returns:
             Tensor: (B, npoint, sample_num) Indices of sampled points.
         """
         indices = []


### PR DESCRIPTION
## Motivation

There exits some invalid symbols in docstring, and raise exception when compiling documents with latex 

## Modification

1. revise the docstring in mmcv/ops/correlation.py
2. revise the docstring in mmcv/ops/group_points.py
3. revise the docstring in mmcv/ops/points_sampler.py

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
