### PR TITLE
[Doc]: Fix deploy doc

### DIFF
--- a/docs/deployment/mmcv_ops_definition.md
+++ b/docs/deployment/mmcv_ops_definition.md
@@ -1,9 +1,9 @@
-# Operator Schemas
+# MMCV Operators
 
 To make custom operators in MMCV more standard, precise definitions of each operator are listed in this document.
 
 <!-- TOC -->
-- [Operator Schemas](#operator-schemas)
+- [MMCV Operators](#mmcv-operators)
   - [MMCVBorderAlign](#mmcvborderalign)
     - [Description](#description)
     - [Parameters](#parameters)

--- a/docs/deployment/mmcv_ops_definition.md
+++ b/docs/deployment/mmcv_ops_definition.md
@@ -1,7 +1,9 @@
-# Definition of custom operators in MMCV
+# Operator Schemas
+
+To make custom operators in MMCV more standard, precise definitions of each operator are listed in this document.
 
 <!-- TOC -->
-- [Definition of custom operators in MMCV](#definition-of-custom-operators-in-mmcv)
+- [Operator Schemas](#operator-schemas)
   - [MMCVBorderAlign](#mmcvborderalign)
     - [Description](#description)
     - [Parameters](#parameters)
@@ -80,25 +82,25 @@
     - [Inputs](#inputs-12)
     - [Outputs](#outputs-12)
     - [Type Constraints](#type-constraints-12)
-- [torch](#torch)
-  - [grid_sampler](#grid_sampler)
+  - [grid_sampler*](#grid_sampler)
     - [Description](#description-13)
     - [Parameters](#parameters-13)
     - [Inputs](#inputs-13)
     - [Outputs](#outputs-13)
     - [Type Constraints](#type-constraints-13)
-  - [cummax](#cummax)
+  - [cummax*](#cummax)
     - [Description](#description-14)
     - [Parameters](#parameters-14)
     - [Inputs](#inputs-14)
     - [Outputs](#outputs-14)
     - [Type Constraints](#type-constraints-14)
-  - [cummin](#cummin)
+  - [cummin*](#cummin)
     - [Description](#description-15)
     - [Parameters](#parameters-15)
     - [Inputs](#inputs-15)
     - [Outputs](#outputs-15)
     - [Type Constraints](#type-constraints-15)
+  - [Reminders](#reminders)
 <!-- TOC -->
 
 ## MMCVBorderAlign
@@ -118,9 +120,9 @@ Read [BorderDet: Border Feature for Dense Object Detection](ttps://arxiv.org/abs
 
 ### Parameters
 
-| Type    | Parameter       | Description                                                    |
-| ------- | --------------- | -------------------------------------------------------------- |
-| `int`   | `pool_size`        | number of positions sampled over the boxes' borders(e.g. top, bottom, left, right). |
+| Type  | Parameter   | Description                                                                         |
+|-------|-------------|-------------------------------------------------------------------------------------|
+| `int` | `pool_size` | number of positions sampled over the boxes' borders(e.g. top, bottom, left, right). |
 
 ### Inputs
 
@@ -152,11 +154,11 @@ Read [CARAFE: Content-Aware ReAssembly of FEatures](https://arxiv.org/abs/1905.0
 
 ### Parameters
 
-| Type    | Parameter       | Description                                                    |
-| ------- | --------------- | -------------------------------------------------------------- |
-| `int`   | `kernel_size`        | reassemble kernel size, should be odd integer|
-| `int`   | `group_size`        | reassemble group size |
-| `float`   | `scale_factor`        | upsample ratio(>=1) |
+| Type    | Parameter      | Description                                   |
+|---------|----------------|-----------------------------------------------|
+| `int`   | `kernel_size`  | reassemble kernel size, should be odd integer |
+| `int`   | `group_size`   | reassemble group size                         |
+| `float` | `scale_factor` | upsample ratio(>=1)                           |
 
 ### Inputs
 
@@ -187,8 +189,7 @@ Read [CCNet: Criss-Cross Attention for SemanticSegmentation](https://arxiv.org/p
 
 ### Parameters
 
-| Type    | Parameter       | Description                                                    |
-| ------- | --------------- | -------------------------------------------------------------- |
+None
 
 ### Inputs
 
@@ -219,8 +220,7 @@ Read [CCNet: Criss-Cross Attention for SemanticSegmentation](https://arxiv.org/p
 
 ### Parameters
 
-| Type    | Parameter       | Description                                                    |
-| ------- | --------------- | -------------------------------------------------------------- |
+None
 
 ### Inputs
 
@@ -251,9 +251,9 @@ Perform CornerPool on `input` features. Read [CornerNet -- Detecting Objects as 
 
 ### Parameters
 
-| Type    | Parameter       | Description                                                      |
-| ------- | --------------- | ---------------------------------------------------------------- |
-| `int`   | `mode`          | corner pool mode, (0: `top`, 1: `bottom`, 2: `left`, 3: `right`) |
+| Type  | Parameter | Description                                                      |
+|-------|-----------|------------------------------------------------------------------|
+| `int` | `mode`    | corner pool mode, (0: `top`, 1: `bottom`, 2: `left`, 3: `right`) |
 
 ### Inputs
 
@@ -283,15 +283,15 @@ Read [Deformable Convolutional Networks](https://arxiv.org/pdf/1703.06211.pdf) f
 
 ### Parameters
 
-| Type           | Parameter          | Description                                                                           |
-| -------------- | ------------------ | ------------------------------------------------------------------------------------- |
-| `list of ints` | `stride`           | The stride of the convolving kernel, (sH, sW). Defaults to `(1, 1)`.                                        |
-| `list of ints` | `padding`          | Paddings on both sides of the input, (padH, padW).  Defaults to `(0, 0)`.                                   |
-| `list of ints` | `dilation`         | The spacing between kernel elements (dH, dW). Defaults to `(1, 1)`.                                      |
-| `int`          | `groups`            | Split input into groups. `input_channel` should be divisible by the number of groups. Defaults to `1`.|
-| `int`          | `deformable_groups` | Groups of deformable offset. Defaults to `1`.                                                         |
-| `int`          | `bias` | Whether to add a learnable bias to the output. `0` stands for `False` and `1` stands for `True`. Defaults to `0`.                                                          |
-| `int`          | `im2col_step` | Groups of deformable offset. Defaults to `32`.                                                         |
+| Type           | Parameter           | Description                                                                                                       |
+|----------------|---------------------|-------------------------------------------------------------------------------------------------------------------|
+| `list of ints` | `stride`            | The stride of the convolving kernel, (sH, sW). Defaults to `(1, 1)`.                                              |
+| `list of ints` | `padding`           | Paddings on both sides of the input, (padH, padW).  Defaults to `(0, 0)`.                                         |
+| `list of ints` | `dilation`          | The spacing between kernel elements (dH, dW). Defaults to `(1, 1)`.                                               |
+| `int`          | `groups`            | Split input into groups. `input_channel` should be divisible by the number of groups. Defaults to `1`.            |
+| `int`          | `deformable_groups` | Groups of deformable offset. Defaults to `1`.                                                                     |
+| `int`          | `bias`              | Whether to add a learnable bias to the output. `0` stands for `False` and `1` stands for `True`. Defaults to `0`. |
+| `int`          | `im2col_step`       | Groups of deformable offset. Defaults to `32`.                                                                    |
 
 ### Inputs
 
@@ -323,11 +323,11 @@ Perform Modulated Deformable Convolution on input feature, read [Deformable Conv
 
 ### Parameters
 
-| Type           | Parameter          | Description                                                                           |
-| -------------- | ------------------ | ------------------------------------------------------------------------------------- |
-| `list of ints` | `stride`           | The stride of the convolving kernel. (sH, sW)                                         |
-| `list of ints` | `padding`          | Paddings on both sides of the input. (padH, padW)                                     |
-| `list of ints` | `dilation`         | The spacing between kernel elements. (dH, dW)                                         |
+| Type           | Parameter           | Description                                                                           |
+|----------------|---------------------|---------------------------------------------------------------------------------------|
+| `list of ints` | `stride`            | The stride of the convolving kernel. (sH, sW)                                         |
+| `list of ints` | `padding`           | Paddings on both sides of the input. (padH, padW)                                     |
+| `list of ints` | `dilation`          | The spacing between kernel elements. (dH, dW)                                         |
 | `int`          | `deformable_groups` | Groups of deformable offset.                                                          |
 | `int`          | `groups`            | Split input into groups. `input_channel` should be divisible by the number of groups. |
 
@@ -365,13 +365,13 @@ Deformable roi pooling layer
 
 ### Parameters
 
-| Type    | Parameter       | Description                                                    |
-| ------- | --------------- | -------------------------------------------------------------- |
+| Type    | Parameter        | Description                                                                                                   |
+|---------|------------------|---------------------------------------------------------------------------------------------------------------|
 | `int`   | `output_height`  | height of output roi                                                                                          |
 | `int`   | `output_width`   | width of output roi                                                                                           |
 | `float` | `spatial_scale`  | used to scale the input boxes                                                                                 |
 | `int`   | `sampling_ratio` | number of input samples to take for each output sample. `0` means to take samples densely for current models. |
-| `float`   | `gamma`        | gamma |
+| `float` | `gamma`          | gamma                                                                                                         |
 
 ### Inputs
 
@@ -404,10 +404,10 @@ Read [Pixel Recurrent Neural Networks](https://arxiv.org/abs/1601.06759) for mor
 
 ### Parameters
 
-| Type    | Parameter       | Description                                                    |
-| ------- | --------------- | -------------------------------------------------------------- |
-| `list of ints` | `stride`           | The stride of the convolving kernel. (sH, sW). **Only support stride=1 in mmcv**                                         |
-| `list of ints` | `padding`          | Paddings on both sides of the input. (padH, padW). Defaults to `(0, 0)`.                                     |
+| Type           | Parameter | Description                                                                      |
+|----------------|-----------|----------------------------------------------------------------------------------|
+| `list of ints` | `stride`  | The stride of the convolving kernel. (sH, sW). **Only support stride=1 in mmcv** |
+| `list of ints` | `padding` | Paddings on both sides of the input. (padH, padW). Defaults to `(0, 0)`.         |
 
 ### Inputs
 
@@ -443,10 +443,10 @@ Read [PSANet: Point-wise Spatial Attention Network for Scene Parsing](https://hs
 
 ### Parameters
 
-| Type    | Parameter       | Description                                                    |
-| ------- | --------------- | -------------------------------------------------------------- |
-| `int`   | `psa_type`        | `0` means collect and `1` means `distribute` |
-| `list of ints`   | `mask_size`        | The size of mask |
+| Type           | Parameter   | Description                                  |
+|----------------|-------------|----------------------------------------------|
+| `int`          | `psa_type`  | `0` means collect and `1` means `distribute` |
+| `list of ints` | `mask_size` | The size of mask                             |
 
 ### Inputs
 
@@ -477,7 +477,7 @@ Note this definition is slightly different with [onnx: NonMaxSuppression](https:
 ### Parameters
 
 | Type    | Parameter                    | Description                                                                                                                          |
-| ------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+|---------|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | `int`   | `center_point_box`           | 0 - the box data is supplied as [y1, x1, y2, x2], 1-the box data is supplied as [x_center, y_center, width, height].                 |
 | `int`   | `max_output_boxes_per_class` | The maximum number of boxes to be selected per batch per class. Default to 0, number of output boxes equal to number of input boxes. |
 | `float` | `iou_threshold`              | The threshold for deciding whether boxes overlap too much with respect to IoU. Value range [0, 1]. Default to 0.                     |
@@ -515,7 +515,7 @@ Perform RoIAlign on output feature, used in bbox_head of most two-stage detector
 ### Parameters
 
 | Type    | Parameter        | Description                                                                                                   |
-| ------- | ---------------- | ------------------------------------------------------------------------------------------------------------- |
+|---------|------------------|---------------------------------------------------------------------------------------------------------------|
 | `int`   | `output_height`  | height of output roi                                                                                          |
 | `int`   | `output_width`   | width of output roi                                                                                           |
 | `float` | `spatial_scale`  | used to scale the input boxes                                                                                 |
@@ -543,7 +543,6 @@ Perform RoIAlign on output feature, used in bbox_head of most two-stage detector
 
 - T:tensor(float32)
 
-
 ## MMCVRoIAlignRotated
 
 ### Description
@@ -552,15 +551,15 @@ Perform RoI align pooling for rotated proposals
 
 ### Parameters
 
-| Type    | Parameter       | Description                                                    |
-| ------- | --------------- | -------------------------------------------------------------- |
+| Type    | Parameter        | Description                                                                                                   |
+|---------|------------------|---------------------------------------------------------------------------------------------------------------|
 | `int`   | `output_height`  | height of output roi                                                                                          |
 | `int`   | `output_width`   | width of output roi                                                                                           |
 | `float` | `spatial_scale`  | used to scale the input boxes                                                                                 |
 | `int`   | `sampling_ratio` | number of input samples to take for each output sample. `0` means to take samples densely for current models. |
 | `str`   | `mode`           | pooling mode in each bin. `avg` or `max`                                                                      |
 | `int`   | `aligned`        | If `aligned=0`, use the legacy implementation in MMDetection. Else, align the results more perfectly.         |
-| `int`   | `clockwise`        | If `aligned=0`, use the legacy implementation in MMDetection. Else, align the results more perfectly.         |
+| `int`   | `clockwise`      | If `aligned=0`, use the legacy implementation in MMDetection. Else, align the results more perfectly.         |
 
 ### Inputs
 
@@ -581,9 +580,7 @@ Perform RoI align pooling for rotated proposals
 
 - T:tensor(float32)
 
-# torch
-
-## grid_sampler
+## grid_sampler*
 
 ### Description
 
@@ -594,7 +591,7 @@ Check [torch.nn.functional.grid_sample](https://pytorch.org/docs/stable/generate
 ### Parameters
 
 | Type  | Parameter            | Description                                                                                                                                                                                                                                                                                     |
-| ----- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `int` | `interpolation_mode` | Interpolation mode to calculate output values. (0: `bilinear` , 1: `nearest`)                                                                                                                                                                                                                   |
 | `int` | `padding_mode`       | Padding mode for outside grid values. (0: `zeros`, 1: `border`, 2: `reflection`)                                                                                                                                                                                                                |
 | `int` | `align_corners`      | If `align_corners=1`, the extrema (`-1` and `1`) are considered as referring to the center points of the input's corner pixels. If `align_corners=0`, they are instead considered as referring to the corner points of the input's corner pixels, making the sampling more resolution agnostic. |
@@ -619,7 +616,7 @@ Check [torch.nn.functional.grid_sample](https://pytorch.org/docs/stable/generate
 
 - T:tensor(float32, Linear)
 
-## cummax
+## cummax*
 
 ### Description
 
@@ -627,9 +624,9 @@ Returns a tuple (`values`, `indices`) where `values` is the cumulative maximum e
 
 ### Parameters
 
-| Type    | Parameter       | Description                                                      |
-| ------- | --------------- | ---------------------------------------------------------------- |
-| `int`   | `dim`           | the dimension to do the operation over                           |
+| Type  | Parameter | Description                            |
+|-------|-----------|----------------------------------------|
+| `int` | `dim`     | the dimension to do the operation over |
 
 ### Inputs
 
@@ -651,7 +648,7 @@ Returns a tuple (`values`, `indices`) where `values` is the cumulative maximum e
 
 - T:tensor(float32)
 
-## cummin
+## cummin*
 
 ### Description
 
@@ -659,9 +656,9 @@ Returns a tuple (`values`, `indices`) where `values` is the cumulative minimum e
 
 ### Parameters
 
-| Type    | Parameter       | Description                                                      |
-| ------- | --------------- | ---------------------------------------------------------------- |
-| `int`   | `dim`           | the dimension to do the operation over                           |
+| Type  | Parameter | Description                            |
+|-------|-----------|----------------------------------------|
+| `int` | `dim`     | the dimension to do the operation over |
 
 ### Inputs
 
@@ -682,3 +679,7 @@ Returns a tuple (`values`, `indices`) where `values` is the cumulative minimum e
 ### Type Constraints
 
 - T:tensor(float32)
+
+## Reminders
+
+- Operators endwith `*` are defined in Torch and are included here for the conversion to ONNX.

--- a/docs/deployment/onnx.md
+++ b/docs/deployment/onnx.md
@@ -1,4 +1,4 @@
-## Introduction of onnx module in MMCV (Experimental)
+## Introduction of onnx module
 
 ### register_extra_symbolics
 
@@ -13,6 +13,10 @@ from mmcv.onnx import register_extra_symbolics
 opset_version = 11
 register_extra_symbolics(opset_version)
 ```
+
+#### Reminder
+
+- *Please note that this feature is experimental and may change fast.*
 
 #### FAQs
 

--- a/docs/deployment/onnx.md
+++ b/docs/deployment/onnx.md
@@ -1,4 +1,4 @@
-## Introduction of onnx module
+## Introduction of mmcv.onnx module
 
 ### register_extra_symbolics
 
@@ -16,7 +16,7 @@ register_extra_symbolics(opset_version)
 
 #### Reminder
 
-- *Please note that this feature is experimental and may change fast.*
+- *Please note that this feature is experimental and may change in the future.*
 
 #### FAQs
 

--- a/docs/deployment/onnxruntime_custom_ops.md
+++ b/docs/deployment/onnxruntime_custom_ops.md
@@ -1,8 +1,8 @@
-## Onnxruntime Custom Ops
+## ONNX Runtime Custom Ops
 
 <!-- TOC -->
 
-- [Onnxruntime Custom Ops](#onnxruntime-custom-ops)
+- [ONNX Runtime Custom Ops](#onnx-runtime-custom-ops)
   - [SoftNMS](#softnms)
     - [Description](#description)
     - [Parameters](#parameters)
@@ -69,7 +69,7 @@ Perform soft NMS on `boxes` with `scores`. Read [Soft-NMS -- Improving Object De
 #### Parameters
 
 | Type    | Parameter       | Description                                                    |
-| ------- | --------------- | -------------------------------------------------------------- |
+|---------|-----------------|----------------------------------------------------------------|
 | `float` | `iou_threshold` | IoU threshold for NMS                                          |
 | `float` | `sigma`         | hyperparameter for gaussian method                             |
 | `float` | `min_score`     | score filter threshold                                         |
@@ -107,7 +107,7 @@ Perform RoIAlign on output feature, used in bbox_head of most two-stage detector
 #### Parameters
 
 | Type    | Parameter        | Description                                                                                                   |
-| ------- | ---------------- | ------------------------------------------------------------------------------------------------------------- |
+|---------|------------------|---------------------------------------------------------------------------------------------------------------|
 | `int`   | `output_height`  | height of output roi                                                                                          |
 | `int`   | `output_width`   | width of output roi                                                                                           |
 | `float` | `spatial_scale`  | used to scale the input boxes                                                                                 |
@@ -144,7 +144,7 @@ Filter out boxes has high IoU overlap with previously selected boxes.
 #### Parameters
 
 | Type    | Parameter       | Description                                                                                                      |
-| ------- | --------------- | ---------------------------------------------------------------------------------------------------------------- |
+|---------|-----------------|------------------------------------------------------------------------------------------------------------------|
 | `float` | `iou_threshold` | The threshold for deciding whether boxes overlap too much with respect to IoU. Value range [0, 1]. Default to 0. |
 | `int`   | `offset`        | 0 or 1, boxes' width or height is (x2 - x1 + offset).                                                            |
 
@@ -177,7 +177,7 @@ Perform sample from `input` with pixel locations from `grid`.
 #### Parameters
 
 | Type  | Parameter            | Description                                                                                                                                                                                                                                                                                     |
-| ----- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-------|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `int` | `interpolation_mode` | Interpolation mode to calculate output values. (0: `bilinear` , 1: `nearest`)                                                                                                                                                                                                                   |
 | `int` | `padding_mode`       | Padding mode for outside grid values. (0: `zeros`, 1: `border`, 2: `reflection`)                                                                                                                                                                                                                |
 | `int` | `align_corners`      | If `align_corners=1`, the extrema (`-1` and `1`) are considered as referring to the center points of the input's corner pixels. If `align_corners=0`, they are instead considered as referring to the corner points of the input's corner pixels, making the sampling more resolution agnostic. |
@@ -211,7 +211,7 @@ Perform CornerPool on `input` features. Read [CornerNet -- Detecting Objects as 
 #### Parameters
 
 | Type  | Parameter | Description                                                      |
-| ----- | --------- | ---------------------------------------------------------------- |
+|-------|-----------|------------------------------------------------------------------|
 | `int` | `mode`    | corner pool mode, (0: `top`, 1: `bottom`, 2: `left`, 3: `right`) |
 
 #### Inputs
@@ -241,7 +241,7 @@ Returns a tuple (`values`, `indices`) where `values` is the cumulative maximum e
 #### Parameters
 
 | Type  | Parameter | Description                            |
-| ----- | --------- | -------------------------------------- |
+|-------|-----------|----------------------------------------|
 | `int` | `dim`     | the dimension to do the operation over |
 
 #### Inputs
@@ -273,7 +273,7 @@ Returns a tuple (`values`, `indices`) where `values` is the cumulative minimum e
 #### Parameters
 
 | Type  | Parameter | Description                            |
-| ----- | --------- | -------------------------------------- |
+|-------|-----------|----------------------------------------|
 | `int` | `dim`     | the dimension to do the operation over |
 
 #### Inputs
@@ -305,7 +305,7 @@ Perform Modulated Deformable Convolution on input feature, read [Deformable Conv
 #### Parameters
 
 | Type           | Parameter           | Description                                                                           |
-| -------------- | ------------------- | ------------------------------------------------------------------------------------- |
+|----------------|---------------------|---------------------------------------------------------------------------------------|
 | `list of ints` | `stride`            | The stride of the convolving kernel. (sH, sW)                                         |
 | `list of ints` | `padding`           | Paddings on both sides of the input. (padH, padW)                                     |
 | `list of ints` | `dilation`          | The spacing between kernel elements. (dH, dW)                                         |
@@ -338,16 +338,16 @@ Perform Modulated Deformable Convolution on input feature, read [Deformable Conv
 
 - T:tensor(float32, Linear)
 
-## MMCVDeformConv2d
+### MMCVDeformConv2d
 
-### Description
+#### Description
 
 Perform Deformable Convolution on input feature, read [Deformable Convolutional Network](https://arxiv.org/abs/1703.06211) for detail.
 
-### Parameters
+#### Parameters
 
 | Type           | Parameter          | Description                                                                                                                       |
-| -------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+|----------------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | `list of ints` | `stride`           | The stride of the convolving kernel. (sH, sW)                                                                                     |
 | `list of ints` | `padding`          | Paddings on both sides of the input. (padH, padW)                                                                                 |
 | `list of ints` | `dilation`         | The spacing between kernel elements. (dH, dW)                                                                                     |
@@ -355,7 +355,7 @@ Perform Deformable Convolution on input feature, read [Deformable Convolutional 
 | `int`          | `group`            | Split input into groups. `input_channel` should be divisible by the number of groups.                                             |
 | `int`          | `im2col_step`      | DeformableConv2d use im2col to compute convolution. im2col_step is used to split input and offset, reduce memory usage of column. |
 
-### Inputs
+#### Inputs
 
 <dl>
 <dt><tt>inputs[0]</tt>: T</dt>
@@ -366,13 +366,13 @@ Perform Deformable Convolution on input feature, read [Deformable Convolutional 
 <dd>Input weight; 4-D tensor of shape (output_channel, input_channel, kH, kW).</dd>
 </dl>
 
-### Outputs
+#### Outputs
 
 <dl>
 <dt><tt>outputs[0]</tt>: T</dt>
 <dd>Output feature; 4-D tensor of shape (N, output_channel, outH, outW).</dd>
 </dl>
 
-### Type Constraints
+#### Type Constraints
 
 - T:tensor(float32, Linear)

--- a/docs/deployment/onnxruntime_op.md
+++ b/docs/deployment/onnxruntime_op.md
@@ -1,4 +1,4 @@
-## Introduction of ONNX Runtime custom ops
+## ONNX Runtime Deployment
 
 ### Introduction of ONNX Runtime
 
@@ -88,7 +88,7 @@ onnx_results = sess.run(None, {'input' : input_data})
 
 #### Reminder
 
-- *Please note that this feature is experimental and may change fast. Strongly suggest users always try with the latest master branch.*
+- *Please note that this feature is experimental and may change in the future. Strongly suggest users always try with the latest master branch.*
 
 - The custom operator is not included in [supported operator list](https://github.com/microsoft/onnxruntime/blob/master/docs/OperatorKernels.md) in ONNX Runtime.
 - The custom operator should be able to be exported to ONNX.

--- a/docs/deployment/onnxruntime_op.md
+++ b/docs/deployment/onnxruntime_op.md
@@ -16,14 +16,14 @@
 ### List of operators for ONNX Runtime supported in MMCV
 
 | Operator                                               | CPU | GPU | MMCV Releases |
-|--------------------------------------------------------|-----|-----|---------------|
-| [SoftNMS](onnxruntime_custom_ops.md#softnms)           | Y   | N   | 1.2.3         |
-| [RoIAlign](onnxruntime_custom_ops.md#roialign)         | Y   | N   | 1.2.5         |
-| [NMS](onnxruntime_custom_ops.md#nms)                   | Y   | N   | 1.2.7         |
-| [grid_sampler](onnxruntime_custom_ops.md#grid_sampler) | Y   | N   | 1.3.1         |
-| [CornerPool](onnxruntime_custom_ops.md#cornerpool)     | Y   | N   | 1.3.4         |
-| [cummax](onnxruntime_custom_ops.md#cummax)             | Y   | N   | 1.3.4        |
-| [cummin](onnxruntime_custom_ops.md#cummin)             | Y   | N   | 1.3.4        |
+|:-------------------------------------------------------|:---:|:---:|:-------------:|
+| [SoftNMS](onnxruntime_custom_ops.md#softnms)           |  Y  |  N  |     1.2.3     |
+| [RoIAlign](onnxruntime_custom_ops.md#roialign)         |  Y  |  N  |     1.2.5     |
+| [NMS](onnxruntime_custom_ops.md#nms)                   |  Y  |  N  |     1.2.7     |
+| [grid_sampler](onnxruntime_custom_ops.md#grid_sampler) |  Y  |  N  |     1.3.1     |
+| [CornerPool](onnxruntime_custom_ops.md#cornerpool)     |  Y  |  N  |     1.3.4     |
+| [cummax](onnxruntime_custom_ops.md#cummax)             |  Y  |  N  |     1.3.4     |
+| [cummin](onnxruntime_custom_ops.md#cummin)             |  Y  |  N  |     1.3.4     |
 
 ### How to build custom operators for ONNX Runtime
 

--- a/docs/deployment/onnxruntime_op.md
+++ b/docs/deployment/onnxruntime_op.md
@@ -1,4 +1,4 @@
-## Custom operators for ONNX Runtime in MMCV
+## ONNX Runtime custom operators
 
 ### Introduction of ONNX Runtime
 
@@ -87,6 +87,8 @@ onnx_results = sess.run(None, {'input' : input_data})
 ### How to add a new custom operator for ONNX Runtime in MMCV
 
 #### Reminder
+
+- *Please note that this feature is experimental and may change fast. Strongly suggest users always try with the latest master branch.*
 
 - The custom operator is not included in [supported operator list](https://github.com/microsoft/onnxruntime/blob/master/docs/OperatorKernels.md) in ONNX Runtime.
 - The custom operator should be able to be exported to ONNX.

--- a/docs/deployment/onnxruntime_op.md
+++ b/docs/deployment/onnxruntime_op.md
@@ -1,4 +1,4 @@
-## ONNX Runtime custom operators
+## Introduction of ONNX Runtime custom ops
 
 ### Introduction of ONNX Runtime
 
@@ -15,15 +15,15 @@
 
 ### List of operators for ONNX Runtime supported in MMCV
 
-|                        Operator                        |  CPU  |  GPU  | MMCV Releases |
-| :----------------------------------------------------: | :---: | :---: | :-----------: |
-|      [SoftNMS](onnxruntime_custom_ops.md#softnms)      |   Y   |   N   |     1.2.3     |
-|     [RoIAlign](onnxruntime_custom_ops.md#roialign)     |   Y   |   N   |     1.2.5     |
-|          [NMS](onnxruntime_custom_ops.md#nms)          |   Y   |   N   |     1.2.7     |
-| [grid_sampler](onnxruntime_custom_ops.md#grid_sampler) |   Y   |   N   |     1.3.1     |
-|   [CornerPool](onnxruntime_custom_ops.md#cornerpool)   |   Y   |   N   |     1.3.4     |
-|       [cummax](onnxruntime_custom_ops.md#cummax)       |   Y   |   N   |    master     |
-|       [cummin](onnxruntime_custom_ops.md#cummin)       |   Y   |   N   |    master     |
+| Operator                                               | CPU | GPU | MMCV Releases |
+|--------------------------------------------------------|-----|-----|---------------|
+| [SoftNMS](onnxruntime_custom_ops.md#softnms)           | Y   | N   | 1.2.3         |
+| [RoIAlign](onnxruntime_custom_ops.md#roialign)         | Y   | N   | 1.2.5         |
+| [NMS](onnxruntime_custom_ops.md#nms)                   | Y   | N   | 1.2.7         |
+| [grid_sampler](onnxruntime_custom_ops.md#grid_sampler) | Y   | N   | 1.3.1         |
+| [CornerPool](onnxruntime_custom_ops.md#cornerpool)     | Y   | N   | 1.3.4         |
+| [cummax](onnxruntime_custom_ops.md#cummax)             | Y   | N   | 1.3.4        |
+| [cummin](onnxruntime_custom_ops.md#cummin)             | Y   | N   | 1.3.4        |
 
 ### How to build custom operators for ONNX Runtime
 

--- a/docs/deployment/tensorrt_plugin.md
+++ b/docs/deployment/tensorrt_plugin.md
@@ -1,8 +1,8 @@
-## TensorRT Plugins
+## Introduction of TensorRT Plugins
 
 <!-- TOC -->
 
-- [TensorRT Plugins](#tensorrt-plugins)
+- [Introduction of TensorRT Plugins](#introduction-of-tensorrt-plugins)
   - [Introduction](#introduction)
   - [List of TensorRT plugins supported in MMCV](#list-of-tensorrt-plugins-supported-in-mmcv)
   - [How to build TensorRT plugins in MMCV](#how-to-build-tensorrt-plugins-in-mmcv)
@@ -24,17 +24,17 @@ To ease the deployment of trained models with custom operators from `mmcv.ops` u
 
 ### List of TensorRT plugins supported in MMCV
 
-|       ONNX Operator       |                                 TensorRT Plugin                                 | MMCV Releases |
-| :-----------------------: | :-----------------------------------------------------------------------------: | :-----------: |
-|       MMCVRoiAlign        |              [MMCVRoiAlign](./tensorrt_custom_ops.md#mmcvroialign)              |     1.2.6     |
-|         ScatterND         |                 [ScatterND](./tensorrt_custom_ops.md#scatternd)                 |     1.2.6     |
-|     NonMaxSuppression     |         [NonMaxSuppression](./tensorrt_custom_ops.md#nonmaxsuppression)         |     1.3.0     |
-|     MMCVDeformConv2d      |          [MMCVDeformConv2d](./tensorrt_custom_ops.md#mmcvdeformconv2d)          |     1.3.0     |
-|       grid_sampler        |              [grid_sampler](./tensorrt_custom_ops.md#grid-sampler)              |     1.3.1     |
-|          cummax           |                    [cummax](./tensorrt_custom_ops.md#cummax)                    |     1.3.5     |
-|          cummin           |                    [cummin](./tensorrt_custom_ops.md#cummin)                    |     1.3.5     |
-| MMCVInstanceNormalization | [MMCVInstanceNormalization](./tensorrt_custom_ops.md#mmcvinstancenormalization) |     1.3.5     |
-| MMCVModulatedDeformConv2d | [MMCVModulatedDeformConv2d](./tensorrt_custom_ops.md#mmcvmodulateddeformconv2d) |    master     |
+| ONNX Operator             | TensorRT Plugin                                                                 | MMCV Releases |
+|---------------------------|---------------------------------------------------------------------------------|---------------|
+| MMCVRoiAlign              | [MMCVRoiAlign](./tensorrt_custom_ops.md#mmcvroialign)                           | 1.2.6         |
+| ScatterND                 | [ScatterND](./tensorrt_custom_ops.md#scatternd)                                 | 1.2.6         |
+| NonMaxSuppression         | [NonMaxSuppression](./tensorrt_custom_ops.md#nonmaxsuppression)                 | 1.3.0         |
+| MMCVDeformConv2d          | [MMCVDeformConv2d](./tensorrt_custom_ops.md#mmcvdeformconv2d)                   | 1.3.0         |
+| grid_sampler              | [grid_sampler](./tensorrt_custom_ops.md#grid-sampler)                           | 1.3.1         |
+| cummax                    | [cummax](./tensorrt_custom_ops.md#cummax)                                       | 1.3.5         |
+| cummin                    | [cummin](./tensorrt_custom_ops.md#cummin)                                       | 1.3.5         |
+| MMCVInstanceNormalization | [MMCVInstanceNormalization](./tensorrt_custom_ops.md#mmcvinstancenormalization) | 1.3.5         |
+| MMCVModulatedDeformConv2d | [MMCVModulatedDeformConv2d](./tensorrt_custom_ops.md#mmcvmodulateddeformconv2d) | 1.3.8         |
 
 Notes
 

--- a/docs/deployment/tensorrt_plugin.md
+++ b/docs/deployment/tensorrt_plugin.md
@@ -1,8 +1,8 @@
-## Introduction of TensorRT Plugins
+## TensorRT Deployment
 
 <!-- TOC -->
 
-- [Introduction of TensorRT Plugins](#introduction-of-tensorrt-plugins)
+- [TensorRT Deployment](#tensorrt-deployment)
   - [Introduction](#introduction)
   - [List of TensorRT plugins supported in MMCV](#list-of-tensorrt-plugins-supported-in-mmcv)
   - [How to build TensorRT plugins in MMCV](#how-to-build-tensorrt-plugins-in-mmcv)
@@ -163,7 +163,7 @@ Below are the main steps:
 
 #### Reminders
 
-- *Please note that this feature is experimental and may change fast. Strongly suggest users always try with the latest master branch.*
+- *Please note that this feature is experimental and may change in the future. Strongly suggest users always try with the latest master branch.*
 
 - Some of the [custom ops](https://mmcv.readthedocs.io/en/latest/ops.html) in `mmcv` have their cuda implementations, which could be referred.
 

--- a/docs/deployment/tensorrt_plugin.md
+++ b/docs/deployment/tensorrt_plugin.md
@@ -1,8 +1,8 @@
-## TensorRT Plugins for custom operators in MMCV (Experimental)
+## TensorRT Plugins
 
 <!-- TOC -->
 
-- [TensorRT Plugins for custom operators in MMCV (Experimental)](#tensorrt-plugins-for-custom-operators-in-mmcv-experimental)
+- [TensorRT Plugins](#tensorrt-plugins)
   - [Introduction](#introduction)
   - [List of TensorRT plugins supported in MMCV](#list-of-tensorrt-plugins-supported-in-mmcv)
   - [How to build TensorRT plugins in MMCV](#how-to-build-tensorrt-plugins-in-mmcv)
@@ -162,6 +162,8 @@ Below are the main steps:
    Check [here](https://github.com/open-mmlab/mmcv/blob/master/tests/test_ops/test_tensorrt.py) for examples.
 
 #### Reminders
+
+- *Please note that this feature is experimental and may change fast. Strongly suggest users always try with the latest master branch.*
 
 - Some of the [custom ops](https://mmcv.readthedocs.io/en/latest/ops.html) in `mmcv` have their cuda implementations, which could be referred.
 

--- a/docs/deployment/tensorrt_plugin.md
+++ b/docs/deployment/tensorrt_plugin.md
@@ -25,16 +25,16 @@ To ease the deployment of trained models with custom operators from `mmcv.ops` u
 ### List of TensorRT plugins supported in MMCV
 
 | ONNX Operator             | TensorRT Plugin                                                                 | MMCV Releases |
-|---------------------------|---------------------------------------------------------------------------------|---------------|
-| MMCVRoiAlign              | [MMCVRoiAlign](./tensorrt_custom_ops.md#mmcvroialign)                           | 1.2.6         |
-| ScatterND                 | [ScatterND](./tensorrt_custom_ops.md#scatternd)                                 | 1.2.6         |
-| NonMaxSuppression         | [NonMaxSuppression](./tensorrt_custom_ops.md#nonmaxsuppression)                 | 1.3.0         |
-| MMCVDeformConv2d          | [MMCVDeformConv2d](./tensorrt_custom_ops.md#mmcvdeformconv2d)                   | 1.3.0         |
-| grid_sampler              | [grid_sampler](./tensorrt_custom_ops.md#grid-sampler)                           | 1.3.1         |
-| cummax                    | [cummax](./tensorrt_custom_ops.md#cummax)                                       | 1.3.5         |
-| cummin                    | [cummin](./tensorrt_custom_ops.md#cummin)                                       | 1.3.5         |
-| MMCVInstanceNormalization | [MMCVInstanceNormalization](./tensorrt_custom_ops.md#mmcvinstancenormalization) | 1.3.5         |
-| MMCVModulatedDeformConv2d | [MMCVModulatedDeformConv2d](./tensorrt_custom_ops.md#mmcvmodulateddeformconv2d) | 1.3.8         |
+|:--------------------------|:--------------------------------------------------------------------------------|:-------------:|
+| MMCVRoiAlign              | [MMCVRoiAlign](./tensorrt_custom_ops.md#mmcvroialign)                           |     1.2.6     |
+| ScatterND                 | [ScatterND](./tensorrt_custom_ops.md#scatternd)                                 |     1.2.6     |
+| NonMaxSuppression         | [NonMaxSuppression](./tensorrt_custom_ops.md#nonmaxsuppression)                 |     1.3.0     |
+| MMCVDeformConv2d          | [MMCVDeformConv2d](./tensorrt_custom_ops.md#mmcvdeformconv2d)                   |     1.3.0     |
+| grid_sampler              | [grid_sampler](./tensorrt_custom_ops.md#grid-sampler)                           |     1.3.1     |
+| cummax                    | [cummax](./tensorrt_custom_ops.md#cummax)                                       |     1.3.5     |
+| cummin                    | [cummin](./tensorrt_custom_ops.md#cummin)                                       |     1.3.5     |
+| MMCVInstanceNormalization | [MMCVInstanceNormalization](./tensorrt_custom_ops.md#mmcvinstancenormalization) |     1.3.5     |
+| MMCVModulatedDeformConv2d | [MMCVModulatedDeformConv2d](./tensorrt_custom_ops.md#mmcvmodulateddeformconv2d) |     1.3.8     |
 
 Notes
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,8 +31,8 @@ You can switch between Chinese and English documents in the lower-left corner of
 
    deployment/onnx.md
    deployment/onnxruntime_op.md
-   deployment/onnxruntime_custom_ops.md
    deployment/tensorrt_plugin.md
+   deployment/onnxruntime_custom_ops.md
    deployment/tensorrt_custom_ops.md
    deployment/mmcv_ops_definition.md
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,12 +29,10 @@ You can switch between Chinese and English documents in the lower-left corner of
    :maxdepth: 2
    :caption: Deployment
 
+   deployment/mmcv_ops_definition.md
    deployment/onnx.md
    deployment/onnxruntime_op.md
    deployment/tensorrt_plugin.md
-   deployment/onnxruntime_custom_ops.md
-   deployment/tensorrt_custom_ops.md
-   deployment/mmcv_ops_definition.md
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Motivation

Origanization of documents for deployment in mmcv is a bit mess, could refer to [readthedocs](https://mmcv.readthedocs.io/en/latest/)


![1](https://user-images.githubusercontent.com/28671653/142816842-4d40470f-9c69-4ebe-81aa-3063a3d890a9.png)

## Modification

Reorganize docs in deployment and fix some bad formats.

![3](https://user-images.githubusercontent.com/28671653/143390732-c8119a8b-1431-455d-a2ee-aa020aa00362.png)

## BC-breaking (Optional)

None
