### PR TITLE
[Fix] Fix build with cuda9.0

### DIFF
--- a/mmcv/ops/csrc/common/cuda/correlation_cuda.cuh
+++ b/mmcv/ops/csrc/common/cuda/correlation_cuda.cuh
@@ -14,7 +14,7 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <torch/extension.h>
+#include <torch/types.h>
 
 #include <iostream>
 #include <vector>

--- a/mmcv/ops/csrc/common/cuda/correlation_cuda.cuh
+++ b/mmcv/ops/csrc/common/cuda/correlation_cuda.cuh
@@ -14,6 +14,10 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
+// Using <torch/extension.h> is recommended in the official documentation in
+// https://pytorch.org/tutorials/advanced/cpp_extension.html#writing-the-c-op.
+// However, we use <torch/types.h> for compatibility with CUDA 9.0
+// Read https://github.com/pytorch/extension-cpp/issues/35 for more details.
 #include <torch/types.h>
 
 #include <iostream>

--- a/mmcv/ops/csrc/common/pytorch_device_registry.hpp
+++ b/mmcv/ops/csrc/common/pytorch_device_registry.hpp
@@ -1,6 +1,10 @@
 #ifndef PYTORCH_DEVICE_REGISTRY_H
 #define PYTORCH_DEVICE_REGISTRY_H
 
+// Using <torch/extension.h> is recommended in the official documentation in
+// https://pytorch.org/tutorials/advanced/cpp_extension.html#writing-the-c-op.
+// However, we use <torch/types.h> for compatibility with CUDA 9.0
+// Read https://github.com/pytorch/extension-cpp/issues/35 for more details.
 #include <torch/types.h>
 
 #include <cassert>

--- a/mmcv/ops/csrc/common/pytorch_device_registry.hpp
+++ b/mmcv/ops/csrc/common/pytorch_device_registry.hpp
@@ -1,7 +1,7 @@
 #ifndef PYTORCH_DEVICE_REGISTRY_H
 #define PYTORCH_DEVICE_REGISTRY_H
 
-#include <torch/extension.h>
+#include <torch/types.h>
 
 #include <cassert>
 #include <functional>


### PR DESCRIPTION

## Motivation

Can not build mmcv-full with cuda9.0.

Reference
https://github.com/pytorch/extension-cpp/issues/35

## Modification

Replace `torch/extension.h` with `torch/types.h`
