### PR TITLE
[Fix] Fix compiled error on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -227,10 +227,10 @@ def get_extensions():
 
         # Before PyTorch1.8.0, when compiling CUDA code, `cxx` is a
         # required key passed to PyTorch. Even if there is no flag passed
-        # to cxx, user also need to pass an empty list to PyTorch.
-        # Since PyTorch1.8.0, it has a default value so user do no need
+        # to cxx, users also need to pass an empty list to PyTorch.
+        # Since PyTorch1.8.0, it has a default value so users do not need
         # to pass an empty list anymore.
-        # More datails at https://github.com/pytorch/pytorch/pull/45956
+        # More details at https://github.com/pytorch/pytorch/pull/45956
         extra_compile_args = {'cxx': []}
 
         # Since the PR (https://github.com/open-mmlab/mmcv/pull/1463) uses

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,15 @@ def get_extensions():
 
         os.environ.setdefault('MAX_JOBS', str(cpu_use))
         define_macros = []
-        extra_compile_args = {}
+
+        # Before PyTorch1.8.0, when compiling CUDA code, `cxx` is a
+        # required key passed to PyTorch. Even if there is no flag passed
+        # to cxx, user also need to pass an empty list to PyTorch.
+        # Since PyTorch1.8.0, it has a default value so user do no need
+        # to pass an empty list anymore.
+        # More datails at https://github.com/pytorch/pytorch/pull/45956
+        extra_compile_args = {'cxx': []}
+
         # Since the PR (https://github.com/open-mmlab/mmcv/pull/1463) uses
         # c++14 features, the argument ['std=c++14'] must be added here.
         # However, in the windows environment, some standard libraries


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix compiled error on windows when the version of PyTorch is less than 1.8.0.

Before PyTorch1.8.0, when compiling CUDA code, `cxx` is a required key passed to PyTorch. Even if there is no flag passed
to cxx, the user also needs to pass an empty list to PyTorch. Since PyTorch1.8.0, it has a default value so users do not need
to pass an empty list anymore. More details at https://github.com/pytorch/pytorch/pull/45956.

## Modification

setup.py

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
