### PR TITLE
[Feature] Add aws s3 file backend to FileClient

### DIFF
--- a/mmcv/fileio/file_client.py
+++ b/mmcv/fileio/file_client.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import inspect
+import io
 import os
 import os.path as osp
 import re
@@ -410,6 +411,375 @@ class PetrelBackend(BaseStorageBackend):
                                  recursive)
 
 
+class AWSBackend(BaseStorageBackend):
+    """AWSBackend is Amazon Simple Storage Service(s3).
+
+    AWSBackend supports reading and writing data to aws s3.
+    It relies on awscli and boto3, you must install and run ``aws configure``
+    in advance to use it.
+
+    Args:
+        path_mapping (dict, optional): Path mapping dict from local path to
+            Petrel path. When ``path_mapping={'src': 'dst'}``, ``src`` in
+            ``filepath`` will be replaced by ``dst``. Default: None.
+
+    Examples:
+        >>> filepath = 's3://bucket/obj'
+        >>> client = AWSBackend()
+        >>> client.get(filepath1)  # get data from aws s3
+        >>> client.put(obj, filepath)
+    """
+
+    def __init__(self, path_mapping: Optional[dict] = None):
+        try:
+            import boto3
+            from botocore.exceptions import ClientError
+        except ImportError:
+            raise ImportError('Please install boto3 to enable AWSBackend.')
+
+        self._client = boto3.client('s3')
+        assert isinstance(path_mapping, dict) or path_mapping is None
+        self.path_mapping = path_mapping
+        # Use to parse bucket and obj_name
+        self.parse_bucket = re.compile('s3://(.+?)/(.+)')
+        self.check_exception = ClientError
+
+    def _map_path(self, filepath: Union[str, Path]) -> str:
+        """Map ``filepath`` to a string path whose prefix will be replaced by
+        :attr:`self.path_mapping`.
+
+        Args:
+            filepath (str): Path to be mapped.
+        """
+        filepath = str(filepath)
+        if self.path_mapping is not None:
+            for k, v in self.path_mapping.items():
+                filepath = filepath.replace(k, v)
+        return filepath
+
+    def _format_path(self, filepath: str) -> str:
+        """Convert a ``filepath`` to standard format of aws s3.
+
+        If the ``filepath`` is concatenated by ``os.path.join``, in a Windows
+        environment, the ``filepath`` will be the format of
+        's3://bucket_name\\image.jpg'. By invoking :meth:`_format_path`, the
+        above ``filepath`` will be converted to 's3://bucket_name/image.jpg'.
+
+        Args:
+            filepath (str): Path to be formatted.
+        """
+        return re.sub(r'\\+', '/', filepath)
+
+    def _parse_path(self, filepath: str) -> Tuple[str, str]:
+        """Parse bucket and object name from a given ``filepath``.
+
+        Args:
+            filepath (str or Path): Path to read data.
+
+        Returns:
+            bucket (str): Bucket name of aws s3.
+            obj_name (str): Object relative path to bucket.
+        """
+        filepath = self._map_path(filepath)
+        filepath = self._format_path(filepath)
+        parse_res = self.parse_bucket.findall(filepath)
+        if not parse_res:
+            raise ValueError(
+                f"The input path '{filepath}' format is incorrect.")
+        bucket, obj_name = parse_res[0]
+        return bucket, obj_name
+
+    def _check_bucket(self, bucket: str) -> bool:
+        """Check if bucket exists.
+
+        Args:
+            bucket (str): Bucket name
+
+        Returns:
+            bool: True if bucket is existing.
+        """
+        try:
+            self._client.head_bucket(Bucket=bucket)
+            return True
+        except self.check_exception:
+            return False
+
+    def _check_object(self, bucket: str, obj_name: str) -> bool:
+        """Check if object exists.
+
+        Args:
+            bucket (str): Bucket name
+            obj_name (str): Object name
+
+        Returns:
+            bool: True if object is existing.
+        """
+        try:
+            self._client.head_object(Bucket=bucket, Key=obj_name)
+            return True
+        except self.check_exception:
+            return False
+
+    def get(self, filepath: Union[str, Path]) -> memoryview:
+        """Read data from a given ``filepath`` with 'rb' mode.
+
+        Args:
+            filepath (str or Path): Path to read data.
+
+        Returns:
+            memoryview: A memory view of expected bytes object to avoid
+                copying. The memoryview object can be converted to bytes by
+                ``value_buf.tobytes()``.
+        """
+        bucket, obj_name = self._parse_path(filepath)
+        value = io.BytesIO()
+        self._client.download_fileobj(bucket, obj_name, value)
+        value_buf = memoryview(value.getvalue())
+        return value_buf
+
+    def get_text(self,
+                 filepath: Union[str, Path],
+                 encoding: str = 'utf-8') -> str:
+        """Read data from a given ``filepath`` with 'r' mode.
+
+        Args:
+            filepath (str or Path): Path to read data.
+            encoding (str): The encoding format used to open the ``filepath``.
+                Default: 'utf-8'.
+
+        Returns:
+            str: Expected text reading from ``filepath``.
+        """
+        return str(self.get(filepath), encoding=encoding)
+
+    def put(self, obj: bytes, filepath: Union[str, Path]) -> None:
+        """Save data to a given ``filepath``.
+
+        Args:
+            obj (bytes): Data to be saved.
+            filepath (str or Path): Path to write data.
+        """
+        bucket, obj_name = self._parse_path(filepath)
+        if not self._check_bucket(bucket):
+            raise ValueError(f"This bucket '{bucket}' is not found.")
+        with io.BytesIO(obj) as buff:
+            self._client.upload_fileobj(buff, bucket, obj_name)
+
+    def put_text(self,
+                 obj: str,
+                 filepath: Union[str, Path],
+                 encoding: str = 'utf-8') -> None:
+        """Save data to a given ``filepath``.
+
+        Args:
+            obj (str): Data to be written.
+            filepath (str or Path): Path to write data.
+            encoding (str): The encoding format used to encode the ``obj``.
+                Default: 'utf-8'.
+        """
+        self.put(bytes(obj, encoding=encoding), filepath)
+
+    def remove(self, filepath: Union[str, Path]) -> None:
+        """Remove a file from aws s3.
+
+        Args:
+            filepath (str or Path): Path to be removed.
+        """
+        bucket, obj_name = self._parse_path(filepath)
+        self._client.delete_object(Bucket=bucket, Key=obj_name)
+
+    def exists(self, filepath: Union[str, Path]) -> bool:
+        """Check whether a file path exists.
+
+        Args:
+            filepath (str or Path): Path to be checked whether exists.
+
+        Returns:
+            bool: Return ``True`` if ``filepath`` exists, ``False`` otherwise.
+        """
+        bucket, obj_name = self._parse_path(filepath)
+        return self._check_object(bucket, obj_name)
+
+    def isdir(self, filepath: Union[str, Path]) -> bool:
+        """Check whether a file path is a directory.
+
+        Args:
+            filepath (str or Path): Path to be checked whether it is a
+                directory.
+
+        Returns:
+            bool: Return ``True`` if ``filepath`` points to a directory,
+                ``False`` otherwise.
+        """
+        bucket, obj_name = self._parse_path(filepath)
+        if obj_name.endswith('/') and self._check_object(bucket, obj_name):
+            return True
+        return False
+
+    def isfile(self, filepath: Union[str, Path]) -> bool:
+        """Check whether a file path is a file.
+
+        Args:
+            filepath (str or Path): Path to be checked whether it is a file.
+
+        Returns:
+            bool: Return ``True`` if ``filepath`` points to a file, ``False``
+                otherwise.
+        """
+        bucket, obj_name = self._parse_path(filepath)
+        if not obj_name.endswith('/') and self._check_object(bucket, obj_name):
+            return True
+        return False
+
+    def join_path(self, filepath: Union[str, Path],
+                  *filepaths: Union[str, Path]) -> str:
+        """Concatenate all file paths.
+
+        Args:
+            filepath (str or Path): Path to be concatenated.
+
+        Returns:
+            str: The result after concatenation.
+        """
+        filepath = self._format_path(self._map_path(filepath))
+        if filepath.endswith('/'):
+            filepath = filepath[:-1]
+        formatted_paths = [filepath]
+        for path in filepaths:
+            formatted_paths.append(self._format_path(self._map_path(path)))
+        return '/'.join(formatted_paths)
+
+    @contextmanager
+    def get_local_path(self, filepath: Union[str, Path]) -> Iterable[str]:
+        """Download a file from ``filepath`` and return a temporary path.
+
+        ``get_local_path`` is decorated by :meth:`contxtlib.contextmanager`. It
+        can be called with ``with`` statement, and when exists from the
+        ``with`` statement, the temporary path will be released.
+
+        Args:
+            filepath (str | Path): Download a file from ``filepath``.
+
+        Examples:
+            >>> client = AWSBackend()
+            >>> # After existing from the ``with`` clause,
+            >>> # the path will be removed
+            >>> with client.get_local_path('s3://path/of/your/file') as path:
+            ...     # do something here
+
+        Yields:
+            Iterable[str]: Only yield one temporary path.
+        """
+        assert self.isfile(filepath)
+        try:
+            f = tempfile.NamedTemporaryFile(delete=False)
+            f.write(self.get(filepath))
+            f.close()
+            yield f.name
+        finally:
+            os.remove(f.name)
+
+    def list_dir_or_file(self,
+                         dir_path: Union[str, Path],
+                         list_dir: bool = True,
+                         list_file: bool = True,
+                         suffix: Optional[Union[str, Tuple[str]]] = None,
+                         recursive: bool = False,
+                         maxnum: int = 1000) -> Iterator[str]:
+        """Scan a directory to find the interested directories or files in
+        arbitrary order.
+
+        Note:
+            AWS s3 has no concept of directories but it simulates the directory
+            hierarchy in the filesystem through public prefixes. In addition,
+            if the returned path ends with '/', it means the path is a public
+            prefix which is a logical directory.
+
+        Note:
+            :meth:`list_dir_or_file` returns the path relative to ``dir_path``.
+            In addition, the returned path of directory will not contains the
+            suffix '/' which is consistent with other backends.
+
+        Args:
+            dir_path (str | Path): Path of the directory.
+            list_dir (bool): List the directories. Default: True.
+            list_file (bool): List the path of files. Default: True.
+            suffix (str or tuple[str], optional):  File suffix
+                that we are interested in. Default: None.
+            recursive (bool): If set to True, recursively scan the
+                directory. Default: False.
+            maxnum (int): The maximum number of list. Default: 1000.
+
+        Yields:
+            Iterable[str]: A relative path to ``dir_path``.
+        """
+        if list_dir and suffix is not None:
+            raise TypeError(
+                '`list_dir` should be False when `suffix` is not None')
+
+        if (suffix is not None) and not isinstance(suffix, (str, tuple)):
+            raise TypeError('`suffix` must be a string or tuple of strings')
+
+        dir_path = self._map_path(dir_path)
+        dir_path = self._format_path(dir_path)
+        # If dir_path not contain object name, use the ``_parse_path`` method
+        # will cause an error. eg. dir_path = 's3://bucket'
+        res = re.findall('s3://(.+)', dir_path)
+        if not res:
+            raise ValueError(
+                f"The input dir_path '{dir_path}' format is error")
+        dir_path = res[0]
+        split_dir_path = dir_path.split('/')
+        bucket = split_dir_path[0]
+        dir_path = '/'.join(
+            split_dir_path[1:]) if len(split_dir_path) > 1 else ''
+        # AWS s3's simulated directory hierarchy assumes that directory paths
+        # should end with `/` if it not equal to ''.
+        if dir_path and not dir_path.endswith('/'):
+            dir_path += '/'
+
+        root = dir_path
+
+        def _list_dir_or_file(dir_path, list_dir, list_file, suffix,
+                              recursive):
+            # boto3 list method, it return json data as follows:
+            # {
+            #     'ResponseMetadata': {..., 'HTTPStatusCode': 200, ...},
+            #     ...,
+            #     'Contents': [{'Key': 'path/object', ...}, ...],
+            #     ...
+            # }
+            response = self._client.list_objects_v2(
+                Bucket=bucket, MaxKeys=maxnum, Prefix=dir_path)
+            if (response['ResponseMetadata']['HTTPStatusCode'] == 200
+                    and 'Contents' in response):
+                for content in response['Contents']:
+                    path = content['Key']
+                    # AWS s3 has no concept of directories, it will list all
+                    # path of object from bucket. Compute folder level to
+                    # distinguish different folder.
+                    level = len([
+                        item for item in path.replace(root, '').split('/')
+                        if item
+                    ])
+                    if level == 0 or (level > 1 and not recursive):
+                        continue
+                    if path.endswith('/'):  # a directory path
+                        if list_dir:
+                            # get the relative path and exclude the last
+                            # character '/'
+                            rel_dir = path[len(root):-1]
+                            yield rel_dir
+                    else:  # a file path
+                        rel_path = path[len(root):]
+                        if (suffix is None
+                                or rel_path.endswith(suffix)) and list_file:
+                            yield rel_path
+
+        return _list_dir_or_file(dir_path, list_dir, list_file, suffix,
+                                 recursive)
+
+
 class MemcachedBackend(BaseStorageBackend):
     """Memcached storage backend.
 
@@ -769,6 +1139,7 @@ class FileClient:
         'lmdb': LmdbBackend,
         'petrel': PetrelBackend,
         'http': HTTPBackend,
+        'aws': AWSBackend
     }
     # This collection is used to record the overridden backends, and when a
     # backend appears in the collection, the singleton pattern is disabled for
@@ -776,7 +1147,7 @@ class FileClient:
     # returned will be the backend before overwriting
     _overridden_backends = set()
     _prefix_to_backends = {
-        's3': PetrelBackend,
+        's3': [PetrelBackend, AWSBackend, CephBackend],
         'http': HTTPBackend,
         'https': HTTPBackend,
     }
@@ -806,16 +1177,33 @@ class FileClient:
         if (arg_key in cls._instances
                 and backend not in cls._overridden_backends
                 and prefix not in cls._overridden_prefixes):
-            _instance = cls._instances[arg_key]
-        else:
-            # create a new object and put it to _instance
-            _instance = super().__new__(cls)
-            if backend is not None:
-                _instance.client = cls._backends[backend](**kwargs)
-            else:
-                _instance.client = cls._prefix_to_backends[prefix](**kwargs)
+            return cls._instances[arg_key]
 
-            cls._instances[arg_key] = _instance
+        # create a new object and put it to _instance
+        _instance = super().__new__(cls)
+
+        if backend is not None:
+            _instance.client = cls._backends[backend](**kwargs)
+        # The prefix is supported by Multi backends, need to try in turn.
+        elif isinstance(cls._prefix_to_backends[prefix], list):
+            import_errors = []
+            for backend_cls in cls._prefix_to_backends[prefix]:
+                try:
+                    _instance.client = backend_cls(**kwargs)
+                except ImportError as e:
+                    import_errors.append(str(e))
+                    continue
+                break
+            if not hasattr(_instance, 'client'):
+                raise ImportError(
+                    f"The prefix '{prefix}' is supported by Multi backends, "
+                    'install at least one of the packages as follows:\n' +
+                    '\n'.join(import_errors))
+        else:
+            # The prefix only contains one backend, create a new object.
+            _instance.client = cls._prefix_to_backends[prefix](**kwargs)
+
+        cls._instances[arg_key] = _instance
 
         return _instance
 

--- a/mmcv/fileio/parse.py
+++ b/mmcv/fileio/parse.py
@@ -32,7 +32,7 @@ def list_from_file(filename,
     Examples:
         >>> list_from_file('/path/of/your/file')  # disk
         ['hello', 'world']
-        >>> list_from_file('s3://path/of/your/file')  # ceph or petrel
+        >>> list_from_file('s3://path/of/your/file')  # ceph or petrel or aws
         ['hello', 'world']
 
     Returns:
@@ -79,7 +79,7 @@ def dict_from_file(filename,
     Examples:
         >>> dict_from_file('/path/of/your/file')  # disk
         {'key1': 'value1', 'key2': 'value2'}
-        >>> dict_from_file('s3://path/of/your/file')  # ceph or petrel
+        >>> dict_from_file('s3://path/of/your/file')  # ceph or petrel or aws
         {'key1': 'value1', 'key2': 'value2'}
 
     Returns:

--- a/tests/test_fileio.py
+++ b/tests/test_fileio.py
@@ -3,15 +3,22 @@ import os
 import os.path as osp
 import sys
 import tempfile
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 import mmcv
-from mmcv.fileio.file_client import HTTPBackend, PetrelBackend
+from mmcv.fileio.file_client import AWSBackend, HTTPBackend, PetrelBackend
 
-sys.modules['petrel_client'] = MagicMock()
-sys.modules['petrel_client.client'] = MagicMock()
+
+@contextmanager
+def package_mock(package_name):
+    try:
+        sys.modules[package_name] = MagicMock()
+        yield
+    finally:
+        del sys.modules[package_name]
 
 
 def _test_handler(file_format, test_obj, str_checker, mode='r+'):
@@ -29,7 +36,9 @@ def _test_handler(file_format, test_obj, str_checker, mode='r+'):
 
     # load/dump with filename from petrel
     method = 'put' if 'b' in mode else 'put_text'
-    with patch.object(PetrelBackend, method, return_value=None) as mock_method:
+    with package_mock('petrel_client'), package_mock(
+            'petrel_client.client'), patch.object(
+                PetrelBackend, method, return_value=None) as mock_method:
         filename = 's3://path/of/your/file'
         mmcv.dump(test_obj, filename, file_format=file_format)
     mock_method.assert_called()
@@ -95,6 +104,10 @@ def test_exception():
 
     with pytest.raises(TypeError):
         mmcv.dump(test_obj, 'tmp.txt')
+
+    with pytest.raises(ImportError):
+        mmcv.FileClient._instances = {}
+        mmcv.FileClient(prefix='s3')
 
 
 def test_register_handler():
@@ -162,11 +175,28 @@ def test_list_from_file():
         assert filelist == ['1.jpg', '2.jpg', '3.jpg']
 
     # get list from petrel
-    with patch.object(
-            PetrelBackend, 'get_text', return_value='1.jpg\n2.jpg\n3.jpg'):
+    with package_mock('petrel_client'), package_mock(
+            'petrel_client.client'), patch.object(
+                PetrelBackend, 'get_text', return_value='1.jpg\n2.jpg\n3.jpg'):
+        mmcv.FileClient._instances = {}
         filename = 's3://path/of/your/file'
         filelist = mmcv.list_from_file(
             filename, file_client_args={'backend': 'petrel'})
+        assert filelist == ['1.jpg', '2.jpg', '3.jpg']
+        filelist = mmcv.list_from_file(
+            filename, file_client_args={'prefix': 's3'})
+        assert filelist == ['1.jpg', '2.jpg', '3.jpg']
+        filelist = mmcv.list_from_file(filename)
+        assert filelist == ['1.jpg', '2.jpg', '3.jpg']
+
+    # get list from aws
+    with package_mock('boto3'), package_mock(
+            'botocore.exceptions'), patch.object(
+                AWSBackend, 'get_text', return_value='1.jpg\n2.jpg\n3.jpg'):
+        mmcv.FileClient._instances = {}
+        filename = 's3://path/of/your/file'
+        filelist = mmcv.list_from_file(
+            filename, file_client_args={'backend': 'aws'})
         assert filelist == ['1.jpg', '2.jpg', '3.jpg']
         filelist = mmcv.list_from_file(
             filename, file_client_args={'prefix': 's3'})
@@ -197,9 +227,12 @@ def test_dict_from_file():
         assert mapping == {'1': 'cat', '2': ['dog', 'cow'], '3': 'panda'}
 
     # get dict from petrel
-    with patch.object(
-            PetrelBackend, 'get_text',
-            return_value='1 cat\n2 dog cow\n3 panda'):
+    with package_mock('petrel_client'), package_mock(
+            'petrel_client.client'), patch.object(
+                PetrelBackend,
+                'get_text',
+                return_value='1 cat\n2 dog cow\n3 panda'):
+        mmcv.FileClient._instances = {}
         filename = 's3://path/of/your/file'
         mapping = mmcv.dict_from_file(
             filename, file_client_args={'backend': 'petrel'})
@@ -209,3 +242,24 @@ def test_dict_from_file():
         assert mapping == {'1': 'cat', '2': ['dog', 'cow'], '3': 'panda'}
         mapping = mmcv.dict_from_file(filename)
         assert mapping == {'1': 'cat', '2': ['dog', 'cow'], '3': 'panda'}
+
+    # get dict from aws
+    with package_mock('boto3'), package_mock(
+            'botocore.exceptions'), patch.object(
+                AWSBackend,
+                'get_text',
+                return_value='1 cat\n2 dog cow\n3 panda'):
+        mmcv.FileClient._instances = {}
+        filename = 's3://path/of/your/file'
+        mapping = mmcv.dict_from_file(
+            filename, file_client_args={'backend': 'aws'})
+        assert mapping == {'1': 'cat', '2': ['dog', 'cow'], '3': 'panda'}
+        mapping = mmcv.dict_from_file(
+            filename, file_client_args={'prefix': 's3'})
+        assert mapping == {'1': 'cat', '2': ['dog', 'cow'], '3': 'panda'}
+        mapping = mmcv.dict_from_file(filename)
+        assert mapping == {'1': 'cat', '2': ['dog', 'cow'], '3': 'panda'}
+
+
+if __name__ == '__main__':
+    test_dict_from_file()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The motivation of the PR is allow `FileClient` to support aws s3 file backend, and when the `prefix` is '​​s3', the installed backend can be automatically selected.

## Modification

1. AWSBackend
    - Add a new Class `AWSBackend` to support reading/writing data from aws s3. Its interface is the same as PetrelBackend.
2. FileClient
    - Add 'aws' to Attribute `_backends`.
    - Modify `_prefix_to_backends` to support multi file backend (PetrelBackend、CephBackend and AWSBackend).
    - Modify `__new__` method to support when the `prefix` is '​​s3', the installed backend can be automatically selected.
3. load_from_ceph
    - Modify try excpet, when backend import error, use prefix to Instantiate `FileClient`.
4. test_fileio.py
    - Add `AWSBackend` unittest.

## BC-breaking (Optional)

No

## Use cases (Optional)

1. It relies on awscli and boto3, you must install and run ``aws configure``
    in advance to use `AWSBackend`.
```python
import mmcv

s3_path = 's3://bucket/object_name'
client = mmcv.FileClient(backend='aws')
client = mmcv.FileClient(prefix='s3')
client = mmcv.FileClient.infer_client(uri=s3_path)
```

## Test
- [x] The method of `AWSBackend` are all tested on aws s3, works as expected.
- [x] `__new__` of `FileClient` works as expected.
- [x] `load_from_ceph` works as expected.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
