### PR TITLE
[Feature] Detect anomalous parameters

### DIFF
--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -26,8 +26,9 @@ class OptimizerHook(Hook):
     Args:
         grad_clip (dict, optional): A config dict to control the clip_grad.
             Default: None.
-        detect_anomalous_params (bool):  Detect anomalous parameters
-            of the model which are not included in
+        detect_anomalous_params (bool): This option is only used for
+            debugging which will slow down the training speed.
+            Detect anomalous parameters that are not included in
             the computational graph with `loss` as the root.
             There are two cases
 

--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -24,6 +24,7 @@ class OptimizerHook(Hook):
 
     Args:
         grad_clip (dict): A config dict to control the clip_grad.
+            Default: None.
         detect_anomalous_params (bool):  Detect anomalous parameters
             of the model. Such as
 
@@ -31,9 +32,10 @@ class OptimizerHook(Hook):
                   forward pass.
                 - Parameters were not used to produce
                   loss.
+            Default: False.
     """
 
-    def __init__(self, grad_clip=None, detect_anomalous_params=True):
+    def __init__(self, grad_clip=None, detect_anomalous_params=False):
 
         self.grad_clip = grad_clip
         self.detect_anomalous_params = detect_anomalous_params
@@ -92,9 +94,9 @@ class OptimizerHook(Hook):
             if p not in parameters_in_graph and p.requires_grad:
                 logger.info(f'{n} with shape {p.size()} does not '
                             f'be used in forward pass, if you are '
-                            f'sure there is no problem, you can set'
+                            f'sure there is no problem, you can set '
                             f'`find_unused_parameters` '
-                            f"in `DistributedDataParallel`  ' \n")
+                            f'in `DistributedDataParallel` \n')
 
 
 @HOOKS.register_module()

--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -24,7 +24,7 @@ class OptimizerHook(Hook):
     """A hook contains custom operations for the optimizer.
 
     Args:
-        grad_clip (dict): A config dict to control the clip_grad.
+        grad_clip (dict, optional): A config dict to control the clip_grad.
             Default: None.
         detect_anomalous_params (bool):  Detect anomalous parameters
             of the model which are not included in
@@ -39,7 +39,6 @@ class OptimizerHook(Hook):
     """
 
     def __init__(self, grad_clip=None, detect_anomalous_params=False):
-
         self.grad_clip = grad_clip
         self.detect_anomalous_params = detect_anomalous_params
 

--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -26,7 +26,7 @@ class OptimizerHook(Hook):
         grad_clip (dict): A config dict to control the clip_grad.
             Default: None.
         detect_anomalous_params (bool):  Detect anomalous parameters
-            of the model which is not included in
+            of the model which are not included in
             the computational graph with `loss` as the root.
             There are two cases
 

--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
+import logging
 from collections import defaultdict
 from itertools import chain
 
@@ -83,8 +84,10 @@ class OptimizerHook(Hook):
         traverse(loss.grad_fn)
         for n, p in runner.model.named_parameters():
             if p not in parameters_in_graph and p.requires_grad:
-                logger.info(f'{n} with shape {p.size()} is not '
-                            f'in the computational graph \n')
+                logger.log(
+                    level=logging.ERROR,
+                    msg=f'{n} with shape {p.size()} is not '
+                    f'in the computational graph \n')
 
 
 @HOOKS.register_module()

--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -72,15 +72,13 @@ class OptimizerHook(Hook):
                 return
             if grad_fn not in visited:
                 visited.add(grad_fn)
-            else:
-                return
-            if hasattr(grad_fn, 'variable'):
-                parameters_in_graph.add(grad_fn.variable)
-            parents = grad_fn.next_functions
-            if parents is not None:
-                for parent in parents:
-                    grad_fn = parent[0]
-                    traverse(grad_fn)
+                if hasattr(grad_fn, 'variable'):
+                    parameters_in_graph.add(grad_fn.variable)
+                parents = grad_fn.next_functions
+                if parents is not None:
+                    for parent in parents:
+                        grad_fn = parent[0]
+                        traverse(grad_fn)
 
         traverse(loss.grad_fn)
         for n, p in runner.model.named_parameters():

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -88,7 +88,7 @@ def test_optimizerhook():
         def __init__(self):
             self.msg = ''
 
-        def info(self, msg):
+        def log(self, msg=None, **kwargs):
             self.msg += msg
 
     dummy_runner.logger = DummyLogger()

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -12,7 +12,7 @@ import re
 import shutil
 import sys
 import tempfile
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 import torch
@@ -37,6 +37,85 @@ from mmcv.runner.hooks.lr_updater import (CosineRestartLrUpdaterHook,
 
 sys.modules['petrel_client'] = MagicMock()
 sys.modules['petrel_client.client'] = MagicMock()
+
+
+def test_optimizerhook():
+
+    class Model(nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.conv1 = nn.Conv2d(
+                in_channels=1,
+                out_channels=2,
+                kernel_size=3,
+                stride=1,
+                padding=1,
+                dilation=1)
+            self.conv2 = nn.Conv2d(
+                in_channels=2,
+                out_channels=2,
+                kernel_size=3,
+                stride=1,
+                padding=1,
+                dilation=1)
+            self.conv3 = nn.Conv2d(
+                in_channels=1,
+                out_channels=2,
+                kernel_size=3,
+                stride=1,
+                padding=1,
+                dilation=1)
+
+        def forward(self, x):
+            x1 = self.conv1(x)
+            x2 = self.conv2(x1)
+            return x1, x2
+
+    model = Model()
+    x = torch.rand(1, 1, 3, 3)
+
+    dummy_runner = Mock()
+    dummy_runner.optimizer.zero_grad = Mock(return_value=None)
+    dummy_runner.optimizer.step = Mock(return_value=None)
+    dummy_runner.model = model
+    dummy_runner.outputs = dict()
+
+    dummy_runner.outputs['num_samples'] = 0
+
+    class DummyLogger():
+
+        def __init__(self):
+            self.msg = ''
+
+        def info(self, msg):
+            self.msg += msg
+
+    dummy_runner.logger = DummyLogger()
+    optimizer_hook = OptimizerHook(
+        dict(max_norm=2), detect_anomalous_params=True)
+
+    dummy_runner.outputs['loss'] = model(x)[0].sum()
+    optimizer_hook.after_train_iter(dummy_runner)
+    # assert the parameters of conv2 and conv3 are not in the
+    # computational graph which is with x1.sum() as root.
+    assert 'conv2.weight' in dummy_runner.logger.msg
+    assert 'conv2.bias' in dummy_runner.logger.msg
+    assert 'conv3.weight' in dummy_runner.logger.msg
+    assert 'conv3.bias' in dummy_runner.logger.msg
+    assert 'conv1.weight' not in dummy_runner.logger.msg
+    assert 'conv1.bias' not in dummy_runner.logger.msg
+
+    dummy_runner.outputs['loss'] = model(x)[1].sum()
+    dummy_runner.logger.msg = ''
+    optimizer_hook.after_train_iter(dummy_runner)
+    # assert the parameters of conv3 are not in the computational graph
+    assert 'conv3.weight' in dummy_runner.logger.msg
+    assert 'conv3.bias' in dummy_runner.logger.msg
+    assert 'conv2.weight' not in dummy_runner.logger.msg
+    assert 'conv2.bias' not in dummy_runner.logger.msg
+    assert 'conv1.weight' not in dummy_runner.logger.msg
+    assert 'conv1.bias' not in dummy_runner.logger.msg
 
 
 def test_checkpoint_hook(tmp_path):


### PR DESCRIPTION
## Motivation

Sometimes there are some anomalous parameters in the training phase, mainly two cases 

- Some parameters are  not be used in a forward pass due to our wrong implementation, which causes the error when doing `loss.backward()`
- Some parameters are not be used to produce loss, which causes the deadlock when doing `loss.backward()`
 
In both cases，anomalous parameters are not included in the computational graph that is with `loss` as the root.

## Modification

I add a debug option named `detect_anomalous_params`  to `OptimizerHook`, which can help you find anomalous parameters  

## BC-breaking (Optional)
None

