### PR TITLE
Add EarlyStopHook

### DIFF
--- a/mmcv/runner/__init__.py
+++ b/mmcv/runner/__init__.py
@@ -11,8 +11,9 @@ from .dist_utils import (allreduce_grads, allreduce_params, get_dist_info,
 from .epoch_based_runner import EpochBasedRunner, Runner
 from .fp16_utils import LossScaler, auto_fp16, force_fp32, wrap_fp16_model
 from .hooks import (HOOKS, CheckpointHook, ClosureHook, DistEvalHook,
-                    DistSamplerSeedHook, DvcliveLoggerHook, EMAHook, EvalHook,
-                    Fp16OptimizerHook, GradientCumulativeFp16OptimizerHook,
+                    DistSamplerSeedHook, DvcliveLoggerHook, EarlyStoppingHook,
+                    EMAHook, EvalHook, Fp16OptimizerHook,
+                    GradientCumulativeFp16OptimizerHook,
                     GradientCumulativeOptimizerHook, Hook, IterTimerHook,
                     LoggerHook, MlflowLoggerHook, NeptuneLoggerHook,
                     OptimizerHook, PaviLoggerHook, SyncBuffersHook,
@@ -60,5 +61,6 @@ __all__ = [
     'allreduce_params', 'LossScaler', 'CheckpointLoader', 'BaseModule',
     '_load_checkpoint_with_prefix', 'EvalHook', 'DistEvalHook', 'Sequential',
     'ModuleDict', 'ModuleList', 'GradientCumulativeOptimizerHook',
-    'GradientCumulativeFp16OptimizerHook', 'DefaultRunnerConstructor'
+    'GradientCumulativeFp16OptimizerHook', 'DefaultRunnerConstructor',
+    'EarlyStoppingHook'
 ]

--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -103,6 +103,7 @@ class BaseRunner(metaclass=ABCMeta):
         self.optimizer = optimizer
         self.logger = logger
         self.meta = meta
+        self.should_stop = False
         # create work_dir
         if mmcv.is_str(work_dir):
             self.work_dir = osp.abspath(work_dir)

--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -107,7 +107,7 @@ class EpochBasedRunner(BaseRunner):
                          self._max_epochs)
         self.call_hook('before_run')
 
-        while self.epoch < self._max_epochs:
+        while self.epoch < self._max_epochs and not self.should_stop:
             for i, flow in enumerate(workflow):
                 mode, epochs = flow
                 if isinstance(mode, str):  # self.train()

--- a/mmcv/runner/hooks/__init__.py
+++ b/mmcv/runner/hooks/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .checkpoint import CheckpointHook
 from .closure import ClosureHook
+from .early_stopping import EarlyStoppingHook
 from .ema import EMAHook
 from .evaluation import DistEvalHook, EvalHook
 from .hook import HOOKS, Hook
@@ -38,5 +39,6 @@ __all__ = [
     'StepMomentumUpdaterHook', 'CosineAnnealingMomentumUpdaterHook',
     'CyclicMomentumUpdaterHook', 'OneCycleMomentumUpdaterHook',
     'SyncBuffersHook', 'EMAHook', 'EvalHook', 'DistEvalHook', 'ProfilerHook',
-    'GradientCumulativeOptimizerHook', 'GradientCumulativeFp16OptimizerHook'
+    'GradientCumulativeOptimizerHook', 'GradientCumulativeFp16OptimizerHook',
+    'EarlyStoppingHook'
 ]

--- a/mmcv/runner/hooks/early_stopping.py
+++ b/mmcv/runner/hooks/early_stopping.py
@@ -1,0 +1,222 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+# Adapted from
+# https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pytorch_lightning/callbacks/early_stopping.py
+
+import warnings
+from typing import Callable, Dict, Optional
+
+import numpy as np
+
+from ..hooks.hook import HOOKS, Hook
+
+
+@HOOKS.register_module()
+class EarlyStoppingHook(Hook):
+    r"""Stop training when a monitored metric has stopped improving.
+
+    Args:
+    monitor: quantity to be monitored.
+    phase: runner mode when executing model.Evaluation will only take place
+        with corresponding runner mode.
+    min_delta: minimum change in the monitored quantity to qualify as an
+        improvement, i.e. an absolute change of less than or equal to
+        `min_delta`, will count as no improvement.
+    patience: number of checks with no improvement
+        after which training will be stopped. Under the default configuration,
+        one check happens after every training epoch. However, the frequency
+        of validation can be modified by setting various parameters on the
+        ``Runner``, for example ``[(train, 10), (val, 1)]``.
+        .. note::
+            It must be noted that the patience parameter counts the number of
+            validation checks with no improvement, and not the number of
+            training epochs. Therefore, with parameters
+            ``[(train, 10), (val, 1)]`` and ``patience=3``, the runner
+            will perform at least 40 training epochs before being stopped.
+    verbose: verbosity mode.
+    mode: one of ``'min'``, ``'max'``. In ``'min'`` mode, training will stop
+        when the quantity monitored has stopped decreasing and in ``'max'``
+        mode it will stop when the quantity monitored has stopped increasing.
+    strict: whether to crash the training if `monitor` is not found in the
+        validation metrics.
+    check_finite: When set ``True``, stops training when the monitor becomes
+        NaN or infinite.
+    stopping_threshold: Stop training immediately once the monitored quantity
+        reaches this threshold.
+    divergence_threshold: Stop training as soon as the monitored quantity
+        becomes worse than this threshold.
+    """
+
+    mode_dict = {'min': np.less, 'max': np.greater}
+
+    def __init__(self,
+                 monitor: str,
+                 phase: str = 'train',
+                 min_delta: float = 0.0,
+                 patience: int = 3,
+                 verbose: bool = False,
+                 mode: str = 'min',
+                 strict: bool = True,
+                 check_finite: bool = True,
+                 stopping_threshold: Optional[float] = None,
+                 divergence_threshold: Optional[float] = None,
+                 by_epoch=True):
+        assert isinstance(
+            patience,
+            int) and patience > 0, 'patience must be positive integer'
+        self.monitor = monitor
+        self.phase = phase
+        self.min_delta = min_delta
+        self.patience = patience
+        self.verbose = verbose
+        self.mode = mode
+        self.strict = strict
+        self.check_finite = check_finite
+        self.stopping_threshold = stopping_threshold
+        self.divergence_threshold = divergence_threshold
+        self.by_epoch = by_epoch
+        self.wait_count = 0
+        self.stopped_step = 0
+
+        if self.mode not in self.mode_dict:
+            raise ValueError(
+                f"`mode` can be {', '.join(self.mode_dict.keys())}, got"
+                f' {self.mode}')
+
+        self.min_delta *= 1 if self.monitor_op == np.greater else -1
+        self.best_score = np.Inf if self.monitor_op == np.less else -np.Inf
+
+    def before_run(self, runner):
+        if runner.meta is None:
+            warnings.warn('runner.meta is None. Creating an empty one.')
+            runner.meta = dict()
+        runner.meta.setdefault('hook_msgs', dict())
+        self.wait_count = runner.meta['hook_msgs'].get('wait_count',
+                                                       self.wait_count)
+        self.best_score = runner.meta['hook_msgs'].get('early_stop_best_score',
+                                                       self.best_score)
+
+    def before_train_epoch(self, runner):
+        runner.log_buffer.clear()
+
+    def before_val_epoch(self, runner):
+        runner.log_buffer.clear()
+
+    def after_train_iter(self, runner):
+        if self.by_epoch or self.phase == 'val':
+            return
+        runner.log_buffer.average(1)
+        self._run_early_stopping_check(runner, runner.log_buffer.output)
+
+    def after_train_epoch(self, runner):
+        if not self.by_epoch or self.phase == 'val':
+            return
+        runner.log_buffer.average()
+        self._run_early_stopping_check(runner, runner.log_buffer.output)
+
+    def after_val_iter(self, runner):
+        if self.by_epoch or self.phase == 'train':
+            return
+        runner.log_buffer.average(1)
+        self._run_early_stopping_check(runner, runner.log_buffer.output)
+
+    def after_val_epoch(self, runner):
+        if not self.by_epoch or self.phase == 'train':
+            return
+        runner.log_buffer.average()
+        self._run_early_stopping_check(runner, runner.log_buffer.output)
+
+    @property
+    def monitor_op(self) -> Callable:
+        return self.mode_dict[self.mode]
+
+    def get_mode(self, runner):
+        return runner.mode
+
+    def _validate_condition_metric(self, runner, logs: Dict[str,
+                                                            float]) -> bool:
+        monitor_val = logs.get(self.monitor)
+
+        error_msg = (
+            f'Early stopping conditioned on metric `{self.monitor}` which is'
+            ' not available.  Pass in or modify your `EarlyStopping` callback'
+            ' to use any of the following:'
+            f' `{"`, `".join(list(logs.keys()))}`')
+
+        if monitor_val is None:
+            if self.strict:
+                raise RuntimeError(error_msg)
+            if self.verbose > 0:
+                runner.logger.warn(error_msg)
+
+            return False
+
+        return True
+
+    def _run_early_stopping_check(self, runner, logs: Dict[str, float]):
+        if not self._validate_condition_metric(
+                runner, logs):  # short circuit if metric not present
+            return
+
+        current = logs[self.monitor].squeeze()
+        should_stop, reason = self._evaluate_stopping_criteria(current)
+        runner.should_stop = runner.should_stop or should_stop
+        runner.meta['hook_msgs']['wait_count'] = self.wait_count
+        runner.meta['hook_msgs']['early_stop_best_score'] = self.best_score
+        if reason and self.verbose > 0:
+            runner.logger.info(reason)
+
+    def _evaluate_stopping_criteria(self, current: float):
+        should_stop = False
+        reason = None
+
+        if self.check_finite and not np.isfinite(current):
+            should_stop = True
+            reason = (
+                f'Monitored metric {self.monitor} = {current} is not finite.'
+                f' Previous best value was {self.best_score:.3f}. Signaling'
+                ' runner to stop.')
+        elif self.stopping_threshold is not None and self.monitor_op(
+                current, self.stopping_threshold):
+            should_stop = True
+            reason = (
+                'Stopping threshold reached:'
+                f' {self.monitor} = {current} {self.mode_dict[self.mode]}'
+                f' {self.stopping_threshold}.'
+                ' Signaling Trainer to stop.')
+        elif self.divergence_threshold is not None and self.monitor_op(
+                -current, -self.divergence_threshold):
+            should_stop = True
+            reason = (
+                'Divergence threshold reached:'
+                f' {self.monitor} = {current} {self.mode_dict[self.mode]}'
+                f' {self.divergence_threshold}.'
+                ' Signaling Trainer to stop.')
+        elif self.monitor_op(current - self.min_delta, self.best_score):
+            should_stop = False
+            reason = self._improvement_message(current)
+            self.best_score = current
+            self.wait_count = 0
+        else:
+            self.wait_count += 1
+            if self.wait_count >= self.patience:
+                should_stop = True
+                reason = (
+                    f'Monitored metric {self.monitor} did not improve in the'
+                    f' last {self.wait_count} records.'
+                    f' Best score: {self.best_score:.3f}. Signaling Runner to'
+                    ' stop.')
+
+        return should_stop, reason
+
+    def _improvement_message(self, current: np.float) -> str:
+        """Formats a log message that informs the user about an improvement in
+        the monitored score."""
+        if np.isfinite(self.best_score):
+            msg = (f'Metric {self.monitor} improved by'
+                   f' {abs(self.best_score - current):.3f} >='
+                   f' min_delta = {abs(self.min_delta)}. New best score:'
+                   f' {current:.3f}')
+        else:
+            msg = (f'Metric {self.monitor} improved. New best score:'
+                   f' {current:.3f}')
+        return msg

--- a/mmcv/runner/iter_based_runner.py
+++ b/mmcv/runner/iter_based_runner.py
@@ -119,7 +119,7 @@ class IterBasedRunner(BaseRunner):
 
         self.call_hook('before_epoch')
 
-        while self.iter < self._max_iters:
+        while self.iter < self._max_iters and not self.should_stop:
             for i, flow in enumerate(workflow):
                 self._inner_iter = 0
                 mode, iters = flow

--- a/tests/test_runner/test_early_stop.py
+++ b/tests/test_runner/test_early_stop.py
@@ -1,0 +1,269 @@
+"""Tests the hooks with runners.
+
+CommandLine:
+    pytest tests/test_runner/test_early_stop.py
+"""
+import tempfile
+from typing import Callable
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from mmcv.runner import EarlyStoppingHook, EpochBasedRunner, IterBasedRunner
+from mmcv.utils import get_logger
+
+
+class BaseModel(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.step_train = 0
+        self.step_val = 0
+
+    def forward(self, x, **kwargs):
+        return x
+
+    def train_step(self, data_batch, optimizer, **kwargs):
+        log = {
+            'log_vars': {
+                self.loss_key:
+                torch.tensor(self.loss_values[self.step], dtype=torch.float32)
+            },
+            'num_samples': data_batch.size(0)
+        }
+        self.step += 1
+        return log
+
+    def val_step(self, data_batch, optimizer, **kwargs):
+        return {'loss': torch.sum(self(data_batch['x']))}
+
+
+def _build_epoch_runner(model, steps=4):
+    tmp_dir = tempfile.mkdtemp()
+
+    runner = EpochBasedRunner(
+        model=model,
+        work_dir=tmp_dir,
+        logger=get_logger('demo'),
+        max_epochs=steps)
+    return runner
+
+
+def _build_iter_runner(model, steps=4):
+    tmp_dir = tempfile.mkdtemp()
+
+    runner = IterBasedRunner(
+        model=model,
+        work_dir=tmp_dir,
+        logger=get_logger('demo'),
+        max_iters=steps)
+    return runner
+
+
+def test_early_stop():
+    with pytest.raises(AssertionError):
+        # `patience` should be a positive integer
+        EarlyStoppingHook('loss', patience=-1)
+
+
+@pytest.mark.parametrize('_build_demo_runner, by_epoch, step_attr',
+                         [(_build_epoch_runner, True, 'epoch'),
+                          (_build_iter_runner, False, 'iter')])
+@pytest.mark.parametrize('loss_values, patience, expected_stop_step',
+                         [([6, 5, 5, 5, 5, 5], 3, 5),
+                          ([6, 5, 4, 4, 3, 3], 1, 4),
+                          ([6, 5, 6, 5, 5, 5], 3, 5)])
+@pytest.mark.parametrize('workflow, phase', [([('train', 1)], 'train'),
+                                             ([('train', 1),
+                                               ('val', 1)], 'val')])
+def test_early_stopping_patience(_build_demo_runner: Callable, by_epoch: int,
+                                 step_attr: str, loss_values: list,
+                                 patience: int, expected_stop_step: int,
+                                 workflow: list, phase: str):
+    if by_epoch:
+        # simulate 2 ite / epoch.
+        loss_values = np.array(loss_values).repeat(2)
+    else:
+        loss_values = np.array(loss_values)
+
+    class Model(BaseModel):
+
+        def train_step(self, data_batch, optimizer, **kwargs):
+            log = {
+                'log_vars': {
+                    'loss':
+                    torch.tensor(
+                        loss_values[self.step_train], dtype=torch.float32)
+                },
+                'num_samples': data_batch.size(0)
+            }
+            self.step_train += 1
+            return log
+
+        def val_step(self, data_batch, *args, **kwargs):
+            log = {
+                'log_vars': {
+                    'loss':
+                    torch.tensor(
+                        loss_values[self.step_val], dtype=torch.float32)
+                },
+                'num_samples': data_batch.size(0)
+            }
+            self.step_val += 1
+            return log
+
+    dataloader = DataLoader(torch.ones(10, 2), batch_size=5)
+    runner = _build_demo_runner(Model(), steps=10)
+    hook = EarlyStoppingHook(
+        monitor='loss', phase=phase, patience=patience, by_epoch=by_epoch)
+    runner.register_hook(hook)
+    runner.run([dataloader] * len(workflow), workflow)
+    assert getattr(runner, step_attr) == expected_stop_step
+
+
+@pytest.mark.parametrize('_build_demo_runner, by_epoch',
+                         [(_build_epoch_runner, True),
+                          (_build_iter_runner, False)])
+def test_early_stopping_no_monitor(_build_demo_runner, by_epoch: bool):
+    """Test that early stopping callback falls back to training metrics when no
+    validation defined."""
+
+    class Model(BaseModel):
+
+        def train_step(self, data_batch, optimizer, **kwargs):
+            log = {
+                'log_vars': {
+                    'loss': torch.tensor(0, dtype=torch.float32)
+                },
+                'num_samples': data_batch.size(0)
+            }
+            self.step_train += 1
+            return log
+
+    dataloader = DataLoader(torch.ones(10, 2), batch_size=5)
+    runner = _build_demo_runner(Model(), steps=10)
+    hook = EarlyStoppingHook(
+        monitor='UNKNOWN_KEY', patience=3, by_epoch=by_epoch)
+    runner.register_hook(hook)
+    with pytest.raises(RuntimeError):
+        runner.run([dataloader], [('train', 1)])
+
+
+@pytest.mark.parametrize('_build_demo_runner, by_epoch, step_attr',
+                         [(_build_epoch_runner, True, 'epoch'),
+                          (_build_iter_runner, False, 'iter')])
+@pytest.mark.parametrize(
+    'stopping_threshold,divergence_threshold,loss_values,expected_stop_step',
+    [
+        (None, None, [8, 4, 2, 3, 4, 5, 8, 10], 6),
+        (2.9, None, [9, 8, 7, 6, 5, 6, 4, 3, 2, 1], 9),
+        (None, 15.9, [9, 4, 2, 16, 32, 64], 4),
+    ],
+)
+@pytest.mark.parametrize('workflow, phase', [([('train', 1)], 'train'),
+                                             ([('train', 1),
+                                               ('val', 1)], 'val')])
+def test_early_stopping_thresholds(_build_demo_runner, by_epoch: bool,
+                                   step_attr: str, stopping_threshold: int,
+                                   divergence_threshold: int,
+                                   loss_values: list, expected_stop_step: int,
+                                   workflow: tuple, phase: str):
+    if by_epoch:
+        # simulate 2 ite / epoch.
+        loss_values = np.array(loss_values).repeat(2)
+    else:
+        loss_values = np.array(loss_values)
+
+    class Model(BaseModel):
+
+        def train_step(self, data_batch, optimizer, **kwargs):
+            log = {
+                'log_vars': {
+                    'loss':
+                    torch.tensor(
+                        loss_values[self.step_train], dtype=torch.float32)
+                },
+                'num_samples': data_batch.size(0)
+            }
+            self.step_train += 1
+            return log
+
+        def val_step(self, data_batch, *args, **kwargs):
+            log = {
+                'log_vars': {
+                    'loss':
+                    torch.tensor(
+                        loss_values[self.step_val], dtype=torch.float32)
+                },
+                'num_samples': data_batch.size(0)
+            }
+            self.step_val += 1
+            return log
+
+    dataloader = DataLoader(torch.ones(10, 2), batch_size=5)
+    runner = _build_demo_runner(Model(), steps=10)
+    hook = EarlyStoppingHook(
+        monitor='loss',
+        patience=3,
+        by_epoch=by_epoch,
+        stopping_threshold=stopping_threshold,
+        divergence_threshold=divergence_threshold)
+    runner.register_hook(hook)
+    runner.run([dataloader] * len(workflow), workflow)
+    assert getattr(runner, step_attr) == expected_stop_step
+
+
+@pytest.mark.parametrize('_build_demo_runner, by_epoch, step_attr',
+                         [(_build_epoch_runner, True, 'epoch'),
+                          (_build_iter_runner, False, 'iter')])
+@pytest.mark.parametrize(
+    'stop_value',
+    [torch.tensor(np.inf), torch.tensor(np.nan)])
+def test_early_stopping_on_non_finite_monitor(_build_demo_runner,
+                                              by_epoch: bool, step_attr: str,
+                                              stop_value):
+
+    loss_values = [4, 3, stop_value, 2, 1]
+    expected_stop_step = 3
+
+    if by_epoch:
+        # simulate 2 ite / epoch.
+        loss_values = np.array(loss_values).repeat(2)
+    else:
+        loss_values = np.array(loss_values)
+
+    class Model(BaseModel):
+
+        def train_step(self, data_batch, optimizer, **kwargs):
+            log = {
+                'log_vars': {
+                    'loss':
+                    torch.tensor(
+                        loss_values[self.step_train], dtype=torch.float32)
+                },
+                'num_samples': data_batch.size(0)
+            }
+            self.step_train += 1
+            return log
+
+        def val_step(self, data_batch, *args, **kwargs):
+            log = {
+                'log_vars': {
+                    'loss':
+                    torch.tensor(
+                        loss_values[self.step_val], dtype=torch.float32)
+                },
+                'num_samples': data_batch.size(0)
+            }
+            self.step_val += 1
+            return log
+
+    dataloader = DataLoader(torch.ones(10, 2), batch_size=5)
+    runner = _build_demo_runner(Model(), steps=10)
+    hook = EarlyStoppingHook(monitor='loss', patience=3, by_epoch=by_epoch)
+    runner.register_hook(hook)
+    runner.run([dataloader], [('train', 1)])
+    assert getattr(runner, step_attr) == expected_stop_step


### PR DESCRIPTION
## Motivation
Allow user to specific stopping condition depending on loss value progress. 
following discussion in this issue #403 

## Modification
Added EarlyStopHook and `should_stop` flag in runner to trigger stop.

## BC-breaking (Optional)
No obvious BC-breaking 

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
