### PR TITLE
Update modulated_deform_conv.py

### DIFF
--- a/mmcv/ops/modulated_deform_conv.py
+++ b/mmcv/ops/modulated_deform_conv.py
@@ -66,6 +66,7 @@ class ModulatedDeformConv2dFunction(Function):
         # whatever the pytorch version is.
         input = input.type_as(offset)
         weight = weight.type_as(input)
+        bias = bias.type_as(input)
         ctx.save_for_backward(input, offset, mask, weight, bias)
         output = input.new_empty(
             ModulatedDeformConv2dFunction._output_size(ctx, input, weight))


### PR DESCRIPTION
change bias to the same type as input

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix bug about autocast in ModulatedDeformConv2dFunction when using bias.

## Modification

bias = bias.type_as(input)  : convert bias type to the same as input type

## BC-breaking (Optional)

No
