### PR TITLE
add artifact logging to wandb hook

### DIFF
--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -22,10 +22,9 @@ class WandbLoggerHook(LoggerHook):
             Default: False.
         by_epoch (bool): Whether EpochBasedRunner is used.
             Default: True.
-        log_artifact (bool):
+        log_artifact (bool): If True, artifacts in {work_dir} will be uploaded
+            to wandb after training ends.
             Default: True
-            If True, artifacts in {work_dir} will be uploaded to wandb after
-            training ends.
             `New in version 1.4.3.`
         out_suffix (str or tuple[str], optional): Those filenames ending with
             ``out_suffix`` will be uploaded to wandb.

--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -24,6 +24,9 @@ class WandbLoggerHook(LoggerHook):
             Default: False.
         by_epoch (bool): Whether EpochBasedRunner is used.
             Default: True.
+        with_step (bool): If True, the step will be logged from
+            ``self.get_iters``. Otherwise, step will not be logged.
+            Default: True.
         log_artifact (bool): If True, artifacts in {work_dir} will be uploaded
             to wandb after training ends.
             Default: True

--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -12,7 +12,8 @@ class WandbLoggerHook(LoggerHook):
     """Class to log metrics with wandb.
 
     It requires `wandb` to be installed.
-    
+
+
     Args:
         interval (int): Logging interval (every k iterations).
             Default 10.

--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -12,6 +12,7 @@ class WandbLoggerHook(LoggerHook):
     """Class to log metrics with wandb.
 
     It requires `wandb` to be installed.
+    
     Args:
         interval (int): Logging interval (every k iterations).
             Default 10.

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -1190,8 +1190,6 @@ def test_mlflow_hook(log_model):
 
 
 def test_wandb_hook():
-    from mmcv.utils import scandir
-
     sys.modules['wandb'] = MagicMock()
     runner = _build_demo_runner()
     hook = WandbLoggerHook(log_artifact=True)
@@ -1199,11 +1197,6 @@ def test_wandb_hook():
 
     runner.register_hook(hook)
     runner.run([loader, loader], [('train', 1), ('val', 1)])
-
-    wandb_artifact = hook.wandb.Artifact(name='artifacts', type='model')
-    for filename in scandir(runner.work_dir, hook.out_suffix, True):
-        local_filepath = osp.join(runner.work_dir, filename)
-        wandb_artifact.add_file(local_filepath)
 
     shutil.rmtree(runner.work_dir)
 
@@ -1214,7 +1207,7 @@ def test_wandb_hook():
     },
                                       step=6,
                                       commit=True)
-    hook.wandb.log_artifact.assert_called_with(wandb_artifact)
+    hook.wandb.log_artifact.assert_called()
     hook.wandb.join.assert_called_with()
 
 

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -1195,6 +1195,11 @@ def test_wandb_hook():
     hook = WandbLoggerHook()
     loader = DataLoader(torch.ones((5, 2)))
 
+    # create a dummy config file
+    config_path = osp(runner.work_dir, 'config.py')
+    with open(config_path, 'w') as f:
+        f.write('lorem ipsum')
+
     runner.register_hook(hook)
     runner.run([loader, loader], [('train', 1), ('val', 1)])
     shutil.rmtree(runner.work_dir)
@@ -1206,6 +1211,7 @@ def test_wandb_hook():
     },
                                       step=6,
                                       commit=True)
+    hook.wandb.log_artifact.assert_called_with()
     hook.wandb.join.assert_called_with()
 
 

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -1195,11 +1195,6 @@ def test_wandb_hook():
     hook = WandbLoggerHook()
     loader = DataLoader(torch.ones((5, 2)))
 
-    # create a dummy config file
-    config_path = osp(runner.work_dir, 'config.py')
-    with open(config_path, 'w') as f:
-        f.write('lorem ipsum')
-
     runner.register_hook(hook)
     runner.run([loader, loader], [('train', 1), ('val', 1)])
     shutil.rmtree(runner.work_dir)

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -1194,7 +1194,7 @@ def test_wandb_hook():
 
     sys.modules['wandb'] = MagicMock()
     runner = _build_demo_runner()
-    hook = WandbLoggerHook()
+    hook = WandbLoggerHook(log_artifact=True)
     loader = DataLoader(torch.ones((5, 2)))
 
     runner.register_hook(hook)


### PR DESCRIPTION
**Problem:** Currently it is not possible to upload experiment config files and model weights to wandb. However it very crucial to properly track experiments.

**Solution:** With this PR, users can upload the contents in `work_dir` to wandb after training ends utilizing `log_artifact()` method of wandb logger: https://docs.wandb.ai/ref/python/run#log_artifact

**Usage:**
```python
log_config = dict(
    interval=1,
    hooks=[
        dict(
            type="WandbLoggerHook",
            init_kwargs=dict(
                entity=WANDB_ENTITY,
                project=WANDB_PROJECT,
                name=WANDB_NAME,
            ),
            log_artifact=True,
            out_suffix=('.log.json', '.log', '.py', '.pt')
        ),
    ],
)
```
