### PR TITLE
[Fix] Align HSigmoid with pytorch official

### DIFF
--- a/mmcv/cnn/bricks/hsigmoid.py
+++ b/mmcv/cnn/bricks/hsigmoid.py
@@ -13,7 +13,7 @@ class HSigmoid(nn.Module):
     Default: Hsigmoid(x) = min(max((x + 3) / 6, 0), 1)
 
     Note:
-        In MMCV v1.4.3, we modified the default value of args to align with
+        In MMCV v1.4.4, we modified the default value of args to align with
         PyTorch official.
 
     Args:
@@ -29,7 +29,7 @@ class HSigmoid(nn.Module):
     def __init__(self, bias=3.0, divisor=6.0, min_value=0.0, max_value=1.0):
         super(HSigmoid, self).__init__()
         warnings.warn(
-            'In MMCV v1.4.3, we modified the default value of args to align '
+            'In MMCV v1.4.4, we modified the default value of args to align '
             'with PyTorch official. Previous Implementation: '
             'Hsigmoid(x) = min(max((x + 1) / 2, 0), 1). '
             'Current Implementation: '

--- a/mmcv/cnn/bricks/hsigmoid.py
+++ b/mmcv/cnn/bricks/hsigmoid.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch.nn as nn
-
+import warnings
 from .registry import ACTIVATION_LAYERS
 
 
@@ -26,6 +26,10 @@ class HSigmoid(nn.Module):
 
     def __init__(self, bias=3.0, divisor=6.0, min_value=0.0, max_value=1.0):
         super(HSigmoid, self).__init__()
+        warnings.warn(
+            'In MMCV v1.4.3, we modified the default value of args to align with PyTorch official. '
+            'Previous Implementation: Hsigmoid(x) = min(max((x + 1) / 2, 0), 1). '
+            'Current Implementation: Hsigmoid(x) = min(max((x + 3) / 6, 0), 1).')
         self.bias = bias
         self.divisor = divisor
         assert self.divisor != 0

--- a/mmcv/cnn/bricks/hsigmoid.py
+++ b/mmcv/cnn/bricks/hsigmoid.py
@@ -1,6 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import torch.nn as nn
 import warnings
+
+import torch.nn as nn
+
 from .registry import ACTIVATION_LAYERS
 
 
@@ -27,9 +29,11 @@ class HSigmoid(nn.Module):
     def __init__(self, bias=3.0, divisor=6.0, min_value=0.0, max_value=1.0):
         super(HSigmoid, self).__init__()
         warnings.warn(
-            'In MMCV v1.4.3, we modified the default value of args to align with PyTorch official. '
-            'Previous Implementation: Hsigmoid(x) = min(max((x + 1) / 2, 0), 1). '
-            'Current Implementation: Hsigmoid(x) = min(max((x + 3) / 6, 0), 1).')
+            'In MMCV v1.4.3, we modified the default value of args to align '
+            'with PyTorch official. Previous Implementation: '
+            'Hsigmoid(x) = min(max((x + 1) / 2, 0), 1). '
+            'Current Implementation: '
+            'Hsigmoid(x) = min(max((x + 3) / 6, 0), 1).')
         self.bias = bias
         self.divisor = divisor
         assert self.divisor != 0

--- a/mmcv/cnn/bricks/hsigmoid.py
+++ b/mmcv/cnn/bricks/hsigmoid.py
@@ -8,11 +8,15 @@ from .registry import ACTIVATION_LAYERS
 class HSigmoid(nn.Module):
     """Hard Sigmoid Module. Apply the hard sigmoid function:
     Hsigmoid(x) = min(max((x + bias) / divisor, min_value), max_value)
-    Default: Hsigmoid(x) = min(max((x + 1) / 2, 0), 1)
+    Default: Hsigmoid(x) = min(max((x + 3) / 6, 0), 1)
+
+    Note:
+        In MMCV v1.4.3, we modified the default value of args to align with
+        PyTorch official.
 
     Args:
-        bias (float): Bias of the input feature map. Default: 1.0.
-        divisor (float): Divisor of the input feature map. Default: 2.0.
+        bias (float): Bias of the input feature map. Default: 3.0.
+        divisor (float): Divisor of the input feature map. Default: 6.0.
         min_value (float): Lower bound value. Default: 0.0.
         max_value (float): Upper bound value. Default: 1.0.
 
@@ -20,7 +24,7 @@ class HSigmoid(nn.Module):
         Tensor: The output tensor.
     """
 
-    def __init__(self, bias=1.0, divisor=2.0, min_value=0.0, max_value=1.0):
+    def __init__(self, bias=3.0, divisor=6.0, min_value=0.0, max_value=1.0):
         super(HSigmoid, self).__init__()
         self.bias = bias
         self.divisor = divisor

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,4 +6,4 @@ onnxruntime>=1.8.0
 pytest
 PyTurboJPEG
 scipy
-tiffile
+tifffile

--- a/tests/test_cnn/test_hsigmoid.py
+++ b/tests/test_cnn/test_hsigmoid.py
@@ -9,13 +9,26 @@ def test_hsigmoid():
     with pytest.raises(AssertionError):
         HSigmoid(divisor=0)
 
-    # test with designated parameters
+    # test with default parameters
     act = HSigmoid()
     input_shape = torch.Size([1, 3, 64, 64])
     input = torch.randn(input_shape)
     output = act(input)
     expected_output = torch.min(
         torch.max((input + 3) / 6, torch.zeros(input_shape)),
+        torch.ones(input_shape))
+    # test output shape
+    assert output.shape == expected_output.shape
+    # test output value
+    assert torch.equal(output, expected_output)
+
+    # test with designated parameters
+    act = HSigmoid(1, 2, 0, 1)
+    input_shape = torch.Size([1, 3, 64, 64])
+    input = torch.randn(input_shape)
+    output = act(input)
+    expected_output = torch.min(
+        torch.max((input + 1) / 2, torch.zeros(input_shape)),
         torch.ones(input_shape))
     # test output shape
     assert output.shape == expected_output.shape

--- a/tests/test_cnn/test_hsigmoid.py
+++ b/tests/test_cnn/test_hsigmoid.py
@@ -9,21 +9,8 @@ def test_hsigmoid():
     with pytest.raises(AssertionError):
         HSigmoid(divisor=0)
 
-    # test with default parameters
-    act = HSigmoid()
-    input_shape = torch.Size([1, 3, 64, 64])
-    input = torch.randn(input_shape)
-    output = act(input)
-    expected_output = torch.min(
-        torch.max((input + 1) / 2, torch.zeros(input_shape)),
-        torch.ones(input_shape))
-    # test output shape
-    assert output.shape == expected_output.shape
-    # test output value
-    assert torch.equal(output, expected_output)
-
     # test with designated parameters
-    act = HSigmoid(3, 6, 0, 1)
+    act = HSigmoid()
     input_shape = torch.Size([1, 3, 64, 64])
     input = torch.randn(input_shape)
     output = act(input)


### PR DESCRIPTION
## Motivation

Align `HSigmoid` with pytorch official.
PyTorch `Hardsigmoid` is provided from 1.6.0 and does not support `bias`, `divisor`, `min_value`, `max_value` args.

## Modification

mmcv/cnn/bricks/hsigmoid.py
tests/test_cnn/test_hsigmoid.py

## BC-breaking (Optional)

Yes. Downstream projects could keep compatibility with this PR by modifying the args of `HSigmoid`.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
