### PR TITLE
Implement `FixedMomentumUpdaterHook`

### DIFF
--- a/mmcv/runner/hooks/momentum_updater.py
+++ b/mmcv/runner/hooks/momentum_updater.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import mmcv
-from .hook import HOOKS, Hook
+from .hook import Hook, HOOKS
 from .lr_updater import annealing_cos, annealing_linear, format_param
 
 
@@ -83,7 +83,7 @@ class MomentumUpdaterHook(Hook):
                     _momentum / (1 - k) for _momentum in self.regular_mom
                 ]
             elif self.warmup == 'exp':
-                k = self.warmup_ratio**(1 - cur_iters / self.warmup_iters)
+                k = self.warmup_ratio ** (1 - cur_iters / self.warmup_iters)
                 warmup_momentum = [
                     _momentum / k for _momentum in self.regular_mom
                 ]
@@ -151,6 +151,16 @@ class MomentumUpdaterHook(Hook):
 
 
 @HOOKS.register_module()
+class FixedMomentumUpdaterHook(MomentumUpdaterHook):
+
+    def __init__(self, **kwargs):
+        super(MomentumUpdaterHook, self).__init__(**kwargs)
+
+    def get_momentum(self, runner, base_momentum):
+        raise base_momentum
+
+
+@HOOKS.register_module()
 class StepMomentumUpdaterHook(MomentumUpdaterHook):
     """Step momentum scheduler with min value clipping.
 
@@ -191,7 +201,7 @@ class StepMomentumUpdaterHook(MomentumUpdaterHook):
                     exp = i
                     break
 
-        momentum = base_momentum * (self.gamma**exp)
+        momentum = base_momentum * (self.gamma ** exp)
         if self.min_momentum is not None:
             # clip to a minimum value
             momentum = max(momentum, self.min_momentum)
@@ -411,19 +421,19 @@ class OneCycleMomentumUpdaterHook(MomentumUpdaterHook):
         if self.three_phase:
             self.momentum_phases.append({
                 'end_iter':
-                float(self.pct_start * runner.max_iters) - 1,
+                    float(self.pct_start * runner.max_iters) - 1,
                 'start_momentum':
-                'max_momentum',
+                    'max_momentum',
                 'end_momentum':
-                'base_momentum'
+                    'base_momentum'
             })
             self.momentum_phases.append({
                 'end_iter':
-                float(2 * self.pct_start * runner.max_iters) - 2,
+                    float(2 * self.pct_start * runner.max_iters) - 2,
                 'start_momentum':
-                'base_momentum',
+                    'base_momentum',
                 'end_momentum':
-                'max_momentum'
+                    'max_momentum'
             })
             self.momentum_phases.append({
                 'end_iter': runner.max_iters - 1,
@@ -433,11 +443,11 @@ class OneCycleMomentumUpdaterHook(MomentumUpdaterHook):
         else:
             self.momentum_phases.append({
                 'end_iter':
-                float(self.pct_start * runner.max_iters) - 1,
+                    float(self.pct_start * runner.max_iters) - 1,
                 'start_momentum':
-                'max_momentum',
+                    'max_momentum',
                 'end_momentum':
-                'base_momentum'
+                    'base_momentum'
             })
             self.momentum_phases.append({
                 'end_iter': runner.max_iters - 1,

--- a/mmcv/runner/hooks/momentum_updater.py
+++ b/mmcv/runner/hooks/momentum_updater.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import mmcv
-from .hook import Hook, HOOKS
+from .hook import HOOKS, Hook
 from .lr_updater import annealing_cos, annealing_linear, format_param
 
 
@@ -83,7 +83,7 @@ class MomentumUpdaterHook(Hook):
                     _momentum / (1 - k) for _momentum in self.regular_mom
                 ]
             elif self.warmup == 'exp':
-                k = self.warmup_ratio ** (1 - cur_iters / self.warmup_iters)
+                k = self.warmup_ratio**(1 - cur_iters / self.warmup_iters)
                 warmup_momentum = [
                     _momentum / k for _momentum in self.regular_mom
                 ]
@@ -201,7 +201,7 @@ class StepMomentumUpdaterHook(MomentumUpdaterHook):
                     exp = i
                     break
 
-        momentum = base_momentum * (self.gamma ** exp)
+        momentum = base_momentum * (self.gamma**exp)
         if self.min_momentum is not None:
             # clip to a minimum value
             momentum = max(momentum, self.min_momentum)
@@ -421,19 +421,19 @@ class OneCycleMomentumUpdaterHook(MomentumUpdaterHook):
         if self.three_phase:
             self.momentum_phases.append({
                 'end_iter':
-                    float(self.pct_start * runner.max_iters) - 1,
+                float(self.pct_start * runner.max_iters) - 1,
                 'start_momentum':
-                    'max_momentum',
+                'max_momentum',
                 'end_momentum':
-                    'base_momentum'
+                'base_momentum'
             })
             self.momentum_phases.append({
                 'end_iter':
-                    float(2 * self.pct_start * runner.max_iters) - 2,
+                float(2 * self.pct_start * runner.max_iters) - 2,
                 'start_momentum':
-                    'base_momentum',
+                'base_momentum',
                 'end_momentum':
-                    'max_momentum'
+                'max_momentum'
             })
             self.momentum_phases.append({
                 'end_iter': runner.max_iters - 1,
@@ -443,11 +443,11 @@ class OneCycleMomentumUpdaterHook(MomentumUpdaterHook):
         else:
             self.momentum_phases.append({
                 'end_iter':
-                    float(self.pct_start * runner.max_iters) - 1,
+                float(self.pct_start * runner.max_iters) - 1,
                 'start_momentum':
-                    'max_momentum',
+                'max_momentum',
                 'end_momentum':
-                    'base_momentum'
+                'base_momentum'
             })
             self.momentum_phases.append({
                 'end_iter': runner.max_iters - 1,

--- a/mmcv/runner/hooks/momentum_updater.py
+++ b/mmcv/runner/hooks/momentum_updater.py
@@ -157,7 +157,7 @@ class FixedMomentumUpdaterHook(MomentumUpdaterHook):
         super(MomentumUpdaterHook, self).__init__(**kwargs)
 
     def get_momentum(self, runner, base_momentum):
-        raise base_momentum
+        return base_momentum
 
 
 @HOOKS.register_module()


### PR DESCRIPTION
## Motivation

Currently, I was implementing YOLOv5 model with `mmdetection` and found out that there are not an existed api to implement a momentum updater with warmup scheme only. So I refered to the `FixedLrUpdaterHook` and implemented a `FixedMomentumUpdaterHook` to fill the vacancy.

## Modification

Implemented `FixedMomentumUpdaterHook` in `mmcv.runner.hook.momentum_updater.py`.

## Use cases

Model with warmup momentum update and fixed momentum else.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
