### PR TITLE
Fix Windows cuda compilation error on floor()

### DIFF
--- a/mmcv/ops/csrc/common/cuda/riroi_align_rotated_cuda_kernel.cuh
+++ b/mmcv/ops/csrc/common/cuda/riroi_align_rotated_cuda_kernel.cuh
@@ -47,7 +47,7 @@ __global__ void riroi_align_rotated_forward_cuda_kernel(
 
     // find aligned index
     scalar_t ind_float = theta * num_orientations / (2 * M_PI);
-    int ind = floor(ind_float);
+    int ind = floorf(ind_float);
     scalar_t l_var = ind_float - (scalar_t)ind;
     scalar_t r_var = 1.0 - l_var;
     // correct start channel
@@ -150,7 +150,7 @@ __global__ void riroi_align_rotated_backward_cuda_kernel(
 
     // find aligned index
     scalar_t ind_float = theta * num_orientations / (2 * M_PI);
-    int ind = floor(ind_float);
+    int ind = floorf(ind_float);
     scalar_t l_var = ind_float - (scalar_t)ind;
     scalar_t r_var = 1.0 - l_var;
     // correct start channel

--- a/mmcv/ops/csrc/common/cuda/voxelization_cuda_kernel.cuh
+++ b/mmcv/ops/csrc/common/cuda/voxelization_cuda_kernel.cuh
@@ -23,20 +23,20 @@ __global__ void dynamic_voxelize_kernel(
     // To save some computation
     auto points_offset = points + index * num_features;
     auto coors_offset = coors + index * NDim;
-    int c_x = floor((points_offset[0] - coors_x_min) / voxel_x);
+    int c_x = floorf((points_offset[0] - coors_x_min) / voxel_x);
     if (c_x < 0 || c_x >= grid_x) {
       coors_offset[0] = -1;
       continue;
     }
 
-    int c_y = floor((points_offset[1] - coors_y_min) / voxel_y);
+    int c_y = floorf((points_offset[1] - coors_y_min) / voxel_y);
     if (c_y < 0 || c_y >= grid_y) {
       coors_offset[0] = -1;
       coors_offset[1] = -1;
       continue;
     }
 
-    int c_z = floor((points_offset[2] - coors_z_min) / voxel_z);
+    int c_z = floorf((points_offset[2] - coors_z_min) / voxel_z);
     if (c_z < 0 || c_z >= grid_z) {
       coors_offset[0] = -1;
       coors_offset[1] = -1;


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Compilation errors in CUDA kernels on floor() calls. Type mismatch, floorf must be used for float.

## Modification

Replace floor() by floorf().

## Environment
Windows 10
Visual Studio Community 2019 (v16.9.4)
MSVC++ 14.28
CUDA 11.1

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
