### PR TITLE
Support deepcopy for Config

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -529,7 +529,8 @@ class Config:
         return (self._cfg_dict, self._filename, self._text)
 
     def __deepcopy__(self, memo):
-        other = self.__class__()
+        cls = self.__class__
+        other = cls.__new__(cls)
         memo[id(self)] = other
 
         for key, value in self.__dict__.items():

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -532,13 +532,8 @@ class Config:
         other = self.__class__()
         memo[id(self)] = other
 
-        _cfg_dict = copy.deepcopy(self._cfg_dict, memo)
-        _filename = copy.deepcopy(self._filename, memo)
-        _text = copy.deepcopy(self._text, memo)
-
-        super(Config, other).__setattr__('_cfg_dict', _cfg_dict)
-        super(Config, other).__setattr__('_filename', _filename)
-        super(Config, other).__setattr__('_text', _text)
+        for key, value in self.__dict__.items():
+            super(Config, other).__setattr__(key, copy.deepcopy(value, memo))
 
         return other
 

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -528,6 +528,20 @@ class Config:
     def __getstate__(self):
         return (self._cfg_dict, self._filename, self._text)
 
+    def __deepcopy__(self, memo):
+        other = self.__class__()
+        memo[id(self)] = other
+
+        _cfg_dict = copy.deepcopy(self._cfg_dict, memo)
+        _filename = copy.deepcopy(self._filename, memo)
+        _text = copy.deepcopy(self._text, memo)
+
+        super(Config, other).__setattr__('_cfg_dict', _cfg_dict)
+        super(Config, other).__setattr__('_filename', _filename)
+        super(Config, other).__setattr__('_text', _text)
+
+        return other
+
     def __setstate__(self, state):
         _cfg_dict, _filename, _text = state
         super(Config, self).__setattr__('_cfg_dict', _cfg_dict)

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -544,6 +544,7 @@ def test_deepcopy():
     cfg = Config.fromfile(cfg_file)
     new_cfg = copy.deepcopy(cfg)
 
+    assert isinstance(new_cfg, Config)
     assert new_cfg._cfg_dict == cfg._cfg_dict
     assert new_cfg._cfg_dict is not cfg._cfg_dict
     assert new_cfg._filename == cfg._filename

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
+import copy
 import json
 import os
 import os.path as osp
@@ -536,3 +537,14 @@ def test_deprecation():
         with pytest.warns(DeprecationWarning):
             cfg = Config.fromfile(cfg_file)
         assert cfg.item1 == 'expected'
+
+
+def test_deepcopy():
+    cfg_file = osp.join(data_path, 'config/n.py')
+    cfg = Config.fromfile(cfg_file)
+    new_cfg = copy.deepcopy(cfg)
+
+    assert new_cfg._cfg_dict == cfg._cfg_dict
+    assert new_cfg._cfg_dict is not cfg._cfg_dict
+    assert new_cfg._filename == cfg._filename
+    assert new_cfg._text == cfg._text


### PR DESCRIPTION
## Motivation

The original `Config` doesn't support deep copy because it will call the `__deepcopy__` method of `ConfigDict`.

## Modification

Add `__deepcopy__` to `Config`.

## BC-breaking (Optional)

No

## Use cases (Optional)

- Before the PR

  ```python
  >>> from mmcv import Config
  >>> from copy import deepcopy
  >>> cfg = Config.fromfile("./tests/data/config/a.py")
  >>> new_cfg = deepcopy(cfg)
  >>> type(cfg) == type(new_cfg)
  False
  >>> type(cfg), type(new_cfg)
  (mmcv.utils.config.Config, mmcv.utils.config.ConfigDict)
    ```

- After the PR

  ```python
  >>> from mmcv import Config
  >>> from copy import deepcopy
  >>> cfg = Config.fromfile("./tests/data/config/a.py")
  >>> new_cfg = deepcopy(cfg)
  >>> type(cfg) == type(new_cfg)
  True
  >>> type(cfg), type(new_cfg)
  (mmcv.utils.config.Config, mmcv.utils.config.Config)
  >>> print(cfg._cfg_dict == new_cfg._cfg_dict)
  True
  >>> print(cfg._cfg_dict is new_cfg._cfg_dict)
  False
  ```

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
