### PR TITLE
[Fix] fix a bug of CUDA illegal mem access when training s2anet

### DIFF
--- a/mmcv/ops/csrc/pytorch/cuda/active_rotated_filter_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/active_rotated_filter_cuda.cu
@@ -14,7 +14,7 @@ void ActiveRotatedFilterForwardCUDAKernelLauncher(const Tensor input,
   int kW = input.size(4);
   int num_rotations = indices.size(3);
   int nEntry = num_orientations * kH * kW;
-  int output_size = output.numel();
+  int output_size = input.numel();
 
   at::cuda::CUDAGuard device_guard(input.device());
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();


### PR DESCRIPTION
Fix a bug in the op `active_rotated_filter`. The buggy code incurs "CUDA illegal memory access" and `nan` loss after training s2anet for several iterations.