### PR TITLE
[Feature] Add a script to visualize lr

### DIFF
--- a/.dev_scripts/visualize_lr.py
+++ b/.dev_scripts/visualize_lr.py
@@ -20,7 +20,9 @@ from mmcv.utils import get_logger
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Visualize the given config of learning rate and momentum')
+    parser = argparse.ArgumentParser(description='Visualize the given config'
+                                     'of learning rate and '
+                                     'momentum')
     parser.add_argument('config', help='train config file path')
     parser.add_argument(
         '--work-dir', default='./', help='the dir to save logs and models')

--- a/.dev_scripts/visualize_lr.py
+++ b/.dev_scripts/visualize_lr.py
@@ -1,0 +1,139 @@
+import argparse
+import json
+import os
+import os.path as osp
+import time
+import warnings
+from unittest.mock import Mock, patch
+
+import matplotlib.pyplot as plt
+import torch.nn as nn
+from torch.optim import SGD
+from torch.utils.data import DataLoader
+
+import mmcv
+from mmcv.runner import build_runner
+from mmcv.utils import get_logger
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Train a detector')
+    parser.add_argument('config', help='train config file path')
+    parser.add_argument(
+        '--work-dir', default='./', help='the dir to save logs and models')
+    parser.add_argument(
+        '--num-iters', default=300, help='The number of iters per epoch')
+    parser.add_argument(
+        '--num-epochs', default=10, help='Only used in EpochBasedRinner')
+    parser.add_argument(
+        '--window-size',
+        default='12*7',
+        help='Size of the window to display images, in format of "$W*$H".')
+    parser.add_argument(
+        '--log-interval', default=1, help='The iterval of TextLoggerHook')
+    args = parser.parse_args()
+    return args
+
+
+class SimpleModel(nn.Module):
+
+    def __init__(self):
+        super(SimpleModel, self).__init__()
+        self.conv = nn.Conv2d(1, 1, 1)
+
+    def train_step(self, *args, **kwargs):
+        return dict()
+
+    def val_step(self, *args, **kwargs):
+        return dict()
+
+
+@patch('mmcv.runner.EpochBasedRunner.run_iter', Mock())
+def run(cfg, logger):
+    assert cfg.get('lr_config')
+    model = SimpleModel()
+    optimizer = SGD(model.parameters(), 0.1)
+    cfg.work_dir = cfg.get('work_dir', './')
+    workflow = [('train', 1)]
+
+    if cfg.get('runner') is None:
+        cfg.runner = {
+            'type': 'EpochBasedRunner',
+            'max_epochs': cfg.get('total_epochs', cfg.num_epochs)
+        }
+        warnings.warn(
+            'config is now expected to have a `runner` section, '
+            'please set `runner` in your config.', UserWarning)
+    fake_dataloader = DataLoader(list(range(cfg.num_iters)), batch_size=1)
+    runner = build_runner(
+        cfg.runner,
+        default_args=dict(
+            model=model,
+            batch_processor=None,
+            optimizer=optimizer,
+            work_dir=cfg.work_dir,
+            logger=logger,
+            meta=None))
+    lr_config = cfg.lr_config
+    log_config = dict(
+        interval=cfg.log_interval, hooks=[
+            dict(type='TextLoggerHook'),
+        ])
+    runner.register_training_hooks(lr_config, log_config=log_config)
+    runner.run([fake_dataloader], workflow)
+
+
+def plot_lr_curve(json_file, cfg):
+    lr_list = []
+    assert os.path.isfile(json_file)
+    with open(json_file, 'r') as f:
+        for line in f:
+            log = json.loads(line.strip())
+            lr_list.append(log['lr'])
+    wind_w, wind_h = [int(size) for size in cfg.window_size.split('*')]
+    plt.figure(figsize=(wind_w, wind_h))
+    # if legend is None, use {filename}_{key} as legend
+
+    ax: plt.Axes = plt.subplot()
+
+    ax.plot(lr_list, linewidth=1)
+    if cfg.runner.type == 'EpochBasedRunner':
+        ax.xaxis.tick_top()
+        ax.set_xlabel('Iters')
+        ax.xaxis.set_label_position('top')
+        sec_ax = ax.secondary_xaxis(
+            'bottom',
+            functions=(lambda x: x / cfg.num_iters * cfg.log_interval,
+                       lambda y: y * cfg.num_iters * cfg.log_interval))
+        sec_ax.set_xlabel('Epochs')
+    else:
+        plt.xlabel('Iters')
+    plt.ylabel('Learning Rate')
+    title = cfg.lr_config.type
+    plt.title(title)
+
+    save_path = osp.join(cfg.work_dir, title)
+    plt.savefig(save_path)
+    print(f'The learning rate graph is saved at {save_path}')
+    plt.show()
+
+
+def main():
+    args = parse_args()
+    timestamp = time.strftime('%Y%m%d_%H%M%S', time.localtime())
+    cfg = mmcv.Config.fromfile(args.config)
+    cfg['num_iters'] = args.num_iters
+    cfg['num_epochs'] = args.num_epochs
+    cfg['log_interval'] = args.log_interval
+    cfg['window_size'] = args.window_size
+
+    log_path = osp.join(cfg.get('work_dir', './'), f'{timestamp}.log')
+    json_path = log_path + '.json'
+    logger = get_logger('mmcv', log_path)
+
+    run(cfg, logger)
+    plot_lr_curve(json_path, cfg)
+
+
+if __name__ == '__main__':
+    main()

--- a/.dev_scripts/visualize_lr.py
+++ b/.dev_scripts/visualize_lr.py
@@ -158,6 +158,7 @@ def plot_lr_curve(json_file, cfg):
                 'bottom',
                 functions=(lambda x: x / cfg.num_iters * cfg.log_interval,
                            lambda y: y * cfg.num_iters / cfg.log_interval))
+            sec_ax.tick_params(labelsize=font_size)
             sec_ax.set_xlabel('Epochs', fontsize=font_size)
         else:
             # plt.subplot(2, 1, index + 1)
@@ -178,8 +179,7 @@ def plot_lr_curve(json_file, cfg):
         ax.set_title(title, fontsize=font_size)
         ax.grid()
         # set tick font size
-        ax.xaxis.set_tick_params(labelsize=font_size)
-        ax.yaxis.set_tick_params(labelsize=font_size)
+        ax.tick_params(labelsize=font_size)
     save_path = osp.join(cfg.work_dir, 'visualization-result')
     plt.savefig(save_path)
     print(f'The learning rate graph is saved at {save_path}')

--- a/.dev_scripts/visualize_lr.py
+++ b/.dev_scripts/visualize_lr.py
@@ -20,7 +20,7 @@ from mmcv.utils import get_logger
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='Train a detector')
+    parser = argparse.ArgumentParser(description='Visualize the given config of learning rate and momentum')
     parser.add_argument('config', help='train config file path')
     parser.add_argument(
         '--work-dir', default='./', help='the dir to save logs and models')

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = pkg_resources,setuptools,logging,os,warnings,abc
 known_first_party = mmcv
-known_third_party = addict,cv2,numpy,onnx,onnxruntime,packaging,pytest,pytorch_sphinx_theme,scipy,sphinx,tensorrt,torch,torchvision,yaml,yapf
+known_third_party = addict,cv2,matplotlib,numpy,onnx,onnxruntime,packaging,pytest,pytorch_sphinx_theme,scipy,sphinx,tensorrt,torch,torchvision,yaml,yapf
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification
Add learning rate visualization script. The learning rate curve of target schedule registered in `EpochBasedRunner or IterBasedRunner` can be plot  as follows:

`python ./visualize_lr.py schedule_config.py `
The schedule_config.py can be:
```
lr_config = dict(
    policy='cyclic',
    # anneal_strategy='linear',
    target_ratio=(10, 1e-4),
    cyclic_times=5,
    step_ratio_up=0.4,
)

momentum_config = dict(
    policy='cyclic',
    # anneal_strategy='linear',
    target_ratio=(10, 1e-4),
    cyclic_times=5
)

runner = dict(type='IterBasedRunner',
              max_iters=1000)
```
The log of the runner will be saved in target work_dir and the learning rate curve will be plot according to the json log file:
![image](https://user-images.githubusercontent.com/57566630/149507328-7b62e393-1f4c-4488-9acd-320713082d8b.png)
The visualization of epoch based runner:
```
lr_config = dict(
    policy='cyclic',
    # anneal_strategy='linear',
    target_ratio=(10, 1e-4),
    cyclic_times=5,
    step_ratio_up=0.4,
)

momentum_config = dict(
    policy='cyclic',
    # anneal_strategy='linear',
    target_ratio=(10, 1e-4),
    cyclic_times=5
)
```
![image](https://user-images.githubusercontent.com/57566630/149511069-76be9b6c-63c7-49b1-8871-03bbb4cfe31b.png)





## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
