### PR TITLE
[Bug] Getting torchvision models path

### DIFF
--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -106,7 +106,9 @@ def load_state_dict(module, state_dict, strict=False, logger=None):
 
 
 def get_torchvision_models():
-    model_urls = dict()
+    model_urls = dict()    
+    # Add a prefix to avoid returning wrong directories
+    # More details at https://github.com/open-mmlab/mmcv/pull/1668
     for _, name, ispkg in pkgutil.walk_packages(torchvision.models.__path__,
                                                 prefix='models.'):
         if ispkg:

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -107,7 +107,8 @@ def load_state_dict(module, state_dict, strict=False, logger=None):
 
 def get_torchvision_models():
     model_urls = dict()
-    for _, name, ispkg in pkgutil.walk_packages(torchvision.models.__path__, prefix='models.'):
+    for _, name, ispkg in pkgutil.walk_packages(torchvision.models.__path__,
+                                                prefix='models.'):
         if ispkg:
             continue
         _zoo = import_module(f'torchvision.{name}')

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -106,7 +106,7 @@ def load_state_dict(module, state_dict, strict=False, logger=None):
 
 
 def get_torchvision_models():
-    model_urls = dict()    
+    model_urls = dict()
     # Add a prefix to avoid returning wrong directories
     # More details at https://github.com/open-mmlab/mmcv/pull/1668
     for _, name, ispkg in pkgutil.walk_packages(torchvision.models.__path__,

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -107,10 +107,10 @@ def load_state_dict(module, state_dict, strict=False, logger=None):
 
 def get_torchvision_models():
     model_urls = dict()
-    for _, name, ispkg in pkgutil.walk_packages(torchvision.models.__path__):
+    for _, name, ispkg in pkgutil.walk_packages(torchvision.models.__path__, prefix='models.'):
         if ispkg:
             continue
-        _zoo = import_module(f'torchvision.models.{name}')
+        _zoo = import_module(f'torchvision.{name}')
         if hasattr(_zoo, 'model_urls'):
             _urls = getattr(_zoo, 'model_urls')
             model_urls.update(_urls)


### PR DESCRIPTION
🐛 pkgutil.walk_packages searches unintended path

There are 'detection', 'segmentation', 'video' directories in ['torchvision/models'](https://github.com/pytorch/vision/tree/main/torchvision/models)
If any directories which have the same name as any of above directories are on where you run 'get_torchvision_models()', 'pkgutil.walk_packages' will return including those directories. But those directories doesn't have torchvision model in them, so you will get error.

For example,
Your curruent path: /home/user/work
Directory structure is,

```
work
  |---detection
        |---any.py
        |---file.py
```
If you run
```
model_urls = dict()
for _, name, ispkg in pkgutil.walk_packages(torchvision.models.__path__):
    if ispkg:
        continue
    _zoo = import_module(f'torchvision.models.{name}')
    if hasattr(_zoo, 'model_urls'):
        _urls = getattr(_zoo, 'model_urls')
        model_urls.update(_urls)
```

You will get
```
ModuleNotFoundError: No module named 'torchvision.models.detection.any'
```

To prevent this case, you should add "prefix" option on 'pkgutil.walk_packages'.
