### PR TITLE
[Fix] refactor fp16 utils code so that the integer tensor will not be auto-cast into fp16

### DIFF
--- a/mmcv/runner/fp16_utils.py
+++ b/mmcv/runner/fp16_utils.py
@@ -35,7 +35,7 @@ def cast_tensor_type(inputs, src_type, dst_type):
     if isinstance(inputs, nn.Module):
         return inputs
     elif isinstance(inputs, torch.Tensor):
-        return inputs.to(dst_type)
+        return inputs.to(dst_type) if inputs.is_floating_point() else inputs
     elif isinstance(inputs, str):
         return inputs
     elif isinstance(inputs, np.ndarray):


### PR DESCRIPTION
The original `cast_tensor_type` function sometimes unexpectedly casts integer tensors into fp16 tensors. For almost every situation during fp16 mix precision training, auto-casting integer tensors into fp16 does not make any sense.

PyTorch Tensors' definition is somewhat obscure. According to the official doc here: 
[torch.Tensor is an alias for the default tensor type (torch.FloatTensor).](https://pytorch.org/docs/stable/tensors.html)
But the following statement always returns `True`
```isinstance(torch.LongTensor([1,2,3]), torch.Tensor)```

So I add another branch(`if inputs.is_floating_point()`) to protect integer tensors from being cast.