### PR TITLE
[Fix] mlflow logger error

### DIFF
--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -1,4 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import torch
+
 from ...dist_utils import master_only
 from ..hook import HOOKS
 from .base import LoggerHook
@@ -73,4 +75,7 @@ class MlflowLoggerHook(LoggerHook):
     @master_only
     def after_run(self, runner):
         if self.log_model:
-            self.mlflow_pytorch.log_model(runner.model, 'models')
+            self.mlflow_pytorch.log_model(
+                runner.model,
+                'models',
+                pip_requirements=[f'torch=={torch.__version__}'])

--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -1,6 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import torch
-
+from mmcv.utils import TORCH_VERSION
 from ...dist_utils import master_only
 from ..hook import HOOKS
 from .base import LoggerHook
@@ -78,4 +77,4 @@ class MlflowLoggerHook(LoggerHook):
             self.mlflow_pytorch.log_model(
                 runner.model,
                 'models',
-                pip_requirements=[f'torch=={torch.__version__}'])
+                pip_requirements=[f'torch=={TORCH_VERSION}'])

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -1375,7 +1375,9 @@ def test_mlflow_hook(log_model):
         }, step=6)
     if log_model:
         hook.mlflow_pytorch.log_model.assert_called_with(
-            runner.model, 'models')
+            runner.model,
+            'models',
+            pip_requirements=[f'torch=={torch.__version__}'])
     else:
         assert not hook.mlflow_pytorch.log_model.called
 

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -34,6 +34,7 @@ from mmcv.runner.hooks.lr_updater import (CosineRestartLrUpdaterHook,
                                           FlatCosineAnnealingLrUpdaterHook,
                                           OneCycleLrUpdaterHook,
                                           StepLrUpdaterHook)
+from mmcv.utils import TORCH_VERSION
 
 sys.modules['petrel_client'] = MagicMock()
 sys.modules['petrel_client.client'] = MagicMock()
@@ -1377,7 +1378,7 @@ def test_mlflow_hook(log_model):
         hook.mlflow_pytorch.log_model.assert_called_with(
             runner.model,
             'models',
-            pip_requirements=[f'torch=={torch.__version__}'])
+            pip_requirements=[f'torch=={TORCH_VERSION}'])
     else:
         assert not hook.mlflow_pytorch.log_model.called
 


### PR DESCRIPTION

## Motivation

https://github.com/mlflow/mlflow/issues/4903
Mlflow logger throws an error when saving the pytorch model due to mismatch between torch version and mlflow's torch version interpretation.

## Modification

Followed the suggestion. https://github.com/mlflow/mlflow/issues/4903#issuecomment-944342775

https://mlflow.org/docs/latest/python_api/mlflow.pytorch.html#mlflow.pytorch.log_model
