### PR TITLE
[Fix] DDP duplicate logs handling

### DIFF
--- a/mmcv/utils/logging.py
+++ b/mmcv/utils/logging.py
@@ -48,6 +48,10 @@ def get_logger(name, log_file=None, log_level=logging.INFO, file_mode='w'):
     for handler in logger.root.handlers:
         if type(handler) is logging.StreamHandler:
             handler.setLevel(logging.ERROR)
+    else:
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(logging.ERROR)
+        logger.root.handlers.append(stream_handler)
 
     stream_handler = logging.StreamHandler()
     handlers = [stream_handler]


### PR DESCRIPTION
## Motivation

Essentially, PyTorch DDP attaches StreamHandler directly after first forward() and by default logger.root.handlers may be empty list

## Modification

Added manual append to root.handlers list of StreamHandler with level ERROR in case of empty list

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
