### PR TITLE
ConvModule has no respect to `init_cfg`

### DIFF
--- a/mmcv/cnn/bricks/conv_module.py
+++ b/mmcv/cnn/bricks/conv_module.py
@@ -163,7 +163,7 @@ class ConvModule(nn.Module):
             self.activate = build_activation_layer(act_cfg_)
 
         # Use msra init by default
-        self.init_weights()
+        self._init_default_weights()
 
     @property
     def norm(self):
@@ -172,7 +172,7 @@ class ConvModule(nn.Module):
         else:
             return None
 
-    def init_weights(self):
+    def _init_default_weights(self):
         # 1. It is mainly for customized conv layers with their own
         #    initialization manners by calling their own ``init_weights()``,
         #    and we do not want ConvModule to override the initialization.


### PR DESCRIPTION
## Motivation

`ConvModule` has no respect to `init_cfg` and always initialized with it's own `init_weights` function.

open-mmlab/mmcv#772 implemented the `BaseModule` class which will recursively call `init_weights` of sub-module. When a `ConvModule` is an attribution of one `BaseMocule`, it will initilize the `Conv2d` layer with `kaiming_init` regardless of the `init_cfg`. This requires the downstream application should carefully separate the `ConvModule` with the `nn.Module`, `nn.ModuleList` or `nn.Sequential`, which will break the `init_weights` call chain. Or, overwirte the `init_weights` function of user module.

I checked the mmclassification repo and it avoids the impact with the above trick, but there are several models in mmdetection that are already affected by this bug, although the initialization in `init_weights` of `ConvModule` is robust enough to train a good result.

## Modification

The `init_weights` of `ConvModule` is intended to be called once in the `__init__` function, so I think it is better to rename it to other name rather than `init_weights`.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
