### PR TITLE
[Fix] batched nms for nms_rotated

### DIFF
--- a/mmcv/ops/nms.py
+++ b/mmcv/ops/nms.py
@@ -318,6 +318,7 @@ def batched_nms(boxes, scores, idxs, nms_cfg, class_agnostic=False):
 
     nms_type = nms_cfg_.pop('type', 'nms')
     nms_op = eval(nms_type)
+    score_dim = 5 if 'rotated' in nms_type else 4
 
     split_thr = nms_cfg_.pop('split_thr', 10000)
     # Won't split to multiple nms nodes when exporting to onnx
@@ -329,7 +330,7 @@ def batched_nms(boxes, scores, idxs, nms_cfg, class_agnostic=False):
         # the last dimension is score.
         # TODO: more elegant way to handle the dimension issue.
         # Some type of nms would reweight the score, such as SoftNMS
-        scores = dets[:, 4]
+        scores = dets[:, score_dim]
     else:
         max_num = nms_cfg_.pop('max_num', -1)
         total_mask = scores.new_zeros(scores.size(), dtype=torch.bool)

--- a/mmcv/ops/nms.py
+++ b/mmcv/ops/nms.py
@@ -324,17 +324,13 @@ def batched_nms(boxes, scores, idxs, nms_cfg, class_agnostic=False):
     if boxes_for_nms.shape[0] < split_thr or torch.onnx.is_in_onnx_export():
         dets, keep = nms_op(boxes_for_nms, scores, **nms_cfg_)
         boxes = boxes[keep]
-        # -1 indexing works abnormal in TensorRT
 
         # This assumes `dets` has arbitrary dimensions where
         # the last dimension is score.
-        # Currently it supports bounding boxes [x1, y1, x2, y2, score] and
+        # Currently it supports bounding boxes [x1, y1, x2, y2, score] or
         # rotated boxes [cx, cy, w, h, angle_radian, score].
-        # TODO: more elegant way to handle the dimension issue.
-        # Some type of nms would reweight the score, such as SoftNMS
 
-        score_dim = dets.size(1) - 1
-        scores = dets[:, score_dim]
+        scores = dets[:, -1]
     else:
         max_num = nms_cfg_.pop('max_num', -1)
         total_mask = scores.new_zeros(scores.size(), dtype=torch.bool)

--- a/tests/test_ops/test_nms_rotated.py
+++ b/tests/test_ops/test_nms_rotated.py
@@ -68,3 +68,17 @@ class TestNmsRotated:
         dets[..., -2] *= -1
         assert np.allclose(dets.cpu().numpy()[:, :5], np_expect_dets)
         assert np.allclose(keep_inds.cpu().numpy(), np_expect_keep_inds)
+
+        # test batched_nms with nms_rotated
+        from mmcv.ops import batched_nms
+
+        nms_cfg = dict(type='nms_rotated', iou_threshold=0.5)
+
+        boxes, keep = batched_nms(
+            torch.from_numpy(np_boxes[:, :5]),
+            torch.from_numpy(np_boxes[:, -1]),
+            torch.from_numpy(np.array([0, 0, 0, 0])),
+            nms_cfg,
+            class_agnostic=False)
+        assert np.allclose(boxes.cpu().numpy()[:, :5], np_expect_dets)
+        assert np.allclose(keep.cpu().numpy(), np_expect_keep_inds)


### PR DESCRIPTION
## Motivation

Currently, `batched_nms` does not work appropriately when nms_type is set to 'nms_rotated'.
```
    if boxes_for_nms.shape[0] < split_thr or torch.onnx.is_in_onnx_export():
        dets, keep = nms_op(boxes_for_nms, scores, **nms_cfg_)
        boxes = boxes[keep]
        # -1 indexing works abnormal in TensorRT
        # This assumes `dets` has 5 dimensions where
        # the last dimension is score.
        # TODO: more elegant way to handle the dimension issue.
        # Some type of nms would reweight the score, such as SoftNMS
        scores = dets[:, 4]
```
This is due to fixed indexing for scores.

## Modification

I added a conditional variable to determine the index of scores.

## Consideration
`nms_match` cannot be evaluated with batched_nms, too.
Should we add assertion for nms_type?