### PR TITLE
[Fix] Ensure the type of filename parameter in Config is str

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -12,6 +12,7 @@ import warnings
 from argparse import Action, ArgumentParser
 from collections import abc
 from importlib import import_module
+from pathlib import Path
 
 from addict import Dict
 from yapf.yapflib.yapf_api import FormatCode
@@ -386,6 +387,9 @@ class Config:
         for key in cfg_dict:
             if key in RESERVED_KEYS:
                 raise KeyError(f'{key} is reserved for config file')
+
+        if isinstance(filename, Path):
+            filename = str(filename)
 
         super(Config, self).__setattr__('_cfg_dict', ConfigDict(cfg_dict))
         super(Config, self).__setattr__('_filename', filename)

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -332,6 +332,8 @@ class Config:
     def fromfile(filename,
                  use_predefined_variables=True,
                  import_custom_modules=True):
+        if isinstance(filename, Path):
+            filename = str(filename)
         cfg_dict, cfg_text = Config._file2dict(filename,
                                                use_predefined_variables)
         if import_custom_modules and cfg_dict.get('custom_imports', None):

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -28,16 +28,19 @@ def test_construct():
     cfg_dict = dict(item1=[1, 2], item2=dict(a=0), item3=True, item4='test')
     # test a.py
     cfg_file = osp.join(data_path, 'config/a.py')
-    cfg = Config(cfg_dict, filename=cfg_file)
-    assert isinstance(cfg, Config)
-    assert cfg.filename == cfg_file
-    assert cfg.text == open(cfg_file, 'r').read()
-    assert cfg.dump() == cfg.pretty_text
-    with tempfile.TemporaryDirectory() as temp_config_dir:
-        dump_file = osp.join(temp_config_dir, 'a.py')
-        cfg.dump(dump_file)
-        assert cfg.dump() == open(dump_file, 'r').read()
-        assert Config.fromfile(dump_file)
+    cfg_file_path = Path(cfg_file)
+    file_list = [cfg_file, cfg_file_path]
+    for item in file_list:
+        cfg = Config(cfg_dict, filename=item)
+        assert isinstance(cfg, Config)
+        assert isinstance(cfg.filename, str) and cfg.filename == str(item)
+        assert cfg.text == open(item, 'r').read()
+        assert cfg.dump() == cfg.pretty_text
+        with tempfile.TemporaryDirectory() as temp_config_dir:
+            dump_file = osp.join(temp_config_dir, 'a.py')
+            cfg.dump(dump_file)
+            assert cfg.dump() == open(dump_file, 'r').read()
+            assert Config.fromfile(dump_file)
 
     # test b.json
     cfg_file = osp.join(data_path, 'config/b.json')

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -144,11 +144,14 @@ def test_construct():
 def test_fromfile():
     for filename in ['a.py', 'a.b.py', 'b.json', 'c.yaml']:
         cfg_file = osp.join(data_path, 'config', filename)
-        cfg = Config.fromfile(cfg_file)
-        assert isinstance(cfg, Config)
-        assert cfg.filename == cfg_file
-        assert cfg.text == osp.abspath(osp.expanduser(cfg_file)) + '\n' + \
-            open(cfg_file, 'r').read()
+        cfg_file_path = Path(cfg_file)
+        file_list = [cfg_file, cfg_file_path]
+        for item in file_list:
+            cfg = Config.fromfile(item)
+            assert isinstance(cfg, Config)
+            assert isinstance(cfg.filename, str) and cfg.filename == str(item)
+            assert cfg.text == osp.abspath(osp.expanduser(item)) + '\n' + \
+                open(item, 'r').read()
 
     # test custom_imports for Config.fromfile
     cfg_file = osp.join(data_path, 'config', 'q.py')


### PR DESCRIPTION
## Motivation

Ensure the type of filename parameter in Config is str.

## Modification

As above.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
