### PR TITLE
[Fix] Fix bugs in Voxelization op

### DIFF
--- a/mmcv/ops/csrc/common/cuda/voxelization_cuda_kernel.cuh
+++ b/mmcv/ops/csrc/common/cuda/voxelization_cuda_kernel.cuh
@@ -101,7 +101,7 @@ __global__ void point_to_voxelidx_kernel(const T_int* coor,
   CUDA_1D_KERNEL_LOOP(index, num_points) {
     auto coor_offset = coor + index * NDim;
     // skip invalid points
-    if ((index >= num_points) || (coor_offset[0] == -1)) return;
+    if (coor_offset[0] == -1) return;
 
     int num = 0;
     int coor_x = coor_offset[0];

--- a/mmcv/ops/csrc/common/cuda/voxelization_cuda_kernel.cuh
+++ b/mmcv/ops/csrc/common/cuda/voxelization_cuda_kernel.cuh
@@ -101,7 +101,7 @@ __global__ void point_to_voxelidx_kernel(const T_int* coor,
   CUDA_1D_KERNEL_LOOP(index, num_points) {
     auto coor_offset = coor + index * NDim;
     // skip invalid points
-    if (coor_offset[0] == -1) return;
+    if ((index >= num_points) || (coor_offset[0] == -1)) return;
 
     int num = 0;
     int coor_x = coor_offset[0];

--- a/mmcv/ops/csrc/pytorch/cpu/voxelization.cpp
+++ b/mmcv/ops/csrc/pytorch/cpu/voxelization.cpp
@@ -26,11 +26,15 @@ void dynamic_voxelize_forward_cpu_kernel(
       coor[ndim_minus_1 - j] = c;
     }
 
-    for (int k = 0; k < NDim; ++k) {
-      if (failed)
+    if (failed) {
+      for (int k = 0; k < NDim; ++k) {
         coors[i][k] = -1;
-      else
+      }
+    }
+    else {
+      for (int k = 0; k < NDim; ++k) {
         coors[i][k] = coor[k];
+      }
     }
   }
 

--- a/mmcv/ops/csrc/pytorch/cpu/voxelization.cpp
+++ b/mmcv/ops/csrc/pytorch/cpu/voxelization.cpp
@@ -26,13 +26,16 @@ void dynamic_voxelize_forward_cpu_kernel(
       coor[ndim_minus_1 - j] = c;
     }
 
-    if (failed)
-      memset(&coors[i][0], -1, NDim * sizeof(T_int));
-    else
-      memcpy(&coors[i][0], &coor[0], NDim * sizeof(T_int));
+    for (int k = 0; k < NDim; ++k) {
+      if (failed)
+        coors[i][k] = -1;
+      else
+        coors[i][k] = coor[k];
+    }
   }
 
   delete[] coor;
+  return;
 }
 
 template <typename T, typename T_int>
@@ -72,14 +75,17 @@ void hard_voxelize_forward_cpu_kernel(
       voxel_num += 1;
 
       coor_to_voxelidx[coor[i][0]][coor[i][1]][coor[i][2]] = voxelidx;
-      memcpy(&coors[voxelidx][0], &coor[i][0], NDim * sizeof(T_int));
+      for (int k = 0; k < NDim; ++k) {
+        coors[voxelidx][k] = coor[i][k];
+      }
     }
 
     // put points into voxel
     num = num_points_per_voxel[voxelidx];
     if (max_points == -1 || num < max_points) {
-      memcpy(&voxels[voxelidx][num][0], &points[i][0],
-             num_features * sizeof(T));
+      for (int k = 0; k < num_features; ++k) {
+        voxels[voxelidx][num][k] = points[i][k];
+      }
       num_points_per_voxel[voxelidx] += 1;
     }
   }

--- a/mmcv/ops/csrc/pytorch/cpu/voxelization.cpp
+++ b/mmcv/ops/csrc/pytorch/cpu/voxelization.cpp
@@ -26,6 +26,9 @@ void dynamic_voxelize_forward_cpu_kernel(
       coor[ndim_minus_1 - j] = c;
     }
 
+    // memcpy and memset will cause problem because of the memory distribution
+    // discontinuity of TensorAccessor, so here using loops to replace memcpy
+    // or memset
     if (failed) {
       for (int k = 0; k < NDim; ++k) {
         coors[i][k] = -1;
@@ -78,6 +81,8 @@ void hard_voxelize_forward_cpu_kernel(
       voxel_num += 1;
 
       coor_to_voxelidx[coor[i][0]][coor[i][1]][coor[i][2]] = voxelidx;
+      // memcpy will cause problem because of the memory distribution
+      // discontinuity of TensorAccessor, so here using loops to replace memcpy
       for (int k = 0; k < NDim; ++k) {
         coors[voxelidx][k] = coor[i][k];
       }
@@ -86,6 +91,8 @@ void hard_voxelize_forward_cpu_kernel(
     // put points into voxel
     num = num_points_per_voxel[voxelidx];
     if (max_points == -1 || num < max_points) {
+      // memcpy will cause problem because of the memory distribution
+      // discontinuity of TensorAccessor, so here using loops to replace memcpy
       for (int k = 0; k < num_features; ++k) {
         voxels[voxelidx][num][k] = points[i][k];
       }

--- a/mmcv/ops/csrc/pytorch/cpu/voxelization.cpp
+++ b/mmcv/ops/csrc/pytorch/cpu/voxelization.cpp
@@ -30,8 +30,7 @@ void dynamic_voxelize_forward_cpu_kernel(
       for (int k = 0; k < NDim; ++k) {
         coors[i][k] = -1;
       }
-    }
-    else {
+    } else {
       for (int k = 0; k < NDim; ++k) {
         coors[i][k] = coor[k];
       }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The unittest of mmdet3d fails after importing the Voxeliaztion op from mmcv. I found that there exists an inconsistency of Voxelization op between mmdet3d and mmcv, which causes the failure of mmdet3d.

## Modification

Replace `memcpy` with loop in the Voxelization op.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
