### PR TITLE
deprecate model deployment

### DIFF
--- a/docs/en/deployment/onnx.md
+++ b/docs/en/deployment/onnx.md
@@ -1,5 +1,10 @@
 ## Introduction of mmcv.onnx module
 
+### <span style="color:red">DeprecationWarning</span>
+
+ONNX support will be deprecated in the future.
+Welcome to use the unified model deployment toolbox MMDeploy: https://github.com/open-mmlab/mmdeploy
+
 ### register_extra_symbolics
 
 Some extra symbolic functions need to be registered before exporting PyTorch model to ONNX.

--- a/docs/en/deployment/onnxruntime_op.md
+++ b/docs/en/deployment/onnxruntime_op.md
@@ -1,5 +1,10 @@
 ## ONNX Runtime Deployment
 
+### <span style="color:red">DeprecationWarning</span>
+
+ONNX support will be deprecated in the future.
+Welcome to use the unified model deployment toolbox MMDeploy: https://github.com/open-mmlab/mmdeploy
+
 ### Introduction of ONNX Runtime
 
 **ONNX Runtime** is a cross-platform inferencing and training accelerator compatible with many popular ML/DNN frameworks. Check its [github](https://github.com/microsoft/onnxruntime) for more information.

--- a/docs/en/deployment/tensorrt_plugin.md
+++ b/docs/en/deployment/tensorrt_plugin.md
@@ -1,8 +1,13 @@
 ## TensorRT Deployment
 
+### <span style="color:red">DeprecationWarning</span>
+
+TensorRT support will be deprecated in the future.
+Welcome to use the unified model deployment toolbox MMDeploy: https://github.com/open-mmlab/mmdeploy
 <!-- TOC -->
 
 - [TensorRT Deployment](#tensorrt-deployment)
+  - [<span style="color:red">DeprecationWarning</span>](#deprecationwarning)
   - [Introduction](#introduction)
   - [List of TensorRT plugins supported in MMCV](#list-of-tensorrt-plugins-supported-in-mmcv)
   - [How to build TensorRT plugins in MMCV](#how-to-build-tensorrt-plugins-in-mmcv)

--- a/mmcv/onnx/info.py
+++ b/mmcv/onnx/info.py
@@ -1,10 +1,24 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import os
+import warnings
 
 import torch
 
 
 def is_custom_op_loaded():
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This function will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     flag = False
     try:
         from ..tensorrt import is_tensorrt_plugin_loaded

--- a/mmcv/onnx/symbolic.py
+++ b/mmcv/onnx/symbolic.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 """Modified from https://github.com/pytorch/pytorch."""
 import os
+import warnings
 
 import numpy as np
 import torch
@@ -467,6 +468,18 @@ def roll(g, input, shifts, dims):
 
 
 def register_extra_symbolics(opset=11):
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This function will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     register_op('one_hot', one_hot, '', opset)
     register_op('im2col', im2col, '', opset)
     register_op('topk', topk, '', opset)

--- a/mmcv/tensorrt/init_plugins.py
+++ b/mmcv/tensorrt/init_plugins.py
@@ -2,10 +2,23 @@
 import ctypes
 import glob
 import os
+import warnings
 
 
 def get_tensorrt_op_path():
     """Get TensorRT plugins library path."""
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This function will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     wildcard = os.path.join(
         os.path.abspath(os.path.dirname(os.path.dirname(__file__))),
         '_ext_trt.*.so')
@@ -24,12 +37,38 @@ def is_tensorrt_plugin_loaded():
     Returns:
         bool: plugin_is_loaded flag
     """
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This function will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     global plugin_is_loaded
     return plugin_is_loaded
 
 
 def load_tensorrt_plugin():
     """load TensorRT plugins library."""
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This function will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     global plugin_is_loaded
     lib_path = get_tensorrt_op_path()
     if (not plugin_is_loaded) and os.path.exists(lib_path):

--- a/mmcv/tensorrt/preprocess.py
+++ b/mmcv/tensorrt/preprocess.py
@@ -1,4 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import warnings
+
 import numpy as np
 import onnx
 
@@ -19,6 +21,19 @@ def preprocess_onnx(onnx_model):
     Returns:
         onnx.ModelProto: Modified onnx model.
     """
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This function will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     graph = onnx_model.graph
     nodes = graph.node
     initializers = graph.initializer

--- a/mmcv/tensorrt/tensorrt_utils.py
+++ b/mmcv/tensorrt/tensorrt_utils.py
@@ -40,6 +40,19 @@ def onnx2trt(onnx_model,
         >>>             device_id=0)
         >>>             })
     """
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This function will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     device = torch.device('cuda:{}'.format(device_id))
     # create builder and network
     logger = trt.Logger(log_level)
@@ -94,6 +107,19 @@ def save_trt_engine(engine, path):
         engine (tensorrt.ICudaEngine): TensorRT engine to serialize
         path (str): disk path to write the engine
     """
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This function will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     with open(path, mode='wb') as f:
         f.write(bytearray(engine.serialize()))
 
@@ -107,6 +133,19 @@ def load_trt_engine(path):
     Returns:
         tensorrt.ICudaEngine: the TensorRT engine loaded from disk
     """
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This function will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     with trt.Logger() as logger, trt.Runtime(logger) as runtime:
         with open(path, mode='rb') as f:
             engine_bytes = f.read()
@@ -154,6 +193,20 @@ class TRTWrapper(torch.nn.Module):
     """
 
     def __init__(self, engine, input_names=None, output_names=None):
+
+        # Following strings of text style are from colorama package
+        bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+        red_text, blue_text = '\x1b[31m', '\x1b[34m'
+        white_background = '\x1b[107m'
+
+        msg = white_background + bright_style + red_text
+        msg += 'DeprecationWarning: This tool will be deprecated in future. '
+        msg += blue_text + \
+            'Welcome to use the unified model deployment toolbox '
+        msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+        msg += reset_style
+        warnings.warn(msg)
+
         super(TRTWrapper, self).__init__()
         self.engine = engine
         if isinstance(self.engine, str):

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import glob
 import os
 import platform
 import re
+import warnings
 from pkg_resources import DistributionNotFound, get_distribution
 from setuptools import find_packages, setup
 
@@ -135,6 +136,21 @@ def get_extensions():
     extensions = []
 
     if os.getenv('MMCV_WITH_TRT', '0') != '0':
+
+        # Following strings of text style are from colorama package
+        bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+        red_text, blue_text = '\x1b[31m', '\x1b[34m'
+        white_background = '\x1b[107m'
+
+        msg = white_background + bright_style + red_text
+        msg += 'DeprecationWarning: ' + \
+            'Custom TensorRT Ops will be deprecated in future. '
+        msg += blue_text + \
+            'Welcome to use the unified model deployment toolbox '
+        msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+        msg += reset_style
+        warnings.warn(msg)
+
         ext_name = 'mmcv._ext_trt'
         from torch.utils.cpp_extension import include_paths, library_paths
         library_dirs = []
@@ -314,6 +330,20 @@ def get_extensions():
         extensions.append(ext_ops)
 
     if EXT_TYPE == 'pytorch' and os.getenv('MMCV_WITH_ORT', '0') != '0':
+
+        # Following strings of text style are from colorama package
+        bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+        red_text, blue_text = '\x1b[31m', '\x1b[34m'
+        white_background = '\x1b[107m'
+
+        msg = white_background + bright_style + red_text
+        msg += 'DeprecationWarning: ' + \
+            'Custom ONNXRuntime Ops will be deprecated in future. '
+        msg += blue_text + \
+            'Welcome to use the unified model deployment toolbox '
+        msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+        msg += reset_style
+        warnings.warn(msg)
         ext_name = 'mmcv._ext_ort'
         import onnxruntime
         from torch.utils.cpp_extension import include_paths, library_paths


### PR DESCRIPTION
## Motivation

This PR add deprecate warning to codes about model deployment.

## Modification

Add warning in codes and docs.

## BC-breaking (Optional)

Codes include c++ and cuda ops implement will be deprecated in the future.
