### PR TITLE
Feature/smexperiments logger hook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,8 +111,16 @@ jobs:
       # pstuil is an optional package to detect the number of CPU for compiling mmcv
       - name: Install psutil
         run: pip install psutil
-      - name: Build and install
-        run: rm -rf .eggs && pip install -e .
+      - name: Create sdist and untar
+        run: |
+          MMCV_WITH_OPS=1 python setup.py sdist
+          tar zxvf dist/mmcv-full* -C /tmp
+          rm -r mmcv
+      - name: Build and install from sdist
+        run: |
+          pushd /tmp/mmcv-full*
+          pip install -e .
+          popd
       - name: Validate the installation
         run: python -c "import mmcv"
       - name: Run unittests and generate coverage report

--- a/.owners.yml
+++ b/.owners.yml
@@ -1,0 +1,14 @@
+assign:
+  strategy:
+    # random
+    daily-shift-based
+  scedule:
+    '*/1 * * * *'
+  assignees:
+    - teamwong111
+    - zhouzaida
+    - imabackstabber
+    - HAOCHENYE
+    - teamwong111
+    - HAOCHENYE
+    - zhouzaida

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include mmcv/model_zoo/open_mmlab.json mmcv/model_zoo/deprecated.json mmcv/model
 include mmcv/ops/csrc/common/cuda/*.cuh mmcv/ops/csrc/common/cuda/*.hpp mmcv/ops/csrc/common/*.hpp
 include mmcv/ops/csrc/pytorch/*.cpp mmcv/ops/csrc/pytorch/cuda/*.cu mmcv/ops/csrc/pytorch/cuda/*.cpp mmcv/ops/csrc/pytorch/cpu/*.cpp
 include mmcv/ops/csrc/parrots/*.h mmcv/ops/csrc/parrots/*.cpp
+recursive-include mmcv/ops/csrc/ *.h *.hpp *.cpp *.cuh *.cu

--- a/docs/en/understand_mmcv/config.md
+++ b/docs/en/understand_mmcv/config.md
@@ -196,5 +196,5 @@ _deprecation_ = dict(
 ```python
 >>> cfg = Config.fromfile('./deprecated_cfg.py')
 
-UserWarning: The config file deprecated.py will be deprecated in the future. Please use expected_cfg.py instead. More information can be found at https://github.com/open-mmlab/mmcv/pull/1275
+UserWarning: The config file deprecated_cfg.py will be deprecated in the future. Please use expected_cfg.py instead. More information can be found at https://github.com/open-mmlab/mmcv/pull/1275
 ```

--- a/docs/en/understand_mmcv/registry.md
+++ b/docs/en/understand_mmcv/registry.md
@@ -31,7 +31,7 @@ In the package, we first create a file to implement builders, named `converters/
 ```python
 from mmcv.utils import Registry
 # create a registry for converters
-CONVERTERS = Registry('converter')
+CONVERTERS = Registry('converters')
 ```
 
 Then we can implement different converters in the package. For example, implement `Converter1` in `converters/converter1.py`

--- a/mmcv/cnn/bricks/conv.py
+++ b/mmcv/cnn/bricks/conv.py
@@ -35,7 +35,7 @@ def build_conv_layer(cfg, *args, **kwargs):
 
     layer_type = cfg_.pop('type')
     if layer_type not in CONV_LAYERS:
-        raise KeyError(f'Unrecognized norm type {layer_type}')
+        raise KeyError(f'Unrecognized layer type {layer_type}')
     else:
         conv_layer = CONV_LAYERS.get(layer_type)
 

--- a/mmcv/cnn/bricks/generalized_attention.py
+++ b/mmcv/cnn/bricks/generalized_attention.py
@@ -351,7 +351,7 @@ class GeneralizedAttention(nn.Module):
                         repeat(n, 1, 1, 1)
 
                     position_feat_x_reshape = position_feat_x.\
-                        view(n, num_heads, w*w_kv, self.qk_embed_dim)
+                        view(n, num_heads, w * w_kv, self.qk_embed_dim)
 
                     position_feat_y_reshape = position_feat_y.\
                         view(n, num_heads, h * h_kv, self.qk_embed_dim)

--- a/mmcv/cnn/utils/flops_counter.py
+++ b/mmcv/cnn/utils/flops_counter.py
@@ -459,7 +459,7 @@ def deconv_flops_counter_hook(conv_module, input, output):
     bias_flops = 0
     if conv_module.bias is not None:
         output_height, output_width = output.shape[2:]
-        bias_flops = out_channels * batch_size * output_height * output_height
+        bias_flops = out_channels * batch_size * output_height * output_width
     overall_flops = overall_conv_flops + bias_flops
 
     conv_module.__flops__ += int(overall_flops)

--- a/mmcv/ops/csrc/pytorch/cpu/voxelization.cpp
+++ b/mmcv/ops/csrc/pytorch/cpu/voxelization.cpp
@@ -26,13 +26,22 @@ void dynamic_voxelize_forward_cpu_kernel(
       coor[ndim_minus_1 - j] = c;
     }
 
-    if (failed)
-      memset(&coors[i][0], -1, NDim * sizeof(T_int));
-    else
-      memcpy(&coors[i][0], &coor[0], NDim * sizeof(T_int));
+    // memcpy and memset will cause problem because of the memory distribution
+    // discontinuity of TensorAccessor, so here using loops to replace memcpy
+    // or memset
+    if (failed) {
+      for (int k = 0; k < NDim; ++k) {
+        coors[i][k] = -1;
+      }
+    } else {
+      for (int k = 0; k < NDim; ++k) {
+        coors[i][k] = coor[k];
+      }
+    }
   }
 
   delete[] coor;
+  return;
 }
 
 template <typename T, typename T_int>
@@ -72,14 +81,21 @@ void hard_voxelize_forward_cpu_kernel(
       voxel_num += 1;
 
       coor_to_voxelidx[coor[i][0]][coor[i][1]][coor[i][2]] = voxelidx;
-      memcpy(&coors[voxelidx][0], &coor[i][0], NDim * sizeof(T_int));
+      // memcpy will cause problem because of the memory distribution
+      // discontinuity of TensorAccessor, so here using loops to replace memcpy
+      for (int k = 0; k < NDim; ++k) {
+        coors[voxelidx][k] = coor[i][k];
+      }
     }
 
     // put points into voxel
     num = num_points_per_voxel[voxelidx];
     if (max_points == -1 || num < max_points) {
-      memcpy(&voxels[voxelidx][num][0], &points[i][0],
-             num_features * sizeof(T));
+      // memcpy will cause problem because of the memory distribution
+      // discontinuity of TensorAccessor, so here using loops to replace memcpy
+      for (int k = 0; k < num_features; ++k) {
+        voxels[voxelidx][num][k] = points[i][k];
+      }
       num_points_per_voxel[voxelidx] += 1;
     }
   }

--- a/mmcv/ops/csrc/pytorch/cuda/scatter_points_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/scatter_points_cuda.cu
@@ -26,10 +26,15 @@ std::vector<at::Tensor> DynamicPointToVoxelForwardCUDAKernelLauncher(
   std::tie(out_coors, coors_map, reduce_count) =
       at::unique_dim(coors_clean, 0, true, true, true);
 
-  // the first element of out_coors is always (-1,-1,-1) and should be removed
-  out_coors = out_coors.slice(0, 1);
-  reduce_count = reduce_count.slice(0, 1).to(torch::kInt32);
-  coors_map = coors_map.to(torch::kInt32) - 1;
+  if (out_coors[0][0].lt(0).item<bool>()) {
+    // the first element of out_coors (-1,-1,-1) and should be removed
+    out_coors = out_coors.slice(0, 1);
+    reduce_count = reduce_count.slice(0, 1);
+    coors_map = coors_map - 1;
+  }
+
+  coors_map = coors_map.to(torch::kInt32);
+  reduce_count = reduce_count.to(torch::kInt32);
 
   auto reduced_feats =
       at::empty({out_coors.size(0), num_feats}, feats.options());

--- a/mmcv/ops/gather_points.py
+++ b/mmcv/ops/gather_points.py
@@ -26,7 +26,7 @@ class GatherPoints(Function):
 
         B, npoint = indices.size()
         _, C, N = features.size()
-        output = torch.cuda.FloatTensor(B, C, npoint)
+        output = features.new_zeros((B, C, npoint))
 
         ext_module.gather_points_forward(
             features, indices, output, b=B, c=C, n=N, npoints=npoint)
@@ -41,7 +41,7 @@ class GatherPoints(Function):
         idx, C, N = ctx.for_backwards
         B, npoint = idx.size()
 
-        grad_features = torch.cuda.FloatTensor(B, C, N).zero_()
+        grad_features = grad_out.new_zeros((B, C, N))
         grad_out_data = grad_out.data.contiguous()
         ext_module.gather_points_backward(
             grad_out_data,

--- a/mmcv/runner/__init__.py
+++ b/mmcv/runner/__init__.py
@@ -16,8 +16,8 @@ from .hooks import (HOOKS, CheckpointHook, ClosureHook, DistEvalHook,
                     GradientCumulativeOptimizerHook, Hook, IterTimerHook,
                     LoggerHook, MlflowLoggerHook, NeptuneLoggerHook,
                     OptimizerHook, PaviLoggerHook, SegmindLoggerHook,
-                    SyncBuffersHook, TensorboardLoggerHook, TextLoggerHook,
-                    WandbLoggerHook)
+                    SMExperimentsLoggerHook, SyncBuffersHook,
+                    TensorboardLoggerHook, TextLoggerHook, WandbLoggerHook)
 from .hooks.lr_updater import StepLrUpdaterHook  # noqa
 from .hooks.lr_updater import (CosineAnnealingLrUpdaterHook,
                                CosineRestartLrUpdaterHook, CyclicLrUpdaterHook,
@@ -62,5 +62,5 @@ __all__ = [
     '_load_checkpoint_with_prefix', 'EvalHook', 'DistEvalHook', 'Sequential',
     'ModuleDict', 'ModuleList', 'GradientCumulativeOptimizerHook',
     'GradientCumulativeFp16OptimizerHook', 'DefaultRunnerConstructor',
-    'SegmindLoggerHook'
+    'SegmindLoggerHook', 'SMExperimentsLoggerHook'
 ]

--- a/mmcv/runner/__init__.py
+++ b/mmcv/runner/__init__.py
@@ -15,8 +15,9 @@ from .hooks import (HOOKS, CheckpointHook, ClosureHook, DistEvalHook,
                     Fp16OptimizerHook, GradientCumulativeFp16OptimizerHook,
                     GradientCumulativeOptimizerHook, Hook, IterTimerHook,
                     LoggerHook, MlflowLoggerHook, NeptuneLoggerHook,
-                    OptimizerHook, PaviLoggerHook, SyncBuffersHook,
-                    TensorboardLoggerHook, TextLoggerHook, WandbLoggerHook)
+                    OptimizerHook, PaviLoggerHook, SegmindLoggerHook,
+                    SyncBuffersHook, TensorboardLoggerHook, TextLoggerHook,
+                    WandbLoggerHook)
 from .hooks.lr_updater import StepLrUpdaterHook  # noqa
 from .hooks.lr_updater import (CosineAnnealingLrUpdaterHook,
                                CosineRestartLrUpdaterHook, CyclicLrUpdaterHook,
@@ -60,5 +61,6 @@ __all__ = [
     'allreduce_params', 'LossScaler', 'CheckpointLoader', 'BaseModule',
     '_load_checkpoint_with_prefix', 'EvalHook', 'DistEvalHook', 'Sequential',
     'ModuleDict', 'ModuleList', 'GradientCumulativeOptimizerHook',
-    'GradientCumulativeFp16OptimizerHook', 'DefaultRunnerConstructor'
+    'GradientCumulativeFp16OptimizerHook', 'DefaultRunnerConstructor',
+    'SegmindLoggerHook'
 ]

--- a/mmcv/runner/hooks/__init__.py
+++ b/mmcv/runner/hooks/__init__.py
@@ -6,8 +6,8 @@ from .evaluation import DistEvalHook, EvalHook
 from .hook import HOOKS, Hook
 from .iter_timer import IterTimerHook
 from .logger import (DvcliveLoggerHook, LoggerHook, MlflowLoggerHook,
-                     NeptuneLoggerHook, PaviLoggerHook, TensorboardLoggerHook,
-                     TextLoggerHook, WandbLoggerHook)
+                     NeptuneLoggerHook, PaviLoggerHook, SegmindLoggerHook,
+                     TensorboardLoggerHook, TextLoggerHook, WandbLoggerHook)
 from .lr_updater import (CosineAnnealingLrUpdaterHook,
                          CosineRestartLrUpdaterHook, CyclicLrUpdaterHook,
                          ExpLrUpdaterHook, FixedLrUpdaterHook,
@@ -38,5 +38,6 @@ __all__ = [
     'StepMomentumUpdaterHook', 'CosineAnnealingMomentumUpdaterHook',
     'CyclicMomentumUpdaterHook', 'OneCycleMomentumUpdaterHook',
     'SyncBuffersHook', 'EMAHook', 'EvalHook', 'DistEvalHook', 'ProfilerHook',
-    'GradientCumulativeOptimizerHook', 'GradientCumulativeFp16OptimizerHook'
+    'GradientCumulativeOptimizerHook', 'GradientCumulativeFp16OptimizerHook',
+    'SegmindLoggerHook'
 ]

--- a/mmcv/runner/hooks/__init__.py
+++ b/mmcv/runner/hooks/__init__.py
@@ -7,7 +7,8 @@ from .hook import HOOKS, Hook
 from .iter_timer import IterTimerHook
 from .logger import (DvcliveLoggerHook, LoggerHook, MlflowLoggerHook,
                      NeptuneLoggerHook, PaviLoggerHook, SegmindLoggerHook,
-                     TensorboardLoggerHook, TextLoggerHook, WandbLoggerHook)
+                     SMExperimentsLoggerHook, TensorboardLoggerHook,
+                     TextLoggerHook, WandbLoggerHook)
 from .lr_updater import (CosineAnnealingLrUpdaterHook,
                          CosineRestartLrUpdaterHook, CyclicLrUpdaterHook,
                          ExpLrUpdaterHook, FixedLrUpdaterHook,
@@ -39,5 +40,5 @@ __all__ = [
     'CyclicMomentumUpdaterHook', 'OneCycleMomentumUpdaterHook',
     'SyncBuffersHook', 'EMAHook', 'EvalHook', 'DistEvalHook', 'ProfilerHook',
     'GradientCumulativeOptimizerHook', 'GradientCumulativeFp16OptimizerHook',
-    'SegmindLoggerHook'
+    'SegmindLoggerHook', 'SMExperimentsLoggerHook'
 ]

--- a/mmcv/runner/hooks/logger/__init__.py
+++ b/mmcv/runner/hooks/logger/__init__.py
@@ -4,6 +4,7 @@ from .dvclive import DvcliveLoggerHook
 from .mlflow import MlflowLoggerHook
 from .neptune import NeptuneLoggerHook
 from .pavi import PaviLoggerHook
+from .segmind import SegmindLoggerHook
 from .tensorboard import TensorboardLoggerHook
 from .text import TextLoggerHook
 from .wandb import WandbLoggerHook
@@ -11,5 +12,5 @@ from .wandb import WandbLoggerHook
 __all__ = [
     'LoggerHook', 'MlflowLoggerHook', 'PaviLoggerHook',
     'TensorboardLoggerHook', 'TextLoggerHook', 'WandbLoggerHook',
-    'NeptuneLoggerHook', 'DvcliveLoggerHook'
+    'NeptuneLoggerHook', 'DvcliveLoggerHook', 'SegmindLoggerHook'
 ]

--- a/mmcv/runner/hooks/logger/__init__.py
+++ b/mmcv/runner/hooks/logger/__init__.py
@@ -4,6 +4,7 @@ from .dvclive import DvcliveLoggerHook
 from .mlflow import MlflowLoggerHook
 from .neptune import NeptuneLoggerHook
 from .pavi import PaviLoggerHook
+from .sagemaker_experiments import SMExperimentsLoggerHook
 from .segmind import SegmindLoggerHook
 from .tensorboard import TensorboardLoggerHook
 from .text import TextLoggerHook
@@ -12,5 +13,6 @@ from .wandb import WandbLoggerHook
 __all__ = [
     'LoggerHook', 'MlflowLoggerHook', 'PaviLoggerHook',
     'TensorboardLoggerHook', 'TextLoggerHook', 'WandbLoggerHook',
-    'NeptuneLoggerHook', 'DvcliveLoggerHook', 'SegmindLoggerHook'
+    'NeptuneLoggerHook', 'DvcliveLoggerHook', 'SegmindLoggerHook',
+    'SMExperimentsLoggerHook'
 ]

--- a/mmcv/runner/hooks/logger/sagemaker_experiments.py
+++ b/mmcv/runner/hooks/logger/sagemaker_experiments.py
@@ -11,8 +11,6 @@ class SMExperimentsLoggerHook(LoggerHook):
     experiments`_ and `boto3`_ to be installed.
 
     Args:
-        log_per_epoch (bool, optional): Whether or not metrics
-           should be logged per epoch separately. Default: False.
         interval (int): Logging interval (every k iterations). Default: 10.
         ignore_last (bool): Ignore the log of last iterations in each epoch
             if less than `interval`. Default: True.
@@ -28,7 +26,6 @@ class SMExperimentsLoggerHook(LoggerHook):
 
     def __init__(
         self,
-        log_per_epoch=False,
         interval=10,
         ignore_last=True,
         reset_flag=False,
@@ -36,7 +33,6 @@ class SMExperimentsLoggerHook(LoggerHook):
     ):
         super().__init__(interval, ignore_last, reset_flag, by_epoch)
         self.import_smexperiments()
-        self.log_per_epoch = log_per_epoch
         self.tracker = None
 
     def import_smexperiments(self):

--- a/mmcv/runner/hooks/logger/sagemaker_experiments.py
+++ b/mmcv/runner/hooks/logger/sagemaker_experiments.py
@@ -1,0 +1,84 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from ...dist_utils import master_only
+from ..hook import HOOKS
+from .base import LoggerHook
+
+
+@HOOKS.register_module()
+class SMExperimentsLoggerHook(LoggerHook):
+    """Class to log metrics to Sagemaker Experiments.
+    Works within sagemaker training job only due to library implementation.
+    It requires `sagemaker-experiments`_ and `boto3`_ to be installed.
+    Args:
+        log_per_epoch (bool, optional): Whether or not metrics
+           should be logged per epoch separately. Default: False.
+        interval (int): Logging interval (every k iterations). Default: 10.
+        ignore_last (bool): Ignore the log of last iterations in each epoch
+            if less than `interval`. Default: True.
+        reset_flag (bool): Whether to clear the output buffer after logging.
+            Default: False.
+        by_epoch (bool): Whether EpochBasedRunner is used. Default: True.
+    .. _sagemaker-experiments:
+        https://sagemaker-experiments.readthedocs.io/
+    .. _boto3:
+        https://boto3.readthedocs.io/
+    """
+
+    def __init__(
+        self,
+        log_per_epoch=False,
+        interval=10,
+        ignore_last=True,
+        reset_flag=False,
+        by_epoch=True,
+    ):
+        super().__init__(interval, ignore_last, reset_flag, by_epoch)
+        self.import_smexperiments()
+        self.log_per_epoch = log_per_epoch
+        self.tracker = None
+
+    def import_smexperiments(self):
+        try:
+            import boto3
+            from smexperiments import tracker
+        except ImportError:
+            raise ImportError("""Please run
+                    "pip install sagemaker-experiments boto3"
+                    to use smexperiments""")
+        self.smexp_tracker = tracker
+        self.boto3 = boto3
+
+    def _create_tracker(self, **kwargs):
+        self.tracker = self.smexp_tracker.Tracker.load(**kwargs)
+
+    @master_only
+    def before_run(self, runner):
+        super().before_run(runner)
+        self._create_tracker()
+
+    @master_only
+    def log(self, runner):
+        tags = self.get_loggable_tags(runner)
+        if tags:
+            for tag_name, tag_value in tags.items():
+                self.tracker.log_metric(
+                    tag_name,
+                    tag_value,
+                    iteration_number=self.get_iter(runner))
+
+    @master_only
+    def after_run(self, runner):
+        if self.tracker:
+            self.tracker.close()
+
+    @master_only
+    def after_epoch(self, runner):
+        super().after_epoch(runner)
+        if self.log_per_epoch:
+            tags = self.get_loggable_tags(runner)
+            if tags:
+                for tag_name, tag_value in tags.items():
+                    self.tracker.log_metric(
+                        f'{tag_name}/epoch',
+                        tag_value,
+                        iteration_number=self.get_epoch(runner))

--- a/mmcv/runner/hooks/logger/sagemaker_experiments.py
+++ b/mmcv/runner/hooks/logger/sagemaker_experiments.py
@@ -6,9 +6,10 @@ from .base import LoggerHook
 
 @HOOKS.register_module()
 class SMExperimentsLoggerHook(LoggerHook):
-    """Class to log metrics to Sagemaker Experiments.
-    Works within sagemaker training job only due to library implementation.
-    It requires `sagemaker-experiments`_ and `boto3`_ to be installed.
+    """Class to log metrics to Sagemaker Experiments. Works within sagemaker
+    training job only due to library implementation. It requires `sagemaker-
+    experiments`_ and `boto3`_ to be installed.
+
     Args:
         log_per_epoch (bool, optional): Whether or not metrics
            should be logged per epoch separately. Default: False.
@@ -18,6 +19,7 @@ class SMExperimentsLoggerHook(LoggerHook):
         reset_flag (bool): Whether to clear the output buffer after logging.
             Default: False.
         by_epoch (bool): Whether EpochBasedRunner is used. Default: True.
+
     .. _sagemaker-experiments:
         https://sagemaker-experiments.readthedocs.io/
     .. _boto3:
@@ -70,15 +72,3 @@ class SMExperimentsLoggerHook(LoggerHook):
     def after_run(self, runner):
         if self.tracker:
             self.tracker.close()
-
-    @master_only
-    def after_epoch(self, runner):
-        super().after_epoch(runner)
-        if self.log_per_epoch:
-            tags = self.get_loggable_tags(runner)
-            if tags:
-                for tag_name, tag_value in tags.items():
-                    self.tracker.log_metric(
-                        f'{tag_name}/epoch',
-                        tag_value,
-                        iteration_number=self.get_epoch(runner))

--- a/mmcv/runner/hooks/logger/segmind.py
+++ b/mmcv/runner/hooks/logger/segmind.py
@@ -1,0 +1,49 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from ...dist_utils import master_only
+from ..hook import HOOKS
+from .base import LoggerHook
+
+
+@HOOKS.register_module()
+class SegmindLoggerHook(LoggerHook):
+    """Class to log metrics to Segmind.
+
+    It requires `Segmind`_ to be installed.
+
+    Args:
+        interval (int): Logging interval (every k iterations). Default: 10.
+        ignore_last (bool): Ignore the log of last iterations in each epoch
+            if less than `interval`. Default True.
+        reset_flag (bool): Whether to clear the output buffer after logging.
+            Default False.
+        by_epoch (bool): Whether EpochBasedRunner is used. Default True.
+
+    .. _Segmind:
+        https://docs.segmind.com/python-library
+    """
+
+    def __init__(self,
+                 interval=10,
+                 ignore_last=True,
+                 reset_flag=False,
+                 by_epoch=True):
+        super(SegmindLoggerHook, self).__init__(interval, ignore_last,
+                                                reset_flag, by_epoch)
+        self.import_segmind()
+
+    def import_segmind(self):
+        try:
+            import segmind
+        except ImportError:
+            raise ImportError(
+                "Please run 'pip install segmind' to install segmind")
+        self.log_metrics = segmind.tracking.fluent.log_metrics
+        self.mlflow_log = segmind.utils.logging_utils.try_mlflow_log
+
+    @master_only
+    def log(self, runner):
+        tags = self.get_loggable_tags(runner)
+        if tags:
+            # logging metrics to segmind
+            self.mlflow_log(
+                self.log_metrics, tags, step=runner.epoch, epoch=runner.epoch)

--- a/mmcv/runner/hooks/profiler.py
+++ b/mmcv/runner/hooks/profiler.py
@@ -142,7 +142,7 @@ class ProfilerHook(Hook):
             raise ValueError('on_trace_ready should be handler, dict or None, '
                              f'but got {type(self.on_trace_ready)}')
 
-        if runner.max_epochs > 1:
+        if self.by_epoch and runner.max_epochs > 1:
             warnings.warn(f'profiler will profile {runner.max_epochs} epochs '
                           'instead of 1 epoch. Since profiler will slow down '
                           'the training, it is recommended to train 1 epoch '

--- a/mmcv/runner/optimizer/default_constructor.py
+++ b/mmcv/runner/optimizer/default_constructor.py
@@ -84,7 +84,7 @@ class DefaultOptimizerConstructor:
         >>> # assume model have attribute model.backbone and model.cls_head
         >>> optimizer_cfg = dict(type='SGD', lr=0.01, weight_decay=0.95)
         >>> paramwise_cfg = dict(custom_keys={
-                '.backbone': dict(lr_mult=0.1, decay_mult=0.9)})
+                'backbone': dict(lr_mult=0.1, decay_mult=0.9)})
         >>> optim_builder = DefaultOptimizerConstructor(
         >>>     optimizer_cfg, paramwise_cfg)
         >>> optimizer = optim_builder(model)

--- a/tests/test_ops/test_scatter_points.py
+++ b/tests/test_ops/test_scatter_points.py
@@ -83,6 +83,42 @@ def test_dynamic_scatter():
     assert torch.allclose(
         feats_out_max, ref_voxel_feats_max, atol=1e-2, rtol=1e-5)
 
+    # test non-empty input without any point out of bound
+    feats = torch.rand(
+        size=(200000, 3), dtype=torch.float32, device='cuda') * 100 - 50
+    coors = torch.randint(
+        low=0, high=20, size=(200000, 3), dtype=torch.int32, device='cuda')
+
+    ref_voxel_coors = coors.unique(dim=0, sorted=True)
+    ref_voxel_coors = ref_voxel_coors[ref_voxel_coors.min(dim=-1).values >= 0]
+    ref_voxel_feats_mean = []
+    ref_voxel_feats_max = []
+    for ref_voxel_coor in ref_voxel_coors:
+        voxel_mask = (coors == ref_voxel_coor).all(dim=-1)
+        ref_voxel_feats_mean.append(feats[voxel_mask].mean(dim=0))
+        ref_voxel_feats_max.append(feats[voxel_mask].max(dim=0).values)
+    ref_voxel_feats_mean = torch.stack(ref_voxel_feats_mean)
+    ref_voxel_feats_max = torch.stack(ref_voxel_feats_max)
+
+    feats_out_mean, coors_out_mean = dsmean(feats, coors)
+    seq_mean = (coors_out_mean[:, 0] * 400 + coors_out_mean[:, 1] * 20 +
+                coors_out_mean[:, 2]).argsort()
+    feats_out_mean = feats_out_mean[seq_mean]
+    coors_out_mean = coors_out_mean[seq_mean]
+
+    feats_out_max, coors_out_max = dsmax(feats, coors)
+    seq_max = (coors_out_max[:, 0] * 400 + coors_out_max[:, 1] * 20 +
+               coors_out_max[:, 2]).argsort()
+    feats_out_max = feats_out_max[seq_max]
+    coors_cout_max = coors_out_max[seq_max]
+
+    assert (coors_out_mean == ref_voxel_coors).all()
+    assert torch.allclose(
+        feats_out_mean, ref_voxel_feats_mean, atol=1e-2, rtol=1e-5)
+    assert (coors_cout_max == ref_voxel_coors).all()
+    assert torch.allclose(
+        feats_out_max, ref_voxel_feats_max, atol=1e-2, rtol=1e-5)
+
     # test grad #
     feats = torch.rand(
         size=(100, 4), dtype=torch.float32, device='cuda') * 100 - 50

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -22,12 +22,15 @@ from torch.nn.init import constant_
 from torch.utils.data import DataLoader
 
 from mmcv.fileio.file_client import PetrelBackend
+# yapf: disable
 from mmcv.runner import (CheckpointHook, DvcliveLoggerHook, EMAHook,
                          Fp16OptimizerHook,
                          GradientCumulativeFp16OptimizerHook,
                          GradientCumulativeOptimizerHook, IterTimerHook,
                          MlflowLoggerHook, NeptuneLoggerHook, OptimizerHook,
-                         PaviLoggerHook, WandbLoggerHook, build_runner)
+                         PaviLoggerHook, SegmindLoggerHook, WandbLoggerHook,
+                         build_runner)
+# yapf: enable
 from mmcv.runner.fp16_utils import auto_fp16
 from mmcv.runner.hooks.hook import HOOKS, Hook
 from mmcv.runner.hooks.lr_updater import (CosineRestartLrUpdaterHook,
@@ -1399,6 +1402,25 @@ def test_mlflow_hook(log_model):
             pip_requirements=[f'torch=={TORCH_VERSION}'])
     else:
         assert not hook.mlflow_pytorch.log_model.called
+
+
+def test_segmind_hook():
+    sys.modules['segmind'] = MagicMock()
+    runner = _build_demo_runner()
+    hook = SegmindLoggerHook()
+    loader = DataLoader(torch.ones((5, 2)))
+
+    runner.register_hook(hook)
+    runner.run([loader, loader], [('train', 1), ('val', 1)])
+    shutil.rmtree(runner.work_dir)
+
+    hook.mlflow_log.assert_called_with(
+        hook.log_metrics, {
+            'learning_rate': 0.02,
+            'momentum': 0.95
+        },
+        step=runner.epoch,
+        epoch=runner.epoch)
 
 
 def test_wandb_hook():

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -1447,13 +1447,12 @@ def test_wandb_hook():
     hook.wandb.join.assert_called_with()
 
 
-@pytest.mark.parametrize('log_per_epoch', (True, False))
-def test_smexperiments_hook(log_per_epoch):
+def test_smexperiments_hook():
     sys.modules['smexperiments'] = MagicMock()
     sys.modules['boto3'] = MagicMock()
 
     runner = _build_demo_runner()
-    hook = SMExperimentsLoggerHook(log_per_epoch=log_per_epoch)
+    hook = SMExperimentsLoggerHook()
 
     loader = DataLoader(torch.ones((5, 2)))
 


### PR DESCRIPTION
## Motivation

For working with MMDetection in Sagemaker training jobs, we wanted to be able to log metrics to Sagemaker (SM) Experiments. The SM Experiments SDK allowed us to do that, therefore we wanted to implement a hook in mmcv that uses this SDK. SM Experiments is kinda similar to mlflow, but for AWS only.

## Modification

Hook implementation: mmcv/runner/hooks/logger/sagemaker_experiments.py 
Test implementation: tests/test_runner/test_hooks.py 'test_smexperiments_hook' 

Both the hook itself and the tests were built according to the mlflow example in the same location.

## BC-breaking (Optional)

None

## Use cases (Optional)

Run MMDet or MMCls in a Sagemaker training job and logging to Sagemaker Experiments.

## Checklist

**Before PR**:

- [X] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [X] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [X] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [X] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [X] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls. _(has been tested with MMDet)_
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
