### PR TITLE
[WIP] fix checkpoint hook logic

### DIFF
--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -1,7 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import os.path as osp
-import platform
-import shutil
 import time
 import warnings
 
@@ -10,7 +7,6 @@ import torch
 import mmcv
 from .base_runner import BaseRunner
 from .builder import RUNNERS
-from .checkpoint import save_checkpoint
 from .utils import get_host_info
 
 
@@ -128,57 +124,6 @@ class EpochBasedRunner(BaseRunner):
 
         time.sleep(1)  # wait for some hooks like loggers to finish
         self.call_hook('after_run')
-
-    def save_checkpoint(self,
-                        out_dir,
-                        filename_tmpl='epoch_{}.pth',
-                        save_optimizer=True,
-                        meta=None,
-                        create_symlink=True,
-                        by_epoch=True):
-        """Save the checkpoint.
-
-        Args:
-            out_dir (str): The directory that checkpoints are saved.
-            filename_tmpl (str, optional): The checkpoint filename template,
-                which contains a placeholder for the epoch number.
-                Defaults to 'epoch_{}.pth'.
-            save_optimizer (bool, optional): Whether to save the optimizer to
-                the checkpoint. Defaults to True.
-            meta (dict, optional): The meta information to be saved in the
-                checkpoint. Defaults to None.
-            create_symlink (bool, optional): Whether to create a symlink
-                "latest.pth" to point to the latest checkpoint.
-                Defaults to True.
-        """
-        if meta is None:
-            meta = {}
-        elif not isinstance(meta, dict):
-            raise TypeError(
-                f'meta should be a dict or None, but got {type(meta)}')
-        if self.meta is not None:
-            meta.update(self.meta)
-            # Note: meta.update(self.meta) should be done before
-            # meta.update(epoch=self.epoch + 1, iter=self.iter) otherwise
-            # there will be problems with resumed checkpoints.
-            # More details in https://github.com/open-mmlab/mmcv/pull/1108
-        meta.update(epoch=self.epoch + 1, iter=self.iter)
-
-        if by_epoch:
-            filename = filename_tmpl.format(self.epoch + 1)
-        else:
-            filename = filename_tmpl.format(self.iter + 1)
-        filepath = osp.join(out_dir, filename)
-        optimizer = self.optimizer if save_optimizer else None
-        save_checkpoint(self.model, filepath, optimizer=optimizer, meta=meta)
-        # in some environments, `os.symlink` is not supported, you may need to
-        # set `create_symlink` to False
-        if create_symlink:
-            dst_file = osp.join(out_dir, 'latest.pth')
-            if platform.system() != 'Windows':
-                mmcv.symlink(filename, dst_file)
-            else:
-                shutil.copy(filepath, dst_file)
 
 
 @RUNNERS.register_module()

--- a/mmcv/runner/epoch_based_runner.py
+++ b/mmcv/runner/epoch_based_runner.py
@@ -134,7 +134,8 @@ class EpochBasedRunner(BaseRunner):
                         filename_tmpl='epoch_{}.pth',
                         save_optimizer=True,
                         meta=None,
-                        create_symlink=True):
+                        create_symlink=True,
+                        by_epoch=True):
         """Save the checkpoint.
 
         Args:
@@ -163,7 +164,10 @@ class EpochBasedRunner(BaseRunner):
             # More details in https://github.com/open-mmlab/mmcv/pull/1108
         meta.update(epoch=self.epoch + 1, iter=self.iter)
 
-        filename = filename_tmpl.format(self.epoch + 1)
+        if by_epoch:
+            filename = filename_tmpl.format(self.epoch + 1)
+        else:
+            filename = filename_tmpl.format(self.iter + 1)
         filepath = osp.join(out_dir, filename)
         optimizer = self.optimizer if save_optimizer else None
         save_checkpoint(self.model, filepath, optimizer=optimizer, meta=meta)

--- a/mmcv/runner/hooks/checkpoint.py
+++ b/mmcv/runner/hooks/checkpoint.py
@@ -118,8 +118,16 @@ class CheckpointHook(Hook):
     @master_only
     def _save_checkpoint(self, runner):
         """Save the current checkpoint and delete unwanted checkpoint."""
+        if self.by_epoch:
+            filename_tmpl = 'epoch_{}.pth'
+        else:
+            filename_tmpl = 'iter_{}.pth'
         runner.save_checkpoint(
-            self.out_dir, save_optimizer=self.save_optimizer, **self.args)
+            self.out_dir,
+            filename_tmpl=filename_tmpl,
+            save_optimizer=self.save_optimizer,
+            by_epoch=self.by_epoch,
+            **self.args)
         if runner.meta is not None:
             if self.by_epoch:
                 cur_ckpt_filename = self.args.get(

--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -346,7 +346,8 @@ class EvalHook(Hook):
             runner.save_checkpoint(
                 self.out_dir,
                 filename_tmpl=best_ckpt_name,
-                create_symlink=False)
+                create_symlink=False,
+                by_epoch=self.by_epoch)
             runner.logger.info(
                 f'Now best checkpoint is saved as {best_ckpt_name}.')
             runner.logger.info(

--- a/mmcv/runner/hooks/logger/dvclive.py
+++ b/mmcv/runner/hooks/logger/dvclive.py
@@ -65,4 +65,4 @@ class DvcliveLoggerHook(LoggerHook):
                 Path(self.model_file).parent,
                 filename_tmpl=Path(self.model_file).name,
                 create_symlink=False,
-            )
+                by_epoch=self.by_epoch)

--- a/mmcv/runner/iter_based_runner.py
+++ b/mmcv/runner/iter_based_runner.py
@@ -181,7 +181,8 @@ class IterBasedRunner(BaseRunner):
                         filename_tmpl='iter_{}.pth',
                         meta=None,
                         save_optimizer=True,
-                        create_symlink=True):
+                        create_symlink=True,
+                        by_epoch=False):
         """Save checkpoint to file.
 
         Args:
@@ -207,8 +208,10 @@ class IterBasedRunner(BaseRunner):
             # there will be problems with resumed checkpoints.
             # More details in https://github.com/open-mmlab/mmcv/pull/1108
         meta.update(epoch=self.epoch + 1, iter=self.iter)
-
-        filename = filename_tmpl.format(self.iter + 1)
+        if by_epoch:
+            filename = filename_tmpl.format(self.epoch + 1)
+        else:
+            filename = filename_tmpl.format(self.iter + 1)
         filepath = osp.join(out_dir, filename)
         optimizer = self.optimizer if save_optimizer else None
         save_checkpoint(self.model, filepath, optimizer=optimizer, meta=meta)


### PR DESCRIPTION
## Motivation

If use EpochBasedRunner and save ckpt as IterBase (such as `checkpoint_config = dict(by_epoch=False, interval=100)`), this may cause a potential error: the ckpt will name as `epoch_*.pth`.

## Modification

change the logic in checkpoint_hook.


 Maybe we can only set the code in BaseRunner?