### PR TITLE
Fixed typo in docs/en/understand_mmcv/cnn.md

### DIFF
--- a/docs/en/understand_mmcv/cnn.md
+++ b/docs/en/understand_mmcv/cnn.md
@@ -368,7 +368,7 @@ Let us introduce the usage of `initialize` in detail.
 
 4. Initialize model inherited from BaseModule, Sequential, ModuleList, ModuleDict
 
-    `BaseModule` is inherited from `torch.nn.Module`, and the only different between them is that `BaseModule` implements `init_weight`.
+    `BaseModule` is inherited from `torch.nn.Module`, and the only different between them is that `BaseModule` implements `init_weights()`.
 
     `Sequential` is inherited from `BaseModule` and `torch.nn.Sequential`.
 


### PR DESCRIPTION
## Motivation

Making the docs error-proof.

## Modification

Fixed typo in `docs/en/understand_mmcv/cnn.md`. The `BaseModule` class implements `init_weights()` not `init_weight()`

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
