### PR TITLE
[fix] config ignore imported modules and functions

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -7,6 +7,7 @@ import platform
 import shutil
 import sys
 import tempfile
+import types
 import uuid
 import warnings
 from argparse import Action, ArgumentParser
@@ -209,6 +210,8 @@ class Config:
                     name: value
                     for name, value in mod.__dict__.items()
                     if not name.startswith('__')
+                    and not isinstance(value, types.ModuleType)
+                    and not isinstance(value, types.FunctionType)
                 }
                 # delete imported module
                 del sys.modules[temp_module_name]

--- a/tests/data/config/l.py
+++ b/tests/data/config/l.py
@@ -1,4 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import os.path as osp
+
+
+def func(x):
+    return x
+
 _base_ = ['./l1.py', './l2.yaml', './l3.json', './l4.py']
 item3 = False
 item4 = 'test'

--- a/tests/data/config/n.py
+++ b/tests/data/config/n.py
@@ -1,4 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import os.path as osp
+
+
+def func(x):
+    return x
+
 test_item1 = [1, 2]
 bool_item2 = True
 str_item3 = 'test'


### PR DESCRIPTION
## Motivation

When use `import` like `import os.path as osp` in config. The parsed config's `_cfg_dict` contains an entry which looks like `osp: <module ....`. 

Then when calling `pretty_text()`, this dict is converted back to string, which is different from the original config., Then this string is formatted by `yapf` and error occurs. 

```python 
# config: pretty_text()
        cfg_dict = self._cfg_dict.to_dict()
        text = _format_dict(cfg_dict, outest_level=True)
        # copied from setup.cfg
        yapf_style = dict(
            based_on_style='pep8',
            blank_line_before_nested_class_or_def=True,
            split_before_expression_after_opening_paren=True)
        text, _ = FormatCode(text, style_config=yapf_style, verify=True)
```

## Modification

When parsing a config file to dict, modules and functions are ignored. 

## BC-breaking (Optional)

No

## Use cases (Optional)



## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
