### PR TITLE
[Fix] Add @cacheable_method in transform wrapper `RandomChoice`

### DIFF
--- a/mmcv/transforms/utils.py
+++ b/mmcv/transforms/utils.py
@@ -139,15 +139,17 @@ def cache_random_params(transforms: Union[BaseTransform, Iterable]):
                 key = f'{id(t)}.{name}'
                 if key2counter[key] != key2counter[key_transform]:
                     raise RuntimeError(
-                        'The cacheable method should be called once and only'
-                        f'once during processing one data sample. {t} got'
-                        f'unmatched number of {key2counter[key]} ({name}) vs'
+                        'The cacheable method should be called once and only '
+                        f'once during processing one data sample. {t} got '
+                        f'unmatched number of {key2counter[key]} ({name}) vs '
                         f'{key2counter[key_transform]} (data samples)')
                 setattr(t, name, key2method[key])
             setattr(t, 'transform', key2method[key_transform])
 
     def _apply(t: Union[BaseTransform, Iterable],
                func: Callable[[BaseTransform], None]):
+        # Note that BaseTransform and Iterable are not mutually exclusive,
+        # e.g. Compose, RandomChoice
         if isinstance(t, BaseTransform):
             if hasattr(t, '_cacheable_methods'):
                 func(t)

--- a/mmcv/transforms/wrappers.py
+++ b/mmcv/transforms/wrappers.py
@@ -8,7 +8,7 @@ import numpy as np
 import mmcv
 from .base import BaseTransform
 from .builder import TRANSFORMS
-from .utils import cache_random_params
+from .utils import cache_random_params, cacheable_method
 
 # Indicator for required but missing keys in results
 NotInResults = object()
@@ -452,6 +452,11 @@ class RandomChoice(BaseTransform):
         self.pipeline_probs = pipeline_probs
         self.pipelines = [Compose(transforms) for transforms in pipelines]
 
+    @cacheable_method
+    def random_pipeline_index(self):
+        indices = np.arange(len(self.pipelines))
+        return np.random.choice(indices, self.pipeline_probs)
+
     def transform(self, results):
-        pipeline = np.random.choice(self.pipelines, p=self.pipeline_probs)
-        return pipeline(results)
+        idx = self.random_pipeline_index()
+        return self.pipelines[idx](results)

--- a/mmcv/transforms/wrappers.py
+++ b/mmcv/transforms/wrappers.py
@@ -452,10 +452,13 @@ class RandomChoice(BaseTransform):
         self.pipeline_probs = pipeline_probs
         self.pipelines = [Compose(transforms) for transforms in pipelines]
 
+    def __iter__(self):
+        return iter(self.pipelines)
+
     @cacheable_method
     def random_pipeline_index(self):
         indices = np.arange(len(self.pipelines))
-        return np.random.choice(indices, self.pipeline_probs)
+        return np.random.choice(indices, p=self.pipeline_probs)
 
     def transform(self, results):
         idx = self.random_pipeline_index()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In `RandomChoice` the selected index of sub-pipeline candidates is randomly generated, thus should be decorated by `cacheable_method`.

## Modification

- RandomChoice uses cacheable_method to generate pipeline index
- RandomChoice add `__iter__()`
- Fix incorrect use of cacheable_method in unit tests.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
