### PR TITLE
Add annotation for ninja build in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -241,6 +241,11 @@ def get_extensions():
             num_cpu = len(psutil.Process().cpu_affinity())
             cpu_use = max(4, num_cpu - 1)
         except (ModuleNotFoundError, AttributeError):
+            # for macos, due to psutil.Process() has no method 'cpu_affinity',
+            # due to its own design which aims to
+            # let kernel manage cache affinity well.
+            # Because of that, AttributeError will be invoked,
+            # and here set cpu_use = 4 by default.
             cpu_use = 4
 
         os.environ.setdefault('MAX_JOBS', str(cpu_use))


### PR DESCRIPTION
## Motivation

Add annotation, which explains why code (the part for adjusting number of cpu used in ninja build) will inevitably goes into Except block due to inherent design on MacOS,in setup.py.

## Modification

Add annotation.

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
