### PR TITLE
[Enhancment] Optimize correlation

### DIFF
--- a/mmcv/ops/csrc/pytorch/cuda/correlation_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/correlation_cuda.cu
@@ -24,8 +24,8 @@ void CorrelationForwardCUDAKernelLauncher(Tensor input1, Tensor input2,
   auto trInput1 = input1.permute({0, 2, 3, 1}).contiguous();
   auto trInput2 = input2.permute({0, 2, 3, 1}).contiguous();
 
-  const int threads = THREADS_FORWARD;
-  const dim3 blocks(batch_size, oH, oW);
+  const dim3 threads(WARP_SIZE, 4, 4);
+  const dim3 blocks(batch_size, (oH + 3) >> 2, (oW + 3) >> 2);
 
   at::cuda::CUDAGuard device_guard(input1.device());
 
@@ -57,7 +57,7 @@ void CorrelationBackwardCUDAKernelLauncher(
   const int C = input1.size(1);
 
   const dim3 blocks(C, iH, iW);
-  const dim3 threads(THREADS_BACKWARD, THREADS_BACKWARD);
+  const dim3 threads(WARP_SIZE, THREADS_BACKWARD);
 
   at::cuda::CUDAGuard device_guard(input1.device());
 


### PR DESCRIPTION
This PR optmize correlation ops.

Tested on:
Device: RTX 2070super
CUDA: 11.3
nvidia driver: 465.19.01

input size: 2x256x256x256

`num_warmup=10` and `num_tests=100`, `model = Correlation(max_displacement=3)`

| Model        | master         | optmized |
| :----------- | :----------: | :------: |
| forward | 15.46502ms | 9.32997ms |
| forward+backward | 708.94648ms | 198.22428ms |

Note that there are two extra permute(of input) in backward. That means more memory usage.
It will cost us extra ~50ms if we remove the permute tensor.

More test is required.