### PR TITLE
[Bug] Fix voxelization bug

### DIFF
--- a/mmcv/ops/csrc/common/cuda/voxelization_cuda_kernel.cuh
+++ b/mmcv/ops/csrc/common/cuda/voxelization_cuda_kernel.cuh
@@ -101,7 +101,7 @@ __global__ void point_to_voxelidx_kernel(const T_int* coor,
   CUDA_1D_KERNEL_LOOP(index, num_points) {
     auto coor_offset = coor + index * NDim;
     // skip invalid points
-    if (coor_offset[0] == -1) return;
+    if (coor_offset[0] == -1) continue;
 
     int num = 0;
     int coor_x = coor_offset[0];
@@ -122,7 +122,7 @@ __global__ void point_to_voxelidx_kernel(const T_int* coor,
           point_to_pointidx[index] = i;
         } else if (num >= max_points) {
           // out of boundary
-          return;
+          continue;
         }
       }
     }

--- a/mmcv/ops/csrc/common/cuda/voxelization_cuda_kernel.cuh
+++ b/mmcv/ops/csrc/common/cuda/voxelization_cuda_kernel.cuh
@@ -122,7 +122,7 @@ __global__ void point_to_voxelidx_kernel(const T_int* coor,
           point_to_pointidx[index] = i;
         } else if (num >= max_points) {
           // out of boundary
-          continue;
+          break;
         }
       }
     }


### PR DESCRIPTION
Hello, when I deploy the `CenterPoint` model in mmdeploy, I find a bug in Voxelization op. In point_to_voxelidx_kernel func, if find invalid points or point num out of the boundary, func  `return` will make the following point not processed, and then affect the model results.

Before:
![企业微信截图_1647831647752](https://user-images.githubusercontent.com/88368822/159208141-db0e769a-1ec9-468f-a954-bd2c063b027f.png)

After fix:
![企业微信截图_1647831547777](https://user-images.githubusercontent.com/88368822/159208165-90f95e42-183e-4060-880c-7470126e2b4b.png)

