### PR TITLE
NMS with CUDA only

### DIFF
--- a/mmcv/ops/csrc/common/cuda/nms_cuda_kernel.cuh
+++ b/mmcv/ops/csrc/common/cuda/nms_cuda_kernel.cuh
@@ -73,36 +73,42 @@ __global__ void nms_cuda(const int n_boxes, const float iou_threshold,
   }
 }
 
-__global__ void gather_keep_from_mask_parallize(
-    bool *keep, const unsigned long long *dev_mask, const int n_boxes) {
+__global__ void gather_keep_from_mask(bool *keep,
+                                      const unsigned long long *dev_mask,
+                                      const int n_boxes) {
   const int col_blocks = (n_boxes + threadsPerBlock - 1) / threadsPerBlock;
   const int tid = threadIdx.x;
 
-  extern __shared__ unsigned long long remv[];
+  // mark the bboxes which have been removed.
+  extern __shared__ unsigned long long removed[];
 
+  // initialize removed.
   for (int i = tid; i < col_blocks; i += blockDim.x) {
-    remv[i] = 0;
+    removed[i] = 0;
   }
   __syncthreads();
 
   for (int nblock = 0; nblock < col_blocks; ++nblock) {
-    auto remv_val = remv[nblock];
+    auto removed_val = removed[nblock];
     __syncthreads();
     const int i_offset = nblock * threadsPerBlock;
 #pragma unroll
     for (int inblock = 0; inblock < threadsPerBlock; ++inblock) {
       const int i = i_offset + inblock;
       if (i >= n_boxes) break;
-      if (!(remv_val & (1ULL << inblock))) {
+      // select a candidate, check if it should kept.
+      if (!(removed_val & (1ULL << inblock))) {
         if (tid == 0) {
+          // mark the output.
           keep[i] = true;
         }
         auto p = dev_mask + i * col_blocks;
+        // remove all bboxes which overlap the candidate.
         for (int j = tid; j < col_blocks; j += blockDim.x) {
-          if (j >= nblock) remv[j] |= p[j];
+          if (j >= nblock) removed[j] |= p[j];
         }
         __syncthreads();
-        remv_val = remv[nblock];
+        removed_val = removed[nblock];
       }
     }
   }

--- a/mmcv/ops/csrc/common/cuda/nms_cuda_kernel.cuh
+++ b/mmcv/ops/csrc/common/cuda/nms_cuda_kernel.cuh
@@ -87,16 +87,17 @@ __global__ void gather_keep_from_mask_parallize(
 
   for (int nblock = 0; nblock < col_blocks; ++nblock) {
     auto remv_val = remv[nblock];
+    __syncthreads();
+    const int i_offset = nblock * threadsPerBlock;
 #pragma unroll
     for (int inblock = 0; inblock < threadsPerBlock; ++inblock) {
-      const int i = nblock * threadsPerBlock + inblock;
+      const int i = i_offset + inblock;
       if (i >= n_boxes) break;
       if (!(remv_val & (1ULL << inblock))) {
         if (tid == 0) {
           keep[i] = true;
         }
         auto p = dev_mask + i * col_blocks;
-        __syncthreads();
         for (int j = tid; j < col_blocks; j += blockDim.x) {
           if (j >= nblock) remv[j] |= p[j];
         }

--- a/mmcv/ops/csrc/pytorch/cuda/nms_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/nms_cuda.cu
@@ -24,11 +24,11 @@ Tensor NMSCUDAKernelLauncher(Tensor boxes, Tensor scores, float iou_threshold,
       boxes_num, iou_threshold, offset, boxes_sorted.data_ptr<float>(),
       (unsigned long long*)mask.data_ptr<int64_t>());
 
+  // Filter the boxes which should be kept.
   at::Tensor keep_t = at::zeros(
       {boxes_num}, boxes.options().dtype(at::kBool).device(at::kCUDA));
-  gather_keep_from_mask_parallize<<<1, min(col_blocks, THREADS_PER_BLOCK),
-                                    col_blocks * sizeof(unsigned long long),
-                                    stream>>>(
+  gather_keep_from_mask<<<1, min(col_blocks, THREADS_PER_BLOCK),
+                          col_blocks * sizeof(unsigned long long), stream>>>(
       keep_t.data_ptr<bool>(), (unsigned long long*)mask.data_ptr<int64_t>(),
       boxes_num);
   AT_CUDA_CHECK(cudaGetLastError());

--- a/mmcv/ops/csrc/pytorch/cuda/nms_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/nms_cuda.cu
@@ -33,33 +33,4 @@ Tensor NMSCUDAKernelLauncher(Tensor boxes, Tensor scores, float iou_threshold,
       boxes_num);
   AT_CUDA_CHECK(cudaGetLastError());
   return order_t.masked_select(keep_t);
-
-  // at::Tensor mask_cpu = mask.to(at::kCPU);
-  // unsigned long long* mask_host =
-  //     (unsigned long long*)mask_cpu.data_ptr<int64_t>();
-
-  // std::vector<unsigned long long> remv(col_blocks);
-  // memset(&remv[0], 0, sizeof(unsigned long long) * col_blocks);
-
-  // at::Tensor keep_t =
-  //     at::zeros({boxes_num},
-  //     boxes.options().dtype(at::kBool).device(at::kCPU));
-  // bool* keep = keep_t.data_ptr<bool>();
-
-  // for (int i = 0; i < boxes_num; i++) {
-  //   int nblock = i / threadsPerBlock;
-  //   int inblock = i % threadsPerBlock;
-
-  //   if (!(remv[nblock] & (1ULL << inblock))) {
-  //     keep[i] = true;
-  //     // set every overlap box with bit 1 in remv
-  //     unsigned long long* p = mask_host + i * col_blocks;
-  //     for (int j = nblock; j < col_blocks; j++) {
-  //       remv[j] |= p[j];
-  //     }
-  //   }
-  // }
-
-  // AT_CUDA_CHECK(cudaGetLastError());
-  // return order_t.masked_select(keep_t.to(at::kCUDA));
 }

--- a/mmcv/ops/csrc/pytorch/cuda/nms_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/nms_cuda.cu
@@ -24,31 +24,41 @@ Tensor NMSCUDAKernelLauncher(Tensor boxes, Tensor scores, float iou_threshold,
       boxes_num, iou_threshold, offset, boxes_sorted.data_ptr<float>(),
       (unsigned long long*)mask.data_ptr<int64_t>());
 
-  at::Tensor mask_cpu = mask.to(at::kCPU);
-  unsigned long long* mask_host =
-      (unsigned long long*)mask_cpu.data_ptr<int64_t>();
-
-  std::vector<unsigned long long> remv(col_blocks);
-  memset(&remv[0], 0, sizeof(unsigned long long) * col_blocks);
-
-  at::Tensor keep_t =
-      at::zeros({boxes_num}, boxes.options().dtype(at::kBool).device(at::kCPU));
-  bool* keep = keep_t.data_ptr<bool>();
-
-  for (int i = 0; i < boxes_num; i++) {
-    int nblock = i / threadsPerBlock;
-    int inblock = i % threadsPerBlock;
-
-    if (!(remv[nblock] & (1ULL << inblock))) {
-      keep[i] = true;
-      // set every overlap box with bit 1 in remv
-      unsigned long long* p = mask_host + i * col_blocks;
-      for (int j = nblock; j < col_blocks; j++) {
-        remv[j] |= p[j];
-      }
-    }
-  }
-
+  at::Tensor keep_t = at::zeros(
+      {boxes_num}, boxes.options().dtype(at::kBool).device(at::kCUDA));
+  gather_keep_from_mask_parallize<<<
+      1, THREADS_PER_BLOCK, col_blocks * sizeof(unsigned long long), stream>>>(
+      keep_t.data_ptr<bool>(), (unsigned long long*)mask.data_ptr<int64_t>(),
+      boxes_num);
   AT_CUDA_CHECK(cudaGetLastError());
-  return order_t.masked_select(keep_t.to(at::kCUDA));
+  return order_t.masked_select(keep_t);
+
+  // at::Tensor mask_cpu = mask.to(at::kCPU);
+  // unsigned long long* mask_host =
+  //     (unsigned long long*)mask_cpu.data_ptr<int64_t>();
+
+  // std::vector<unsigned long long> remv(col_blocks);
+  // memset(&remv[0], 0, sizeof(unsigned long long) * col_blocks);
+
+  // at::Tensor keep_t =
+  //     at::zeros({boxes_num},
+  //     boxes.options().dtype(at::kBool).device(at::kCPU));
+  // bool* keep = keep_t.data_ptr<bool>();
+
+  // for (int i = 0; i < boxes_num; i++) {
+  //   int nblock = i / threadsPerBlock;
+  //   int inblock = i % threadsPerBlock;
+
+  //   if (!(remv[nblock] & (1ULL << inblock))) {
+  //     keep[i] = true;
+  //     // set every overlap box with bit 1 in remv
+  //     unsigned long long* p = mask_host + i * col_blocks;
+  //     for (int j = nblock; j < col_blocks; j++) {
+  //       remv[j] |= p[j];
+  //     }
+  //   }
+  // }
+
+  // AT_CUDA_CHECK(cudaGetLastError());
+  // return order_t.masked_select(keep_t.to(at::kCUDA));
 }

--- a/mmcv/ops/csrc/pytorch/cuda/nms_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/nms_cuda.cu
@@ -26,8 +26,9 @@ Tensor NMSCUDAKernelLauncher(Tensor boxes, Tensor scores, float iou_threshold,
 
   at::Tensor keep_t = at::zeros(
       {boxes_num}, boxes.options().dtype(at::kBool).device(at::kCUDA));
-  gather_keep_from_mask_parallize<<<
-      1, THREADS_PER_BLOCK, col_blocks * sizeof(unsigned long long), stream>>>(
+  gather_keep_from_mask_parallize<<<1, min(col_blocks, THREADS_PER_BLOCK),
+                                    col_blocks * sizeof(unsigned long long),
+                                    stream>>>(
       keep_t.data_ptr<bool>(), (unsigned long long*)mask.data_ptr<int64_t>(),
       boxes_num);
   AT_CUDA_CHECK(cudaGetLastError());


### PR DESCRIPTION

This PR add a cuda kernel for nms to avoid computation on cpu.

I am not sure if I should call this an "optimization" cause on small input data, cpu performance might even better than gpu. And the data distribution will also affect the performance.

envs:
- Device: RTX 2070super
- CUDA: 11.3
- nvidia driver: 465.19.01
- CPU: Intel(R) Core(TM) i7-9700KF CPU @ 3.60GHz

Test data comes from [faster rcnn](https://github.com/open-mmlab/mmdetection/blob/master/configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py) and [demo image](https://github.com/open-mmlab/mmdetection/blob/master/demo/demo.jpg). Both nms in rpn and nms in bbox head are tested.

| - | old | new |
| --- | --- | --- |
| rpn data(4741 boxes) | 0.98435ms | **0.88798ms** |
| rcnn data(583 boxes) | 0.23121ms | **0.22827ms** |
| random data(500 boxes) | **0.23056ms** | 0.29762ms |
| random data(1000 boxes) | **0.26279ms** | 0.41685ms |
| random data(5000 boxes) | **1.27405ms** | 1.34129ms |
| random data(10000 boxes) | 3.62377ms | **2.74194ms** |
| random data(20000 boxes) | 21.07619ms | **4.80819ms** |

Real data might have clustered bboxes, which reduce gpu computations. I guess that is why real data performance is better than random data.
