### PR TITLE
[Fix] Fix Python3.10 CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,7 +217,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-        torch: [1.9.0+cu102, 1.10.0+cu102, 1.11.0+cu102]
+        torch: [1.9.0+cu102, 1.10.0+cu102]
         include:
           - torch: 1.9.0+cu102
             torchvision: 0.10.0+cu102
@@ -243,7 +243,7 @@ jobs:
           apt-get update && apt-get install -y software-properties-common
           add-apt-repository -y ppa:deadsnakes/ppa
       - name: Install python-dev
-        run: apt-get update && apt-get install -y python${{matrix.python-version}}-dev
+        run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python${{matrix.python-version}}-dev
       - name: python -m Install PyTorch
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install system dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,7 +217,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-        torch: [1.9.0+cu102, 1.10.0+cu102, 1.11.0+cu102]
+        torch: [1.9.0+cu102, 1.10.0+cu102]
         include:
           - torch: 1.9.0+cu102
             torchvision: 0.10.0+cu102

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,7 +243,7 @@ jobs:
           apt-get update && apt-get install -y software-properties-common
           add-apt-repository -y ppa:deadsnakes/ppa
       - name: Install python-dev
-        run: apt-get update && apt-get install -y python${{matrix.python-version}}-dev
+        run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python${{matrix.python-version}}-dev
       - name: python -m Install PyTorch
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install system dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,6 +248,9 @@ jobs:
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install system dependencies
         run: apt-get update && apt-get install -y ffmpeg libturbojpeg ninja-build
+      - name: Install dependencies for compiling onnx when python=3.10
+        run: python -m pip install protobuf && apt-get -y install libprotobuf-dev protobuf-compiler cmake
+        if: ${{matrix.python-version == '3.10'}}
       # pstuil is an optional package to detect the number of CPU for compiling mmcv
       - name: Install psutil
         run: python -m pip install psutil

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,6 +238,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Add PPA
+        run: |
+          apt-get update && apt-get install -y software-properties-common
+          add-apt-repository -y ppa:deadsnakes/ppa
       - name: Install python-dev
         run: apt-get update && apt-get install -y python${{matrix.python-version}}-dev
       - name: python -m Install PyTorch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,7 +223,8 @@ jobs:
             torchvision: 0.10.0+cu102
           - torch: 1.10.0+cu102
             torchvision: 0.11.0+cu102
-          - torch: 1.11.0+cu102
+          - python-version: '3.10'
+            torch: 1.11.0+cu102
             torchvision: 0.12.0+cu102
           - python-version: 3.6
             torch: 1.9.0+cu102
@@ -237,6 +238,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Add PPA
+        run: |
+          apt-get update && apt-get install -y software-properties-common
+          add-apt-repository -y ppa:deadsnakes/ppa
       - name: Install python-dev
         run: apt-get update && apt-get install -y python${{matrix.python-version}}-dev
       - name: python -m Install PyTorch
@@ -255,6 +260,16 @@ jobs:
           python -m pip install -r requirements/test.txt
           coverage run --branch --source=mmcv -m pytest tests/
           coverage xml
+        if: ${{matrix.python-version != '3.10'}}
+      # special treatment for python3.10 because onnx and onnxruntime don't provide python3.10 pre-built packages
+      - name: Install dependencies for compiling onnx and Run unittests and generate coverage report for python3.10
+        run: |
+          run: python -m pip install protobuf && apt-get -y install libprotobuf-dev protobuf-compiler cmake
+          python -m pip install coverage lmdb pytest PyTurboJPEG scipy tifffile
+          coverage run --branch --source=mmcv -m pytest tests/ --ignore=tests/test_ops/test_onnx.py --ignore=tests/test_ops/test_tensorrt.py --ignore=tests/test_ops/test_tensorrt_preprocess.py
+          coverage xml
+        if: ${{matrix.python-version == '3.10'}}
+
 
   build_windows_without_ops:
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,14 +217,13 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-        torch: [1.9.0+cu102, 1.10.0+cu102]
+        torch: [1.9.0+cu102, 1.10.0+cu102, 1.11.0+cu102]
         include:
           - torch: 1.9.0+cu102
             torchvision: 0.10.0+cu102
           - torch: 1.10.0+cu102
             torchvision: 0.11.0+cu102
-          - python-version: '3.10'
-            torch: 1.11.0+cu102
+          - torch: 1.11.0+cu102
             torchvision: 0.12.0+cu102
           - python-version: 3.6
             torch: 1.9.0+cu102
@@ -238,19 +237,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Add PPA
-        run: |
-          apt-get update && apt-get install -y software-properties-common
-          add-apt-repository -y ppa:deadsnakes/ppa
       - name: Install python-dev
-        run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python${{matrix.python-version}}-dev
+        run: apt-get update && apt-get install -y python${{matrix.python-version}}-dev
       - name: python -m Install PyTorch
         run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
       - name: Install system dependencies
         run: apt-get update && apt-get install -y ffmpeg libturbojpeg ninja-build
-      - name: Install dependencies for compiling onnx when python=3.10
-        run: python -m pip install protobuf && apt-get -y install libprotobuf-dev protobuf-compiler cmake
-        if: ${{matrix.python-version == '3.10'}}
       # pstuil is an optional package to detect the number of CPU for compiling mmcv
       - name: Install psutil
         run: python -m pip install psutil

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,10 +262,9 @@ jobs:
           coverage xml
         if: ${{matrix.python-version != '3.10'}}
       # special treatment for python3.10 because onnx and onnxruntime don't provide python3.10 pre-built packages
-      - name: Install dependencies for compiling onnx and Run unittests and generate coverage report for python3.10
+      - name: Run unittests and generate coverage report for python3.10
         run: |
-          run: python -m pip install protobuf && apt-get -y install libprotobuf-dev protobuf-compiler cmake
-          python -m pip install coverage lmdb pytest PyTurboJPEG scipy tifffile
+          python -m pip install -r requirements/test.txt
           coverage run --branch --source=mmcv -m pytest tests/ --ignore=tests/test_ops/test_onnx.py --ignore=tests/test_ops/test_tensorrt.py --ignore=tests/test_ops/test_tensorrt_preprocess.py
           coverage xml
         if: ${{matrix.python-version == '3.10'}}

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,8 +1,8 @@
 coverage
 lmdb
-onnx==1.7.0
-onnxoptimizer
-onnxruntime>=1.8.0
+onnx==1.7.0z; python_version < '3.10'
+onnxoptimizer; python_version < '3.10'
+onnxruntime>=1.8.0; python_version < '3.10'
 pytest
 PyTurboJPEG
 scipy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,6 @@
 coverage
 lmdb
 onnx==1.7.0
-onnxoptimizer
 onnxruntime>=1.8.0
 pytest
 PyTurboJPEG

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 coverage
 lmdb
-onnx==1.7.0z; python_version < '3.10'
+onnx==1.7.0; python_version < '3.10'
 onnxoptimizer; python_version < '3.10'
 onnxruntime>=1.8.0; python_version < '3.10'
 pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,7 @@
 coverage
 lmdb
 onnx==1.7.0
+onnxoptimizer
 onnxruntime>=1.8.0
 pytest
 PyTurboJPEG


### PR DESCRIPTION
## Motivation

Fix Python3.10 CI.
Special treatment for python3.10 because onnxoptimizer and onnxruntime do not support python3.10.

## Modification

As above

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
