### PR TITLE
[Enhancement] Support None in DictAction

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -638,6 +638,8 @@ class DictAction(Action):
             pass
         if val.lower() in ['true', 'false']:
             return True if val.lower() == 'true' else False
+        if val.lower() == 'none':
+            return None
         return val
 
     @staticmethod

--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -638,7 +638,7 @@ class DictAction(Action):
             pass
         if val.lower() in ['true', 'false']:
             return True if val.lower() == 'true' else False
-        if val.lower() == 'none':
+        if val == 'None':
             return None
         return val
 

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -472,14 +472,15 @@ def test_dict_action():
     # Normal values
     args = parser.parse_args([
         '--options', 'item2.a=1', 'item2.b=0.1', 'item2.c=x', 'item3=false',
-        'item4=none'
+        'item4=none', 'item5=None'
     ])
     out_dict = {
         'item2.a': 1,
         'item2.b': 0.1,
         'item2.c': 'x',
         'item3': False,
-        'item4': None,
+        'item4': 'none',
+        'item5': None,
     }
     assert args.options == out_dict
     cfg_file = osp.join(data_path, 'config/a.py')

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -471,8 +471,19 @@ def test_dict_action():
         parser.parse_args(['--options', 'item2.a=[(a,b), [1,2], false'])
     # Normal values
     args = parser.parse_args(
-        ['--options', 'item2.a=1', 'item2.b=0.1', 'item2.c=x', 'item3=false'])
-    out_dict = {'item2.a': 1, 'item2.b': 0.1, 'item2.c': 'x', 'item3': False}
+        ['--options',
+         'item2.a=1',
+         'item2.b=0.1',
+         'item2.c=x',
+         'item3=false',
+         'item4=none',
+         ])
+    out_dict = {'item2.a': 1,
+                'item2.b': 0.1,
+                'item2.c': 'x',
+                'item3': False,
+                'item4': None,
+                }
     assert args.options == out_dict
     cfg_file = osp.join(data_path, 'config/a.py')
     cfg = Config.fromfile(cfg_file)

--- a/tests/test_utils/test_config.py
+++ b/tests/test_utils/test_config.py
@@ -470,20 +470,17 @@ def test_dict_action():
     with pytest.raises(AssertionError):
         parser.parse_args(['--options', 'item2.a=[(a,b), [1,2], false'])
     # Normal values
-    args = parser.parse_args(
-        ['--options',
-         'item2.a=1',
-         'item2.b=0.1',
-         'item2.c=x',
-         'item3=false',
-         'item4=none',
-         ])
-    out_dict = {'item2.a': 1,
-                'item2.b': 0.1,
-                'item2.c': 'x',
-                'item3': False,
-                'item4': None,
-                }
+    args = parser.parse_args([
+        '--options', 'item2.a=1', 'item2.b=0.1', 'item2.c=x', 'item3=false',
+        'item4=none'
+    ])
+    out_dict = {
+        'item2.a': 1,
+        'item2.b': 0.1,
+        'item2.c': 'x',
+        'item3': False,
+        'item4': None,
+    }
     assert args.options == out_dict
     cfg_file = osp.join(data_path, 'config/a.py')
     cfg = Config.fromfile(cfg_file)


### PR DESCRIPTION
## Motivation

Resolves #1112

## Modification

Adds `--cfg-options key=none` functionality.


## BC-breaking (Optional)

None that I'm aware of.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
