### PR TITLE
[Enhancement] Speed up Registry initialization

### DIFF
--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -139,9 +139,10 @@ class Registry:
         Returns:
             str: The inferred scope name.
         """
-        # inspect.stack() trace where this function is called, the index-2
-        # indicates the frame where `infer_scope()` is called
-        filename = inspect.getmodule(inspect.stack()[2][0]).__name__
+        frame = inspect.currentframe()
+        # get the frame where `infer_scope()` is called
+        infer_scope_caller = frame.f_back.f_back
+        filename = inspect.getmodule(infer_scope_caller).__name__
         split_filename = filename.split('.')
         return split_filename[0]
 

--- a/mmcv/utils/registry.py
+++ b/mmcv/utils/registry.py
@@ -139,6 +139,8 @@ class Registry:
         Returns:
             str: The inferred scope name.
         """
+        # We access the caller using inspect.currentframe() instead of
+        # inspect.stack() for performance reasons. See details in PR #1844
         frame = inspect.currentframe()
         # get the frame where `infer_scope()` is called
         infer_scope_caller = frame.f_back.f_back


### PR DESCRIPTION


Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

This PR addresses https://github.com/open-mmlab/mmcv/issues/1843 by improving the performance of
`Registry.__init__()`

## Modification

Instead of calling inspect.stack() to read the entire stack and its
associated source files from disk, walk up the stack to get only the
specific frame that we need (see [this answer on StackOverflow](https://stackoverflow.com/a/42636264/895769)
for additional information).

This change results in a ~2.5x speed-up when importing from downstream
projects in my local dev environment. For mmaction2, for example:

Before:

    $ python -m timeit -n1 -r1 "from mmaction.apis import init_recognizer, inference_recognizer"
    1 loop, best of 1: 1.94 sec per loop

After:

    $ python -m timeit -n1 -r1 "from mmaction.apis import init_recognizer, inference_recognizer"
    1 loop, best of 1: 754 msec per loop

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ X ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ X ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ X ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ X ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ X ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
