### PR TITLE
[Feature] Support finding free port in _init_dist_slurm()

### DIFF
--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -28,7 +28,7 @@ def _is_port_in_use(port):
     ips = socket.gethostbyname_ex(socket.gethostname())[-1]
     ips.append('localhost')
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return all([s.connect_ex((ip, port)) == 0 for ip in ips])
+        return any([s.connect_ex((ip, port)) == 0 for ip in ips])
 
 
 def init_dist(launcher, backend='nccl', **kwargs):

--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import functools
 import os
-import subprocess
 import socket
+import subprocess
 from collections import OrderedDict
 
 import torch
@@ -15,7 +15,7 @@ from torch._utils import (_flatten_dense_tensors, _take_tensors,
 def find_free_port():
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # Binding to port 0 will cause the OS to find an available port for us
-    sock.bind(("", 0))
+    sock.bind(('', 0))
     port = sock.getsockname()[1]
     sock.close()
     # NOTE: there is still a chance the port could be taken by other processes.
@@ -81,7 +81,7 @@ def _init_dist_slurm(backend, port=None):
         pass  # use MASTER_PORT in the environment variable
     else:
         # if torch.distributed default port(29500) is available
-        # then use it,else find a free port
+        # then use it, else find a free port
         if not is_port_in_use(29500):
             os.environ['MASTER_PORT'] = '29500'
         else:

--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -14,7 +14,7 @@ from torch._utils import (_flatten_dense_tensors, _take_tensors,
 
 
 def _find_free_port():
-    # Copied from https://github.com/facebookresearch/detectron2/blob/main/detectron2/engine/launch.py # noqa: E501 
+    # Copied from https://github.com/facebookresearch/detectron2/blob/main/detectron2/engine/launch.py # noqa: E501
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # Binding to port 0 will cause the OS to find an available port for us
     sock.bind(('', 0))

--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -13,8 +13,8 @@ from torch._utils import (_flatten_dense_tensors, _take_tensors,
                           _unflatten_dense_tensors)
 
 
-# Copied from Detectron2
 def _find_free_port():
+    # Copied from https://github.com/facebookresearch/detectron2/blob/main/detectron2/engine/launch.py
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # Binding to port 0 will cause the OS to find an available port for us
     sock.bind(('', 0))

--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -14,7 +14,7 @@ from torch._utils import (_flatten_dense_tensors, _take_tensors,
 
 
 def _find_free_port():
-    # Copied from https://github.com/facebookresearch/detectron2/blob/main/detectron2/engine/launch.py
+    # Copied from https://github.com/facebookresearch/detectron2/blob/main/detectron2/engine/launch.py # noqa: E501 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # Binding to port 0 will cause the OS to find an available port for us
     sock.bind(('', 0))

--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import functools
 import os
 import socket
@@ -12,6 +13,7 @@ from torch._utils import (_flatten_dense_tensors, _take_tensors,
                           _unflatten_dense_tensors)
 
 
+# Copied from Detectron2
 def find_free_port():
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # Binding to port 0 will cause the OS to find an available port for us

--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -14,7 +14,7 @@ from torch._utils import (_flatten_dense_tensors, _take_tensors,
 
 
 # Copied from Detectron2
-def find_free_port():
+def _find_free_port():
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # Binding to port 0 will cause the OS to find an available port for us
     sock.bind(('', 0))
@@ -24,7 +24,7 @@ def find_free_port():
     return port
 
 
-def is_port_in_use(port):
+def _is_port_in_use(port):
     ips = socket.gethostbyname_ex(socket.gethostname())[-1]
     ips.append('localhost')
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -86,10 +86,10 @@ def _init_dist_slurm(backend, port=None):
     else:
         # if torch.distributed default port(29500) is available
         # then use it, else find a free port
-        if not is_port_in_use(29500):
+        if not _is_port_in_use(29500):
             os.environ['MASTER_PORT'] = '29500'
         else:
-            os.environ['MASTER_PORT'] = str(find_free_port())
+            os.environ['MASTER_PORT'] = str(_find_free_port())
     # use MASTER_ADDR in the environment variable if it already exists
     if 'MASTER_ADDR' not in os.environ:
         os.environ['MASTER_ADDR'] = addr

--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -28,7 +28,7 @@ def _is_free_port(port):
     ips = socket.gethostbyname_ex(socket.gethostname())[-1]
     ips.append('localhost')
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return not any([s.connect_ex((ip, port)) == 0 for ip in ips])
+        return all(s.connect_ex((ip, port)) != 0 for ip in ips)
 
 
 def init_dist(launcher, backend='nccl', **kwargs):

--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -24,11 +24,11 @@ def _find_free_port():
     return port
 
 
-def _is_port_in_use(port):
+def _is_free_port(port):
     ips = socket.gethostbyname_ex(socket.gethostname())[-1]
     ips.append('localhost')
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return any([s.connect_ex((ip, port)) == 0 for ip in ips])
+        return not any([s.connect_ex((ip, port)) == 0 for ip in ips])
 
 
 def init_dist(launcher, backend='nccl', **kwargs):
@@ -86,7 +86,7 @@ def _init_dist_slurm(backend, port=None):
     else:
         # if torch.distributed default port(29500) is available
         # then use it, else find a free port
-        if not _is_port_in_use(29500):
+        if _is_free_port(29500):
             os.environ['MASTER_PORT'] = '29500'
         else:
             os.environ['MASTER_PORT'] = str(_find_free_port())

--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -23,8 +23,10 @@ def find_free_port():
 
 
 def is_port_in_use(port):
+    ips = socket.gethostbyname_ex(socket.gethostname())[-1]
+    ips.append('localhost')
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        return s.connect_ex(('localhost', port)) == 0
+        return all([s.connect_ex((ip, port)) == 0 for ip in ips])
 
 
 def init_dist(launcher, backend='nccl', **kwargs):


### PR DESCRIPTION
## Motivation

Sometimes torch.distributed default port(29500) is occupied,that's when _init_dist_slurm() need to find a free port.

## Modification

Add function ``is_port_in_use`` to test if a port is occupied and ``find_free_port`` to find a free port in ``_init_dist_slurm()``

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
