### PR TITLE
Rename `LoadAnnotation` to `LoadAnnotations`

### DIFF
--- a/docs/zh_cn/understand_mmcv/data_transform.md
+++ b/docs/zh_cn/understand_mmcv/data_transform.md
@@ -74,7 +74,7 @@ dataset = dict(
 | class                         | 功能                                      |
 | :---------------------------: | :---------------------------------------: |
 | [`LoadImageFromFile`](TODO)   | 根据路径加载图像                          |
-| [`LoadAnnotation`](TODO)      | 加载和组织标注信息，如 bbox、语义分割图等 |
+| [`LoadAnnotations`](TODO)      | 加载和组织标注信息，如 bbox、语义分割图等 |
 
 ### 数据预处理及增强
 

--- a/mmcv/transforms/__init__.py
+++ b/mmcv/transforms/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .builder import TRANSFORMS
-from .loading import LoadAnnotation, LoadImageFromFile
+from .loading import LoadAnnotations, LoadImageFromFile
 from .processing import (CenterCrop, MultiScaleFlipAug, Normalize, Pad,
                          RandomChoiceResize, RandomFlip, RandomGrayscale,
                          RandomResize, Resize)
@@ -11,7 +11,7 @@ try:
 except ImportError:
     __all__ = [
         'TRANSFORMS', 'TransformBroadcaster', 'Compose', 'RandomChoice',
-        'KeyMapper', 'LoadImageFromFile', 'LoadAnnotation', 'Normalize',
+        'KeyMapper', 'LoadImageFromFile', 'LoadAnnotations', 'Normalize',
         'Resize', 'Pad', 'RandomFlip', 'RandomChoiceResize', 'CenterCrop',
         'RandomGrayscale', 'MultiScaleFlipAug', 'RandomResize'
     ]
@@ -20,7 +20,7 @@ else:
 
     __all__ = [
         'TRANSFORMS', 'TransformBroadcaster', 'Compose', 'RandomChoice',
-        'KeyMapper', 'LoadImageFromFile', 'LoadAnnotation', 'Normalize',
+        'KeyMapper', 'LoadImageFromFile', 'LoadAnnotations', 'Normalize',
         'Resize', 'Pad', 'ToTensor', 'to_tensor', 'ImageToTensor',
         'RandomFlip', 'RandomChoiceResize', 'CenterCrop', 'RandomGrayscale',
         'MultiScaleFlipAug', 'RandomResize'

--- a/mmcv/transforms/loading.py
+++ b/mmcv/transforms/loading.py
@@ -84,7 +84,7 @@ class LoadImageFromFile(BaseTransform):
         return repr_str
 
 
-class LoadAnnotation(BaseTransform):
+class LoadAnnotations(BaseTransform):
     """Load and process the ``instances`` and ``seg_map`` annotation provided
     by dataset.
 

--- a/tests/test_transforms/test_transforms_loading.py
+++ b/tests/test_transforms/test_transforms_loading.py
@@ -4,7 +4,7 @@ import os.path as osp
 
 import numpy as np
 
-from mmcv.transforms import LoadAnnotation, LoadImageFromFile
+from mmcv.transforms import LoadAnnotations, LoadImageFromFile
 
 
 class TestLoadImageFromFile:
@@ -44,7 +44,7 @@ class TestLoadImageFromFile:
         assert results['img'].dtype == np.uint8
 
 
-class TestLoadAnnotation:
+class TestLoadAnnotations:
 
     def setup_class(cls):
         data_prefix = osp.join(osp.dirname(__file__), '../data')
@@ -64,7 +64,7 @@ class TestLoadAnnotation:
         }
 
     def test_load_bboxes(self):
-        transform = LoadAnnotation(
+        transform = LoadAnnotations(
             with_bbox=True,
             with_label=False,
             with_seg=False,
@@ -76,7 +76,7 @@ class TestLoadAnnotation:
                                                   [10, 10, 110, 120]])).all()
 
     def test_load_labels(self):
-        transform = LoadAnnotation(
+        transform = LoadAnnotations(
             with_bbox=False,
             with_label=True,
             with_seg=False,
@@ -87,7 +87,7 @@ class TestLoadAnnotation:
         assert (results['gt_bboxes_labels'] == np.array([1, 2])).all()
 
     def test_load_kps(self):
-        transform = LoadAnnotation(
+        transform = LoadAnnotations(
             with_bbox=False,
             with_label=False,
             with_seg=False,
@@ -99,7 +99,7 @@ class TestLoadAnnotation:
                                                      [[4, 5, 6]]])).all()
 
     def test_load_seg_map(self):
-        transform = LoadAnnotation(
+        transform = LoadAnnotations(
             with_bbox=False,
             with_label=False,
             with_seg=True,
@@ -110,14 +110,14 @@ class TestLoadAnnotation:
         assert results['gt_seg_map'].shape[:2] == (300, 400)
 
     def test_repr(self):
-        transform = LoadAnnotation(
+        transform = LoadAnnotations(
             with_bbox=True,
             with_label=False,
             with_seg=False,
             with_keypoints=False,
         )
         assert repr(transform) == (
-            'LoadAnnotation(with_bbox=True, '
+            'LoadAnnotations(with_bbox=True, '
             'with_label=False, with_seg=False, '
             "with_keypoints=False, imdecode_backend='cv2', "
             "file_client_args={'backend': 'disk'})")


### PR DESCRIPTION
## Motivation

The `LoadAnnotations` is commonly used in mmdet and mmseg, and I missed the tailed "s"

## Modification

As the title

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
