### PR TITLE
[Fix] Fix spconv unit test by releasing cache on GPU

### DIFF
--- a/tests/test_ops/test_spconv.py
+++ b/tests/test_ops/test_spconv.py
@@ -76,6 +76,7 @@ def make_sparse_convmodule(in_channels,
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason='requires CUDA support')
 def test_make_sparse_convmodule():
+    torch.cuda.empty_cache()
     voxel_features = torch.tensor([[6.56126, 0.9648336, -1.7339306, 0.315],
                                    [6.8162713, -2.480431, -1.3616394, 0.36],
                                    [11.643568, -4.744306, -1.3580885, 0.16],


### PR DESCRIPTION
## Motivation
Some ops unit tests will report errors on circleci, and the main problem is out of memory. So I try to move some op ut to run in sub-threads; when the sub-thread finishes, the sub-thread will release the memory, thus avoiding out of memory.
