### PR TITLE
Sassd

### DIFF
--- a/mmcv/ops/__init__.py
+++ b/mmcv/ops/__init__.py
@@ -40,8 +40,8 @@ from .pixel_group import pixel_group
 from .point_sample import (SimpleRoIAlign, point_sample,
                            rel_roi_point_to_rel_img_point)
 from .points_in_boxes import (points_in_boxes_all, points_in_boxes_cpu,
-                              points_in_boxes_with_offsets_cpu,
-                              points_in_boxes_part)
+                              points_in_boxes_part,
+                              points_in_boxes_with_offsets_cpu)
 from .points_in_polygons import points_in_polygons
 from .points_sampler import PointsSampler
 from .psa_mask import PSAMask

--- a/mmcv/ops/__init__.py
+++ b/mmcv/ops/__init__.py
@@ -40,6 +40,7 @@ from .pixel_group import pixel_group
 from .point_sample import (SimpleRoIAlign, point_sample,
                            rel_roi_point_to_rel_img_point)
 from .points_in_boxes import (points_in_boxes_all, points_in_boxes_cpu,
+                              points_in_boxes_with_offsets_cpu,
                               points_in_boxes_part)
 from .points_in_polygons import points_in_polygons
 from .points_sampler import PointsSampler
@@ -96,5 +97,5 @@ __all__ = [
     'SparseMaxPool2d', 'SparseMaxPool3d', 'SparseConvTensor', 'scatter_nd',
     'points_in_boxes_part', 'points_in_boxes_cpu', 'points_in_boxes_all',
     'points_in_polygons', 'min_area_polygons', 'active_rotated_filter',
-    'convex_iou', 'convex_giou'
+    'convex_iou', 'convex_giou', 'points_in_boxes_with_offsets_cpu'
 ]

--- a/mmcv/ops/csrc/parrots/points_in_boxes_parrots.cpp
+++ b/mmcv/ops/csrc/parrots/points_in_boxes_parrots.cpp
@@ -57,8 +57,29 @@ void points_in_boxes_forward_cpu_parrots(HostContext& ctx,
   points_in_boxes_cpu_forward(boxes_tensor, pts_tensor, pts_indices_tensor);
 }
 
+void points_in_boxes_forward_with_offsets_cpu_parrots(
+                                          HostContext& ctx,
+                                          const SSElement& attr,
+                                          const OperatorBase::in_list_t& ins,
+                                          OperatorBase::out_list_t& outs) {
+  auto boxes_tensor = buildATensor(ctx, ins[0]);
+  auto pts_tensor = buildATensor(ctx, ins[1]);
+
+  auto pts_indices_tensor = buildATensor(ctx, outs[0]);
+  auto center_offsets_tensor = buildATensor(ctx, outs[1]);
+
+  points_in_boxes_cpu_forward(boxes_tensor, pts_tensor, pts_indices_tensor,
+                              center_offsets_tensor);
+}
+
 PARROTS_EXTENSION_REGISTER(points_in_boxes_cpu_forward)
     .input(2)
     .output(1)
     .apply(points_in_boxes_forward_cpu_parrots)
+    .done();
+
+PARROTS_EXTENSION_REGISTER(points_in_boxes_cpu_forward_with_offsets)
+    .input(2)
+    .output(1)
+    .apply(points_in_boxes_forward_with_offsets_cpu_parrots)
     .done();

--- a/mmcv/ops/csrc/parrots/points_in_boxes_parrots.cpp
+++ b/mmcv/ops/csrc/parrots/points_in_boxes_parrots.cpp
@@ -57,7 +57,7 @@ void points_in_boxes_forward_cpu_parrots(HostContext& ctx,
   points_in_boxes_cpu_forward(boxes_tensor, pts_tensor, pts_indices_tensor);
 }
 
-void points_in_boxes_forward_with_offsets_cpu_parrots(
+void points_in_boxes_with_offsets_forward_cpu_parrots(
                                           HostContext& ctx,
                                           const SSElement& attr,
                                           const OperatorBase::in_list_t& ins,
@@ -68,8 +68,9 @@ void points_in_boxes_forward_with_offsets_cpu_parrots(
   auto pts_indices_tensor = buildATensor(ctx, outs[0]);
   auto center_offsets_tensor = buildATensor(ctx, outs[1]);
 
-  points_in_boxes_cpu_forward(boxes_tensor, pts_tensor, pts_indices_tensor,
-                              center_offsets_tensor);
+  points_in_boxes_with_offsets_cpu_forward(boxes_tensor, pts_tensor,
+                                           pts_indices_tensor,
+                                           center_offsets_tensor);
 }
 
 PARROTS_EXTENSION_REGISTER(points_in_boxes_cpu_forward)
@@ -78,8 +79,8 @@ PARROTS_EXTENSION_REGISTER(points_in_boxes_cpu_forward)
     .apply(points_in_boxes_forward_cpu_parrots)
     .done();
 
-PARROTS_EXTENSION_REGISTER(points_in_boxes_cpu_forward_with_offsets)
+PARROTS_EXTENSION_REGISTER(points_in_boxes_with_offsets_cpu_forward)
     .input(2)
-    .output(1)
-    .apply(points_in_boxes_forward_with_offsets_cpu_parrots)
+    .output(2)
+    .apply(points_in_boxes_with_offsets_forward_cpu_parrots)
     .done();

--- a/mmcv/ops/csrc/parrots/points_in_boxes_pytorch.h
+++ b/mmcv/ops/csrc/parrots/points_in_boxes_pytorch.h
@@ -13,4 +13,8 @@ void points_in_boxes_all_forward(Tensor boxes_tensor, Tensor pts_tensor,
 void points_in_boxes_cpu_forward(Tensor boxes_tensor, Tensor pts_tensor,
                                  Tensor pts_indices_tensor);
 
+void points_in_boxes_cpu_forward_with_offsets(Tensor boxes_tensor,
+                                              Tensor pts_tensor,
+                                              Tensor pts_indices_tensor,
+                                              Tensor center_offsets_tensor);
 #endif  // POINTS_IN_BOXES_PYTORCH_H

--- a/mmcv/ops/csrc/parrots/points_in_boxes_pytorch.h
+++ b/mmcv/ops/csrc/parrots/points_in_boxes_pytorch.h
@@ -13,7 +13,7 @@ void points_in_boxes_all_forward(Tensor boxes_tensor, Tensor pts_tensor,
 void points_in_boxes_cpu_forward(Tensor boxes_tensor, Tensor pts_tensor,
                                  Tensor pts_indices_tensor);
 
-void points_in_boxes_cpu_forward_with_offsets(Tensor boxes_tensor,
+void points_in_boxes_with_offsets_cpu_forward(Tensor boxes_tensor,
                                               Tensor pts_tensor,
                                               Tensor pts_indices_tensor,
                                               Tensor center_offsets_tensor);

--- a/mmcv/ops/csrc/pytorch/cpu/points_in_boxes.cpp
+++ b/mmcv/ops/csrc/pytorch/cpu/points_in_boxes.cpp
@@ -52,7 +52,7 @@ void points_in_boxes_cpu_forward(Tensor boxes_tensor, Tensor pts_tensor,
   }
 }
 
-void points_in_boxes_cpu_forward_with_offsets(Tensor boxes_tensor,
+void points_in_boxes_with_offsets_cpu_forward(Tensor boxes_tensor,
                                               Tensor pts_tensor,
                                               Tensor pts_indices_tensor,
                                               Tensor center_offsets_tensor) {

--- a/mmcv/ops/csrc/pytorch/pybind.cpp
+++ b/mmcv/ops/csrc/pytorch/pybind.cpp
@@ -341,7 +341,7 @@ void border_align_backward(const Tensor &grad_output, const Tensor &boxes,
 void points_in_boxes_cpu_forward(Tensor boxes_tensor, Tensor pts_tensor,
                                  Tensor pts_indices_tensor);
 
-void points_in_boxes_cpu_forward_with_offsets(Tensor boxes_tensor,
+void points_in_boxes_with_offsets_cpu_forward(Tensor boxes_tensor,
                                               Tensor pts_tensor,
                                               Tensor pts_indices_tensor,
                                               Tensor center_offsets_tensor);
@@ -766,9 +766,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("points_in_boxes_cpu_forward", &points_in_boxes_cpu_forward,
         "points_in_boxes_cpu_forward", py::arg("boxes_tensor"),
         py::arg("pts_tensor"), py::arg("pts_indices_tensor"));
-  m.def("points_in_boxes_cpu_forward_with_offsets",
-        &points_in_boxes_cpu_forward_with_offsets,
-        "points_in_boxes_cpu_forward_with_offsets", py::arg("boxes_tensor"),
+  m.def("points_in_boxes_with_offsets_cpu_forward",
+        &points_in_boxes_with_offsets_cpu_forward,
+        "points_in_boxes_with_offsets_cpu_forward", py::arg("boxes_tensor"),
         py::arg("pts_tensor"), py::arg("pts_indices_tensor"));
   m.def("points_in_boxes_part_forward", &points_in_boxes_part_forward,
         "points_in_boxes_part_forward", py::arg("boxes_tensor"),

--- a/mmcv/ops/csrc/pytorch/pybind.cpp
+++ b/mmcv/ops/csrc/pytorch/pybind.cpp
@@ -341,6 +341,11 @@ void border_align_backward(const Tensor &grad_output, const Tensor &boxes,
 void points_in_boxes_cpu_forward(Tensor boxes_tensor, Tensor pts_tensor,
                                  Tensor pts_indices_tensor);
 
+void points_in_boxes_cpu_forward_with_offsets(Tensor boxes_tensor,
+                                              Tensor pts_tensor,
+                                              Tensor pts_indices_tensor,
+                                              Tensor center_offsets_tensor);
+
 void points_in_boxes_part_forward(Tensor boxes_tensor, Tensor pts_tensor,
                                   Tensor box_idx_of_points_tensor);
 
@@ -760,6 +765,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         py::arg("dW"));
   m.def("points_in_boxes_cpu_forward", &points_in_boxes_cpu_forward,
         "points_in_boxes_cpu_forward", py::arg("boxes_tensor"),
+        py::arg("pts_tensor"), py::arg("pts_indices_tensor"));
+  m.def("points_in_boxes_cpu_forward_with_offsets",
+        &points_in_boxes_cpu_forward_with_offsets,
+        "points_in_boxes_cpu_forward_with_offsets", py::arg("boxes_tensor"),
         py::arg("pts_tensor"), py::arg("pts_indices_tensor"));
   m.def("points_in_boxes_part_forward", &points_in_boxes_part_forward,
         "points_in_boxes_part_forward", py::arg("boxes_tensor"),

--- a/mmcv/ops/points_in_boxes.py
+++ b/mmcv/ops/points_in_boxes.py
@@ -4,7 +4,7 @@ from ..utils import ext_loader
 
 ext_module = ext_loader.load_ext('_ext', [
     'points_in_boxes_part_forward', 'points_in_boxes_cpu_forward',
-    'points_in_boxes_cpu_forward_with_offsets', 'points_in_boxes_all_forward'
+    'points_in_boxes_with_offsets_cpu_forward', 'points_in_boxes_all_forward'
 ])
 
 
@@ -128,7 +128,7 @@ def points_in_boxes_with_offsets_cpu(points, boxes):
     center_offsets = points.new_zeros((batch_size, num_points, 3),
                                       dtype=torch.int)
     for b in range(batch_size):
-        ext_module.points_in_boxes_cpu_forward_with_offsets(
+        ext_module.points_in_boxes_with_offsets_cpu_forward(
                                                boxes[b].float().contiguous(),
                                                points[b].float().contiguous(),
                                                point_indices[b])

--- a/mmcv/ops/points_in_boxes.py
+++ b/mmcv/ops/points_in_boxes.py
@@ -132,7 +132,8 @@ def points_in_boxes_with_offsets_cpu(points, boxes):
         ext_module.points_in_boxes_with_offsets_cpu_forward(
                                                boxes[b].float().contiguous(),
                                                points[b].float().contiguous(),
-                                               point_indices[b])
+                                               point_indices[b],
+                                               center_offsets[b])
     point_indices = point_indices.transpose(1, 2)
 
     return point_indices, center_offsets

--- a/mmcv/ops/points_in_boxes.py
+++ b/mmcv/ops/points_in_boxes.py
@@ -93,6 +93,7 @@ def points_in_boxes_cpu(points, boxes):
 
     return point_indices
 
+
 def points_in_boxes_with_offsets_cpu(points, boxes):
     """Find all boxes in which each point is, as well as the offsets from the
     box centers (CPU). The CPU version of :meth:`points_in_boxes_all`.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
We added points_in_boxes_with_offsets_cpu_forward under /ops. The purpose is in addition to get the box indexes of each points, it also return the offsets (distance to the box center). The purpose is that we want to add a new model in mmdet3d. This function is crucial to calculate the loss. mmdet3dd suggested us to add this to mmcv.

## Modification
points_in_boxes_with_offsets_cpu_forward related functions under ops. We don't know the purpose of the file under ops/csrc/parrots. Though we implement the functions referring to the others.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
