### PR TITLE
[Fix] Fixed version comparison to include prerelease versions

### DIFF
--- a/mmcv/parallel/distributed.py
+++ b/mmcv/parallel/distributed.py
@@ -45,7 +45,7 @@ class MMDistributedDataParallel(DistributedDataParallel):
                 logger='mmcv')
 
         if ('parrots' not in TORCH_VERSION
-                and digit_version(TORCH_VERSION) >= digit_version('1.11.0')):
+                and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
             if self._check_sync_bufs_pre_fwd():
                 self._sync_buffers()
         else:

--- a/mmcv/parallel/distributed.py
+++ b/mmcv/parallel/distributed.py
@@ -65,7 +65,7 @@ class MMDistributedDataParallel(DistributedDataParallel):
             output = self.module.train_step(*inputs, **kwargs)
 
         if ('parrots' not in TORCH_VERSION
-                and digit_version(TORCH_VERSION) >= digit_version('1.11.0')):
+                and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
             if self._check_sync_bufs_post_fwd():
                 self._sync_buffers()
 
@@ -100,7 +100,7 @@ class MMDistributedDataParallel(DistributedDataParallel):
                 logger='mmcv')
 
         if ('parrots' not in TORCH_VERSION
-                and digit_version(TORCH_VERSION) >= digit_version('1.11.0')):
+                and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
             if self._check_sync_bufs_pre_fwd():
                 self._sync_buffers()
         else:
@@ -120,7 +120,7 @@ class MMDistributedDataParallel(DistributedDataParallel):
             output = self.module.val_step(*inputs, **kwargs)
 
         if ('parrots' not in TORCH_VERSION
-                and digit_version(TORCH_VERSION) >= digit_version('1.11.0')):
+                and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
             if self._check_sync_bufs_post_fwd():
                 self._sync_buffers()
 


### PR DESCRIPTION
## Motivation

Currently all tagged versions of torch 1.11.0 have version 1.11.0a0. Previously the comparison to 1.11.0 failed and self._sync_params() was still used, causing an error. This fix should include all versions of 1.11.

## Modification

Changed a line of code to include prerelease versions in version checking.

## BC-breaking (Optional)

N/A

## Use cases (Optional)
N/A

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
