### PR TITLE
[Fix] Fix the output of scatter on MLU device

### DIFF
--- a/mmcv/device/mlu/scatter_gather.py
+++ b/mmcv/device/mlu/scatter_gather.py
@@ -16,7 +16,7 @@ def scatter(inputs, target_mlus, dim=0):
         if isinstance(obj, torch.Tensor):
             if target_mlus != [-1]:
                 obj = obj.to('mlu')
-                return obj
+                return [obj]
             else:
                 # for CPU inference we use self-implemented scatter
                 return Scatter.forward(target_mlus, obj)


### PR DESCRIPTION
## Motivation

MMDP or MMDDP use origin scatter_gather to scatter Tensor to one or more device(s).
And the result of scatter_map should be a List of Tensor, each item is for one device.

However, the modified scatter_gather for MLUDP or MLUDDP only returns the pure Tensor.

It causes dimension errors when scatter this result again.

## Modification

Change the output of scatter_map, thus the output is just the same size as GPU or CPU result.

## BC-breaking (Optional)

No BC-breaking.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
