### PR TITLE
[Fix] Get correct encoding in Windows for collect_env()

### DIFF
--- a/mmcv/utils/env.py
+++ b/mmcv/utils/env.py
@@ -81,13 +81,13 @@ def collect_env():
             # on Windows, cl.exe is not in PATH. We need to find the path.
             # distutils.ccompiler.new_compiler() returns a msvccompiler
             # object and after initialization, path to cl.exe is found.
-            import locale
+            import os
             from distutils.ccompiler import new_compiler
             ccompiler = new_compiler()
             ccompiler.initialize()
             cc = subprocess.check_output(
                 f'{ccompiler.cc}', stderr=subprocess.STDOUT, shell=True)
-            encoding = locale.getdefaultlocale()[1]
+            encoding = os.device_encoding(1) or 'utf-8'
             env_info['MSVC'] = cc.decode(encoding).partition('\n')[0].strip()
             env_info['GCC'] = 'n/a'
     except subprocess.CalledProcessError:

--- a/mmcv/utils/env.py
+++ b/mmcv/utils/env.py
@@ -87,7 +87,7 @@ def collect_env():
             ccompiler.initialize()
             cc = subprocess.check_output(
                 f'{ccompiler.cc}', stderr=subprocess.STDOUT, shell=True)
-            encoding = os.device_encoding(1) or 'utf-8'
+            encoding = os.device_encoding(sys.stdout.fileno()) or 'utf-8'
             env_info['MSVC'] = cc.decode(encoding).partition('\n')[0].strip()
             env_info['GCC'] = 'n/a'
     except subprocess.CalledProcessError:


### PR DESCRIPTION
## Motivation

On my Windows, the console output is using utf-8. But the `defaultlocale` gives gbk, which cause decoding error. 

I found `os.device_encoding(1)` gives correct encoding. 

## Modification

Change the way to get encoding of console output. 

## BC-breaking (Optional)

None

## Use cases (Optional)

None

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
