### PR TITLE
make mmcv dump work with pathlib

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -13,6 +13,7 @@ import warnings
 from argparse import Action, ArgumentParser
 from collections import abc
 from importlib import import_module
+from pathlib import Path
 
 from addict import Dict
 from yapf.yapflib.yapf_api import FormatCode
@@ -391,6 +392,8 @@ class Config:
                 raise KeyError(f'{key} is reserved for config file')
 
         super(Config, self).__setattr__('_cfg_dict', ConfigDict(cfg_dict))
+        if isinstance(filename, Path):
+            filename = str(filename)
         super(Config, self).__setattr__('_filename', filename)
         if cfg_text:
             text = cfg_text


### PR DESCRIPTION
see also https://github.com/open-mmlab/mmcv/pull/91.


## Motivation

`mmcv.Config.dump(file)` check for file format with suffix, it would be better to make sure `Config._filename` is `str`, and also support `mmcv.Config.fromfile(file: pathlib.Path)`.

## Modification
It a minor modification.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
