### PR TITLE
[Fix]Fix is_module_wrapper

### DIFF
--- a/mmcv/parallel/utils.py
+++ b/mmcv/parallel/utils.py
@@ -8,7 +8,8 @@ def is_module_wrapper(module):
     The following 3 modules in MMCV (and their subclasses) are regarded as
     module wrappers: DataParallel, DistributedDataParallel,
     MMDistributedDataParallel (the deprecated version). You may add you own
-    module wrapper by registering it to mmcv.parallel.MODULE_WRAPPERS.
+    module wrapper by registering it to mmcv.parallel.MODULE_WRAPPERS or
+    its child registry.
 
     Args:
         module (nn.Module): The module to be checked.
@@ -16,5 +17,14 @@ def is_module_wrapper(module):
     Returns:
         bool: True if the input module is a module wrapper.
     """
-    module_wrappers = tuple(MODULE_WRAPPERS.module_dict.values())
-    return isinstance(module, module_wrappers)
+
+    def dfs(MODULE_WRAPPER):
+        module_wrappers = tuple(MODULE_WRAPPER.module_dict.values())
+        if isinstance(module, module_wrappers):
+            return True
+        for CHILD_MODULE_WRAPPER in MODULE_WRAPPER.children.values():
+            if dfs(CHILD_MODULE_WRAPPER):
+                return True
+        return False
+
+    return dfs(MODULE_WRAPPERS)


### PR DESCRIPTION
## Motivation
In order to avoid scope collision with other codebases, DistributedDataParallelWrapper in mmrazor, mmpose, mmedit or some other codebases need to be registered to a separate registry whose parent is the MODULE_WRAPPERS registry in mmcv. Ref to [this pr](https://github.com/open-mmlab/mmpose/pull/1204). When checking if a module is a module wrapper, we need to consider these child MODULE_WRAPPERS.


## Modification
A Depth-First-Search is needed in ``is_module_wrapper``.
