### PR TITLE
[Fix]Fix is_module_wrapper

### DIFF
--- a/mmcv/parallel/utils.py
+++ b/mmcv/parallel/utils.py
@@ -9,7 +9,7 @@ def is_module_wrapper(module):
     module wrappers: DataParallel, DistributedDataParallel,
     MMDistributedDataParallel (the deprecated version). You may add you own
     module wrapper by registering it to mmcv.parallel.MODULE_WRAPPERS or
-    its child registry.
+    its children registries.
 
     Args:
         module (nn.Module): The module to be checked.
@@ -18,13 +18,13 @@ def is_module_wrapper(module):
         bool: True if the input module is a module wrapper.
     """
 
-    def dfs(MODULE_WRAPPER):
-        module_wrappers = tuple(MODULE_WRAPPER.module_dict.values())
+    def is_module_in_wrapper(module, module_wrapper):
+        module_wrappers = tuple(module_wrapper.module_dict.values())
         if isinstance(module, module_wrappers):
             return True
-        for CHILD_MODULE_WRAPPER in MODULE_WRAPPER.children.values():
-            if dfs(CHILD_MODULE_WRAPPER):
+        for child in module_wrapper.children.values():
+            if is_module_in_wrapper(module, child):
                 return True
         return False
 
-    return dfs(MODULE_WRAPPERS)
+    return is_module_in_wrapper(module, MODULE_WRAPPERS)

--- a/mmcv/parallel/utils.py
+++ b/mmcv/parallel/utils.py
@@ -8,7 +8,8 @@ def is_module_wrapper(module):
     The following 3 modules in MMCV (and their subclasses) are regarded as
     module wrappers: DataParallel, DistributedDataParallel,
     MMDistributedDataParallel (the deprecated version). You may add you own
-    module wrapper by registering it to mmcv.parallel.MODULE_WRAPPERS.
+    module wrapper by registering it to mmcv.parallel.MODULE_WRAPPERS or
+    its child registry.
 
     Args:
         module (nn.Module): The module to be checked.
@@ -16,5 +17,14 @@ def is_module_wrapper(module):
     Returns:
         bool: True if the input module is a module wrapper.
     """
-    module_wrappers = tuple(MODULE_WRAPPERS.module_dict.values())
-    return isinstance(module, module_wrappers)
+
+    def dfs(MODULE_WRAPPER):
+        module_wrappers = tuple(MODULE_WRAPPER.module_dict.values())
+        if isinstance(module, module_wrappers):
+            return True
+        for CHILD_MODULE_WRAPPER in MODULE_WRAPPER.children.values():
+            if dfs(CHILD_MODULE_WRAPPER):
+                return True
+        return False
+
+    return dfs(MODULE_WRAPPERS)

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -74,13 +74,13 @@ def test_is_module_wrapper():
     assert is_module_wrapper(module_wraper)
 
     # test module wrapper registry in downstream repo
-    MODULE_WRAPPERS_MMRAZOR = Registry(
+    MMRAZOR_MODULE_WRAPPERS = Registry(
         'mmrazor module wrapper', parent=MODULE_WRAPPERS, scope='mmrazor')
-    MODULE_WRAPPERS_MMPOSE = Registry(
+    MMPOSE_MODULE_WRAPPERS = Registry(
         'mmpose module wrapper', parent=MODULE_WRAPPERS, scope='mmpose')
 
-    @MODULE_WRAPPERS_MMRAZOR.register_module()
-    class ModuleWrapperRazor(object):
+    @MMRAZOR_MODULE_WRAPPERS.register_module()
+    class ModuleWrapperInRazor(object):
 
         def __init__(self, module):
             self.module = module
@@ -88,8 +88,8 @@ def test_is_module_wrapper():
         def forward(self, *args, **kwargs):
             return self.module(*args, **kwargs)
 
-    @MODULE_WRAPPERS_MMPOSE.register_module()
-    class ModuleWrapperPose(object):
+    @MMPOSE_MODULE_WRAPPERS.register_module()
+    class ModuleWrapperInPose(object):
 
         def __init__(self, module):
             self.module = module
@@ -97,11 +97,11 @@ def test_is_module_wrapper():
         def forward(self, *args, **kwargs):
             return self.module(*args, **kwargs)
 
-    module_wraper = ModuleWrapperRazor(model)
-    assert is_module_wrapper(module_wraper)
+    wrapped_module = ModuleWrapperInRazor(model)
+    assert is_module_wrapper(wrapped_module)
 
-    module_wraper = ModuleWrapperPose(model)
-    assert is_module_wrapper(module_wraper)
+    wrapped_module = ModuleWrapperInPose(model)
+    assert is_module_wrapper(wrapped_module)
 
 
 def test_get_input_device():


### PR DESCRIPTION
## Motivation
In order to avoid scope collision with other codebases, DistributedDataParallelWrapper in mmrazor, mmpose, mmedit or some other codebases need to be registered to a separate registry whose parent is the MODULE_WRAPPERS registry in mmcv. Ref to [this pr](https://github.com/open-mmlab/mmpose/pull/1204). When checking if a module is a module wrapper, we need to consider these child MODULE_WRAPPERS.


## Modification
A Depth-First-Search is needed in ``is_module_wrapper``.
