### PR TITLE
Improve setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -389,6 +389,23 @@ def get_extensions():
 
     return extensions
 
+def create_compile_commands(path='build'):
+    path = os.path.realpath(path)
+    os.makedirs(path, exist_ok=True)
+    ninja_files = []
+    for root, dirs, files in os.walk('./'):
+        for file in files:
+            if file == "build.ninja":
+                ninja_files.append(os.path.join(root, file))
+    assert len(ninja_files) == 1, "The number of 'build.ninja' file must be 1."
+
+    real_path = os.path.realpath(ninja_files[0])
+
+    output_path = os.path.join(path, "compile_commands.json")
+    result = os.popen(f"ninja -f {real_path} -t compdb")
+    with open(output_path, 'w+') as f:
+        f.write(result.read())
+    print(f"Saved compile_commands.json at {os.path.relpath(output_path)}")
 
 setup(
     name='mmcv' if os.getenv('MMCV_WITH_OPS', '0') == '0' else 'mmcv-full',
@@ -422,3 +439,5 @@ setup(
     ext_modules=get_extensions(),
     cmdclass=cmd_class,
     zip_safe=False)
+
+create_compile_commands()

--- a/setup.py
+++ b/setup.py
@@ -397,16 +397,16 @@ def create_compile_commands(path='build'):
         for file in files:
             if file == "build.ninja":
                 ninja_files.append(os.path.join(root, file))
-    if(len(ninja_files==1)):
-      real_path = os.path.realpath(ninja_files[0])
+    if(len(ninja_files)==1):
+        real_path = os.path.realpath(ninja_files[0])
 
-      output_path = os.path.join(path, "compile_commands.json")
-      result = os.popen(f"ninja -f {real_path} -t compdb")
-      with open(output_path, 'w+') as f:
-          f.write(result.read())
-      print(f"Saved compile_commands.json at {os.path.relpath(output_path)}")
+        output_path = os.path.join(path, "compile_commands.json")
+        result = os.popen(f"ninja -f {real_path} -t compdb")
+        with open(output_path, 'w') as f:
+            f.write(result.read())
+        print(f"Saved compile_commands.json at {os.path.relpath(output_path)}")
     else:
-      print("Failed to create compile_commands.json, the number of 'build.ninja' file must be 1.")
+        print("Failed to create compile_commands.json, the number of 'build.ninja' file must be 1.")
 
 setup(
     name='mmcv' if os.getenv('MMCV_WITH_OPS', '0') == '0' else 'mmcv-full',

--- a/setup.py
+++ b/setup.py
@@ -397,15 +397,16 @@ def create_compile_commands(path='build'):
         for file in files:
             if file == "build.ninja":
                 ninja_files.append(os.path.join(root, file))
-    assert len(ninja_files) == 1, "The number of 'build.ninja' file must be 1."
+    if(len(ninja_files==1)):
+      real_path = os.path.realpath(ninja_files[0])
 
-    real_path = os.path.realpath(ninja_files[0])
-
-    output_path = os.path.join(path, "compile_commands.json")
-    result = os.popen(f"ninja -f {real_path} -t compdb")
-    with open(output_path, 'w+') as f:
-        f.write(result.read())
-    print(f"Saved compile_commands.json at {os.path.relpath(output_path)}")
+      output_path = os.path.join(path, "compile_commands.json")
+      result = os.popen(f"ninja -f {real_path} -t compdb")
+      with open(output_path, 'w+') as f:
+          f.write(result.read())
+      print(f"Saved compile_commands.json at {os.path.relpath(output_path)}")
+    else:
+      print("Failed to create compile_commands.json, the number of 'build.ninja' file must be 1.")
 
 setup(
     name='mmcv' if os.getenv('MMCV_WITH_OPS', '0') == '0' else 'mmcv-full',


### PR DESCRIPTION

## Motivation

When I wrote a c++ extension, I can't get intellisense and there were a lot of annoying warnings.
<img width="1280" alt="before" src="https://user-images.githubusercontent.com/75783809/164884546-675217b6-fcee-418d-8cc3-ba4a21912316.png">

## Modification

I added an extra function in setup.py to create a compile_commands.json. In this way I can get intellisense about c++ with the help of clangd. 
<img width="1280" alt="after" src="https://user-images.githubusercontent.com/75783809/164884584-7c43aecc-543d-4093-9177-ef14fdb15c4f.png">


## BC-breaking (Optional)

No.

## Use cases (Optional)

Calling create_compile_commands() at the end of setup.py will create a compile_commands.json file in the build directory by default, so that we can get intellisense about c++ with the help of clangd.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
