### PR TITLE
[Enhancement] Add support for latest Pillow resampling filter naming scheme

### DIFF
--- a/mmcv/image/geometric.py
+++ b/mmcv/image/geometric.py
@@ -38,14 +38,24 @@ cv2_interp_codes = {
 }
 
 if Image is not None:
-    pillow_interp_codes = {
-        'nearest': Image.NEAREST,
-        'bilinear': Image.BILINEAR,
-        'bicubic': Image.BICUBIC,
-        'box': Image.BOX,
-        'lanczos': Image.LANCZOS,
-        'hamming': Image.HAMMING
-    }
+    if hasattr(Image, 'Resampling'):
+        pillow_interp_codes = {
+            'nearest': Image.Resampling.NEAREST,
+            'bilinear': Image.Resampling.BILINEAR,
+            'bicubic': Image.Resampling.BICUBIC,
+            'box': Image.Resampling.BOX,
+            'lanczos': Image.Resampling.LANCZOS,
+            'hamming': Image.Resampling.HAMMING
+        }
+    else:
+        pillow_interp_codes = {
+            'nearest': Image.NEAREST,
+            'bilinear': Image.BILINEAR,
+            'bicubic': Image.BICUBIC,
+            'box': Image.BOX,
+            'lanczos': Image.LANCZOS,
+            'hamming': Image.HAMMING
+        }
 
 
 def imresize(img,

--- a/mmcv/image/geometric.py
+++ b/mmcv/image/geometric.py
@@ -37,7 +37,7 @@ cv2_interp_codes = {
     'lanczos': cv2.INTER_LANCZOS4
 }
 
-# Latest PIL versions use a slightly different naming scheme for the Resampling filters.
+# Latest PIL versions use a slightly different naming scheme for filters.
 # Set pillow_interp_codes according to the naming scheme used.
 if Image is not None:
     if hasattr(Image, 'Resampling'):

--- a/mmcv/image/geometric.py
+++ b/mmcv/image/geometric.py
@@ -37,6 +37,8 @@ cv2_interp_codes = {
     'lanczos': cv2.INTER_LANCZOS4
 }
 
+# Latest PIL versions use a slightly different naming scheme for the Resampling filters.
+# Set pillow_interp_codes according to the naming scheme used.
 if Image is not None:
     if hasattr(Image, 'Resampling'):
         pillow_interp_codes = {

--- a/mmcv/image/geometric.py
+++ b/mmcv/image/geometric.py
@@ -37,7 +37,7 @@ cv2_interp_codes = {
     'lanczos': cv2.INTER_LANCZOS4
 }
 
-# Latest PIL versions use a slightly different naming scheme for filters.
+# Pillow >=v9.1.0 use a slightly different naming scheme for filters.
 # Set pillow_interp_codes according to the naming scheme used.
 if Image is not None:
     if hasattr(Image, 'Resampling'):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Resolves #1894 

Since Pillow v9.1.0, it uses a slightly different naming scheme for filters, and the original scheme will be deprecated and removed in Pillow v10 (2023-07-01). More details can be found at https://github.com/python-pillow/Pillow/pull/5954 and https://pillow.readthedocs.io/en/stable/releasenotes/9.1.0.html#deprecations.

## Modification

This PR fixes the issue by checking the Resampling filter naming before setting `pillow_interp_codes`.

- Update mmcv/image/geometric.py

## BC-breaking (Optional)

No