### PR TITLE
[Fix] fileno() error

### DIFF
--- a/mmcv/utils/env.py
+++ b/mmcv/utils/env.py
@@ -88,8 +88,7 @@ def collect_env():
             ccompiler.initialize()
             cc = subprocess.check_output(
                 f'{ccompiler.cc}', stderr=subprocess.STDOUT, shell=True)
-            encoding = os.device_encoding(
-                sys.stdout.fileno()) or locale.getpreferredencoding()
+            encoding = os.device_encoding(1) or locale.getpreferredencoding()
             env_info['MSVC'] = cc.decode(encoding).partition('\n')[0].strip()
             env_info['GCC'] = 'n/a'
     except subprocess.CalledProcessError:


### PR DESCRIPTION

## Motivation

`sys.stdout.fileno()` is not avaliable on some system. Since on Windows this should be 1 for our use case, we can just hardcode it to 1 and let `locale.getpreferredencoding()` handle other scenarios when `device_encoding(1)` fails. 

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
