### PR TITLE
[Docs] Fix heading anchor in documentation

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -54,6 +54,8 @@ extensions = [
     'sphinx_copybutton',
 ]  # yapf: disable
 
+myst_heading_anchors = 4
+
 autodoc_mock_imports = ['mmcv._ext', 'mmcv.utils.ext_loader', 'torchvision']
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/zh_cn/conf.py
+++ b/docs/zh_cn/conf.py
@@ -55,6 +55,8 @@ extensions = [
     'sphinx_copybutton',
 ]  # yapf: disable
 
+myst_heading_anchors = 4
+
 autodoc_mock_imports = ['mmcv._ext', 'mmcv.utils.ext_loader', 'torchvision']
 autosectionlabel_prefix_document = True
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Add `myst_heading_anchors=4` in `docs/en/conf.py` to fix the error that the heading anchors do not work.

- Before the PR

![image](https://user-images.githubusercontent.com/58739961/167426696-510ebb29-f4d4-471e-bc52-01953b9e0626.png)

- After the PR

![image](https://user-images.githubusercontent.com/58739961/167426790-85d96e3b-f5fc-43c1-a741-646a3698b324.png)


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
