### PR TITLE
[Enhancement] Lower the restrictions of _resize method in BaseMergeCell

### DIFF
--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -96,14 +96,17 @@ class BaseMergeCell(nn.Module):
             return F.interpolate(x, size=size, mode=self.upsample_mode)
         else:
             if x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0:
-                padding_h = (x.shape[-2] // size[-2] + 1) * size[-2] - x.shape[-2]
-                padding_w = (x.shape[-1] // size[-1] + 1) * size[-1] - x.shape[-1]
-                padding_left, padding_right = W_pad // 2, W_pad - W_pad // 2
-                padding_top, padding_bottom = H_pad // 2, H_pad - H_pad // 2
-                x = nn.ConstantPad2d(
-                    (padding_left, padding_right, padding_top, padding_bottom),
-                    0)(
-                        x)
+                h, w = x.shape[-2:]
+                h_t, w_t = size
+                padding_h = (h // h_t + 1) * h_t - h
+                padding_w = (w // w_t + 1) * w_t - w
+                padding_left = padding_w // 2
+                padding_right = padding_w - padding_left
+                padding_top = padding_h // 2
+                padding_bottom = padding_h - padding_top
+                pad = (padding_left, padding_right, padding_top,
+                       padding_bottom)
+                x = F.pad(x, pad, mode='constant', value=0.0)
             kernel_size = (x.shape[-2] // size[-2], x.shape[-1] // size[-1])
             x = F.max_pool2d(x, kernel_size=kernel_size, stride=kernel_size)
             return x

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -99,7 +99,7 @@ class BaseMergeCell(nn.Module):
                 h, w = x.shape[-2:]
                 target_h, target_w = size
                 pad_h = (h // target_h + 1) * target_h - h
-                pad_w = (w // target_w + 1) * target_w - w
+                pad_w = ((w + target_w - 1)//taget_w) * target_w - w
                 pad_l = pad_w // 2
                 pad_r = pad_w - pad_l
                 pad_t = pad_h // 2

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import abstractmethod
 
+import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -97,9 +98,9 @@ class BaseMergeCell(nn.Module):
         else:
             if x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0:
                 h, w = x.shape[-2:]
-                target_h, target_w = size
-                pad_h = ((h + target_h - 1)//target_h) * target_h - h
-                pad_w = ((w + target_w - 1)//target_w) * target_w - w
+                target_h, target_w = size            
+                pad_h = math.ceil(h / target_h) * target_h - h
+                pad_w = math.ceil(w / target_w) * target_w - w
                 pad_l = pad_w // 2
                 pad_r = pad_w - pad_l
                 pad_t = pad_h // 2

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -98,7 +98,7 @@ class BaseMergeCell(nn.Module):
             if x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0:
                 h, w = x.shape[-2:]
                 target_h, target_w = size
-                pad_h = (h // target_h + 1) * target_h - h
+                pad_h = ((h + target_h - 1)//taget_h) * target_h - h
                 pad_w = ((w + target_w - 1)//taget_w) * target_w - w
                 pad_l = pad_w // 2
                 pad_r = pad_w - pad_l

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -98,7 +98,7 @@ class BaseMergeCell(nn.Module):
         else:
             if x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0:
                 h, w = x.shape[-2:]
-                target_h, target_w = size            
+                target_h, target_w = size
                 pad_h = math.ceil(h / target_h) * target_h - h
                 pad_w = math.ceil(w / target_w) * target_w - w
                 pad_l = pad_w // 2

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -97,15 +97,14 @@ class BaseMergeCell(nn.Module):
         else:
             if x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0:
                 h, w = x.shape[-2:]
-                h_t, w_t = size
-                padding_h = (h // h_t + 1) * h_t - h
-                padding_w = (w // w_t + 1) * w_t - w
-                padding_left = padding_w // 2
-                padding_right = padding_w - padding_left
-                padding_top = padding_h // 2
-                padding_bottom = padding_h - padding_top
-                pad = (padding_left, padding_right, padding_top,
-                       padding_bottom)
+                target_h, target_w = size
+                pad_h = (h // target_h + 1) * target_h - h
+                pad_w = (w // target_w + 1) * target_w - w
+                pad_l = pad_w // 2
+                pad_r = pad_w - pad_l
+                pad_t = pad_h // 2
+                pad_b = pad_h - pad_t
+                pad = (pad_l, pad_r, pad_t, pad_b)
                 x = F.pad(x, pad, mode='constant', value=0.0)
             kernel_size = (x.shape[-2] // size[-2], x.shape[-1] // size[-1])
             x = F.max_pool2d(x, kernel_size=kernel_size, stride=kernel_size)

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -4,7 +4,6 @@ from abc import abstractmethod
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 from ..cnn import ConvModule
 
 
@@ -95,22 +94,17 @@ class BaseMergeCell(nn.Module):
         elif x.shape[-2:] < size:
             return F.interpolate(x, size=size, mode=self.upsample_mode)
         else:
-            # assert x.shape[-2] % size[-2] == 0 and x.shape[-1] % size[-1] == 0
-            # kernel_size = x.shape[-1] // size[-1]
-
-            # When x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0, pad zero around x to make it can be divisible by size.
             if x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0:
-                H_pad = (x.shape[-2] // size[-2] +1) * size[-2] - x.shape[-2]
-                W_pad = (x.shape[-1] // size[-1] +1) * size[-1] - x.shape[-1]
+                H_pad = (x.shape[-2] // size[-2] + 1) * size[-2] - x.shape[-2]
+                W_pad = (x.shape[-1] // size[-1] + 1) * size[-1] - x.shape[-1]
                 padding_left, padding_right = W_pad//2, W_pad-W_pad//2
                 padding_top, padding_bottom = H_pad//2, H_pad-H_pad//2
-                x = nn.ConstantPad2d((padding_left, padding_right, padding_top, padding_bottom), 0)(x)
-                
-            # Considering the different downsampling scale of H and W, shape[-2] and shape[-1] are involed in the definition of kernel_size.
+                x = nn.ConstantPad2d((padding_left, padding_right,
+                                      padding_top, padding_bottom), 0)(x)
             kernel_size = (x.shape[-2] // size[-2], x.shape[-1] // size[-1])
             x = F.max_pool2d(x, kernel_size=kernel_size, stride=kernel_size)
             return x
-
+        
     def forward(self, x1, x2, out_size=None):
         assert x1.shape[:2] == x2.shape[:2]
         assert out_size is None or len(out_size) == 2

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -96,8 +96,8 @@ class BaseMergeCell(nn.Module):
             return F.interpolate(x, size=size, mode=self.upsample_mode)
         else:
             if x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0:
-                H_pad = (x.shape[-2] // size[-2] + 1) * size[-2] - x.shape[-2]
-                W_pad = (x.shape[-1] // size[-1] + 1) * size[-1] - x.shape[-1]
+                padding_h = (x.shape[-2] // size[-2] + 1) * size[-2] - x.shape[-2]
+                padding_w = (x.shape[-1] // size[-1] + 1) * size[-1] - x.shape[-1]
                 padding_left, padding_right = W_pad // 2, W_pad - W_pad // 2
                 padding_top, padding_bottom = H_pad // 2, H_pad - H_pad // 2
                 x = nn.ConstantPad2d(

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import math
 from abc import abstractmethod
 
-import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -98,10 +98,12 @@ class BaseMergeCell(nn.Module):
             if x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0:
                 H_pad = (x.shape[-2] // size[-2] + 1) * size[-2] - x.shape[-2]
                 W_pad = (x.shape[-1] // size[-1] + 1) * size[-1] - x.shape[-1]
-                padding_left, padding_right = W_pad//2, W_pad-W_pad//2
-                padding_top, padding_bottom = H_pad//2, H_pad-H_pad//2
-                x = nn.ConstantPad2d((padding_left, padding_right,
-                                      padding_top, padding_bottom), 0)(x)
+                padding_left, padding_right = W_pad // 2, W_pad - W_pad // 2
+                padding_top, padding_bottom = H_pad // 2, H_pad - H_pad // 2
+                x = nn.ConstantPad2d(
+                    (padding_left, padding_right, padding_top, padding_bottom),
+                    0)(
+                        x)
             kernel_size = (x.shape[-2] // size[-2], x.shape[-1] // size[-1])
             x = F.max_pool2d(x, kernel_size=kernel_size, stride=kernel_size)
             return x

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
 from ..cnn import ConvModule
 
 
@@ -104,7 +105,7 @@ class BaseMergeCell(nn.Module):
             kernel_size = (x.shape[-2] // size[-2], x.shape[-1] // size[-1])
             x = F.max_pool2d(x, kernel_size=kernel_size, stride=kernel_size)
             return x
-        
+
     def forward(self, x1, x2, out_size=None):
         assert x1.shape[:2] == x2.shape[:2]
         assert out_size is None or len(out_size) == 2

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -95,8 +95,19 @@ class BaseMergeCell(nn.Module):
         elif x.shape[-2:] < size:
             return F.interpolate(x, size=size, mode=self.upsample_mode)
         else:
-            assert x.shape[-2] % size[-2] == 0 and x.shape[-1] % size[-1] == 0
-            kernel_size = x.shape[-1] // size[-1]
+            # assert x.shape[-2] % size[-2] == 0 and x.shape[-1] % size[-1] == 0
+            # kernel_size = x.shape[-1] // size[-1]
+
+            # When x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0, pad zero around x to make it can be divisible by size.
+            if x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0:
+                H_pad = (x.shape[-2] // size[-2] +1) * size[-2] - x.shape[-2]
+                W_pad = (x.shape[-1] // size[-1] +1) * size[-1] - x.shape[-1]
+                padding_left, padding_right = W_pad//2, W_pad-W_pad//2
+                padding_top, padding_bottom = H_pad//2, H_pad-H_pad//2
+                x = nn.ConstantPad2d((padding_left, padding_right, padding_top, padding_bottom), 0)(x)
+                
+            # Considering the different downsampling scale of H and W, shape[-2] and shape[-1] are involed in the definition of kernel_size.
+            kernel_size = (x.shape[-2] // size[-2], x.shape[-1] // size[-1])
             x = F.max_pool2d(x, kernel_size=kernel_size, stride=kernel_size)
             return x
 

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -98,8 +98,8 @@ class BaseMergeCell(nn.Module):
             if x.shape[-2] % size[-2] != 0 or x.shape[-1] % size[-1] != 0:
                 h, w = x.shape[-2:]
                 target_h, target_w = size
-                pad_h = ((h + target_h - 1)//taget_h) * target_h - h
-                pad_w = ((w + target_w - 1)//taget_w) * target_w - w
+                pad_h = ((h + target_h - 1)//target_h) * target_h - h
+                pad_w = ((w + target_w - 1)//target_w) * target_w - w
                 pad_l = pad_w // 2
                 pad_r = pad_w - pad_l
                 pad_t = pad_h // 2

--- a/tests/test_ops/test_merge_cells.py
+++ b/tests/test_ops/test_merge_cells.py
@@ -10,74 +10,87 @@ from mmcv.ops.merge_cells import (BaseMergeCell, ConcatCell, GlobalPoolingCell,
                                   SumCell)
 
 
+# All size (14, 7) below is to test the situation that
+# the input size can't be divisible by the target size.
 def test_sum_cell():
-    inputs_x = torch.randn([2, 256, 14, 7])
-    inputs_y = torch.randn([2, 256, 16, 16])
-    sum_cell = SumCell(256, 256)
-    output = sum_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
-    assert output.size() == inputs_x.size()
-    output = sum_cell(inputs_x, inputs_y, out_size=inputs_y.shape[-2:])
-    assert output.size() == inputs_y.size()
-    output = sum_cell(inputs_x, inputs_y)
-    assert output.size() == inputs_y.size()
+    target_resize_sizes = [
+        torch.randn([2, 256, 16, 16]),
+        torch.randn([2, 256, 14, 7])
+    ]
+    for inputs_x in target_resize_sizes:
+        inputs_y = torch.randn([2, 256, 32, 32])
+        sum_cell = SumCell(256, 256)
+        output = sum_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
+        assert output.size() == inputs_x.size()
+        output = sum_cell(inputs_x, inputs_y, out_size=inputs_y.shape[-2:])
+        assert output.size() == inputs_y.size()
+        output = sum_cell(inputs_x, inputs_y)
+        assert output.size() == inputs_y.size()
 
 
 def test_concat_cell():
-    inputs_x = torch.randn([2, 256, 14, 7])
-    inputs_y = torch.randn([2, 256, 16, 16])
-    concat_cell = ConcatCell(256, 256)
-    output = concat_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
-    assert output.size() == inputs_x.size()
-    output = concat_cell(inputs_x, inputs_y, out_size=inputs_y.shape[-2:])
-    assert output.size() == inputs_y.size()
-    output = concat_cell(inputs_x, inputs_y)
-    assert output.size() == inputs_y.size()
+    target_resize_sizes = [
+        torch.randn([2, 256, 16, 16]),
+        torch.randn([2, 256, 14, 7])
+    ]
+    for inputs_x in target_resize_sizes:
+        inputs_y = torch.randn([2, 256, 32, 32])
+        concat_cell = ConcatCell(256, 256)
+        output = concat_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
+        assert output.size() == inputs_x.size()
+        output = concat_cell(inputs_x, inputs_y, out_size=inputs_y.shape[-2:])
+        assert output.size() == inputs_y.size()
+        output = concat_cell(inputs_x, inputs_y)
+        assert output.size() == inputs_y.size()
 
 
 def test_global_pool_cell():
-    inputs_x = torch.randn([2, 256, 14, 7])
-    inputs_y = torch.randn([2, 256, 32, 32])
-    gp_cell = GlobalPoolingCell(with_out_conv=False)
-    gp_cell_out = gp_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
-    assert (gp_cell_out.size() == inputs_x.size())
-    gp_cell = GlobalPoolingCell(256, 256)
-    gp_cell_out = gp_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
-    assert (gp_cell_out.size() == inputs_x.size())
+    target_resize_sizes = [
+        torch.randn([2, 256, 16, 16]),
+        torch.randn([2, 256, 14, 7])
+    ]
+    for inputs_x in target_resize_sizes:
+        inputs_y = torch.randn([2, 256, 32, 32])
+        gp_cell = GlobalPoolingCell(with_out_conv=False)
+        gp_cell_out = gp_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
+        assert (gp_cell_out.size() == inputs_x.size())
+        gp_cell = GlobalPoolingCell(256, 256)
+        gp_cell_out = gp_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
+        assert (gp_cell_out.size() == inputs_x.size())
 
 
 def test_resize_methods():
     inputs_x = torch.randn([2, 256, 128, 128])
-    target_resize_sizes = [(128, 128), (256, 256)]
+    target_upsample_sizes = [(128, 128), (256, 256)]
     resize_methods_list = ['nearest', 'bilinear']
 
     for method in resize_methods_list:
         merge_cell = BaseMergeCell(upsample_mode=method)
-        for target_size in target_resize_sizes:
+        for target_size in target_upsample_sizes:
             merge_cell_out = merge_cell._resize(inputs_x, target_size)
             gt_out = F.interpolate(inputs_x, size=target_size, mode=method)
             assert merge_cell_out.equal(gt_out)
-    """resize to a smaller size by which the inputs_x can't be divisible.
-    And There're different downsample scale on dim H & dim W.
-    """
-    target_size = (14, 7)
-    merge_cell = BaseMergeCell()
-    merge_cell_out = merge_cell._resize(inputs_x, target_size)
 
-    if inputs_x.shape[-2] % target_size[-2] != 0 or inputs_x.shape[
-            -1] % target_size[-1] != 0:
-        h, w = inputs_x.shape[-2:]
-        h_t, w_t = target_size
-        padding_h = (h // h_t + 1) * h_t - h
-        padding_w = (w // w_t + 1) * w_t - w
-        padding_left = padding_w // 2
-        padding_right = padding_w - padding_left
-        padding_top = padding_h // 2
-        padding_bottom = padding_h - padding_top
-        pad = (padding_left, padding_right, padding_top, padding_bottom)
-        inputs_x = F.pad(inputs_x, pad, mode='constant', value=0.0)
-    kernel_size = (inputs_x.shape[-2] // target_size[-2],
-                   inputs_x.shape[-1] // target_size[-1])
-    gt_out = F.max_pool2d(
-        inputs_x, kernel_size=kernel_size, stride=kernel_size)
-    assert (merge_cell_out == gt_out).all()
-    assert merge_cell_out.shape[2:] == target_size
+    target_domnsample_sizes = [(64, 64), (14, 7)]  # resize to a smaller size
+    for target_size in target_domnsample_sizes:
+        merge_cell = BaseMergeCell()
+        merge_cell_out = merge_cell._resize(inputs_x, target_size)
+
+        if inputs_x.shape[-2] % target_size[-2] != 0 or inputs_x.shape[
+                -1] % target_size[-1] != 0:
+            h, w = inputs_x.shape[-2:]
+            target_h, target_w = target_size
+            pad_h = (h // target_h + 1) * target_h - h
+            pad_w = (w // target_w + 1) * target_w - w
+            pad_l = pad_w // 2
+            pad_r = pad_w - pad_l
+            pad_t = pad_h // 2
+            pad_b = pad_h - pad_t
+            pad = (pad_l, pad_r, pad_t, pad_b)
+            inputs_x = F.pad(inputs_x, pad, mode='constant', value=0.0)
+        kernel_size = (inputs_x.shape[-2] // target_size[-2],
+                       inputs_x.shape[-1] // target_size[-1])
+        gt_out = F.max_pool2d(
+            inputs_x, kernel_size=kernel_size, stride=kernel_size)
+        assert (merge_cell_out == gt_out).all()
+        assert merge_cell_out.shape[2:] == target_size

--- a/tests/test_ops/test_merge_cells.py
+++ b/tests/test_ops/test_merge_cells.py
@@ -3,94 +3,91 @@
 CommandLine:
     pytest tests/test_merge_cells.py
 """
+import pytest
 import torch
 import torch.nn.functional as F
-
+import math
 from mmcv.ops.merge_cells import (BaseMergeCell, ConcatCell, GlobalPoolingCell,
                                   SumCell)
 
 
 # All size (14, 7) below is to test the situation that
 # the input size can't be divisible by the target size.
-def test_sum_cell():
-    target_resize_sizes = [
-        torch.randn([2, 256, 16, 16]),
-        torch.randn([2, 256, 14, 7])
-    ]
-    for inputs_x in target_resize_sizes:
-        inputs_y = torch.randn([2, 256, 32, 32])
-        sum_cell = SumCell(256, 256)
-        output = sum_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
-        assert output.size() == inputs_x.size()
-        output = sum_cell(inputs_x, inputs_y, out_size=inputs_y.shape[-2:])
-        assert output.size() == inputs_y.size()
-        output = sum_cell(inputs_x, inputs_y)
-        assert output.size() == inputs_y.size()
+@pytest.mark.parametrize(
+    'inputs_x, inputs_y',
+    [(torch.randn([2, 256, 16, 16]), torch.randn([2, 256, 32, 32])),
+     (torch.randn([2, 256, 14, 7]), torch.randn([2, 256, 32, 32]))])
+def test_sum_cell(inputs_x, inputs_y):
+    sum_cell = SumCell(256, 256)
+    output = sum_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
+    assert output.size() == inputs_x.size()
+    output = sum_cell(inputs_x, inputs_y, out_size=inputs_y.shape[-2:])
+    assert output.size() == inputs_y.size()
+    output = sum_cell(inputs_x, inputs_y)
+    assert output.size() == inputs_y.size()
 
 
-def test_concat_cell():
-    target_resize_sizes = [
-        torch.randn([2, 256, 16, 16]),
-        torch.randn([2, 256, 14, 7])
-    ]
-    for inputs_x in target_resize_sizes:
-        inputs_y = torch.randn([2, 256, 32, 32])
-        concat_cell = ConcatCell(256, 256)
-        output = concat_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
-        assert output.size() == inputs_x.size()
-        output = concat_cell(inputs_x, inputs_y, out_size=inputs_y.shape[-2:])
-        assert output.size() == inputs_y.size()
-        output = concat_cell(inputs_x, inputs_y)
-        assert output.size() == inputs_y.size()
+@pytest.mark.parametrize(
+    'inputs_x, inputs_y',
+    [(torch.randn([2, 256, 16, 16]), torch.randn([2, 256, 32, 32])),
+     (torch.randn([2, 256, 14, 7]), torch.randn([2, 256, 32, 32]))])
+def test_concat_cell(inputs_x, inputs_y):
+    concat_cell = ConcatCell(256, 256)
+    output = concat_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
+    assert output.size() == inputs_x.size()
+    output = concat_cell(inputs_x, inputs_y, out_size=inputs_y.shape[-2:])
+    assert output.size() == inputs_y.size()
+    output = concat_cell(inputs_x, inputs_y)
+    assert output.size() == inputs_y.size()
 
 
-def test_global_pool_cell():
-    target_resize_sizes = [
-        torch.randn([2, 256, 16, 16]),
-        torch.randn([2, 256, 14, 7])
-    ]
-    for inputs_x in target_resize_sizes:
-        inputs_y = torch.randn([2, 256, 32, 32])
-        gp_cell = GlobalPoolingCell(with_out_conv=False)
-        gp_cell_out = gp_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
-        assert (gp_cell_out.size() == inputs_x.size())
-        gp_cell = GlobalPoolingCell(256, 256)
-        gp_cell_out = gp_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
-        assert (gp_cell_out.size() == inputs_x.size())
+@pytest.mark.parametrize(
+    'inputs_x, inputs_y',
+    [(torch.randn([2, 256, 16, 16]), torch.randn([2, 256, 32, 32])),
+     (torch.randn([2, 256, 14, 7]), torch.randn([2, 256, 32, 32]))])
+def test_global_pool_cell(inputs_x, inputs_y):
+    gp_cell = GlobalPoolingCell(with_out_conv=False)
+    gp_cell_out = gp_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
+    assert (gp_cell_out.size() == inputs_x.size())
+    gp_cell = GlobalPoolingCell(256, 256)
+    gp_cell_out = gp_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
+    assert (gp_cell_out.size() == inputs_x.size())
 
 
-def test_resize_methods():
+@pytest.mark.parametrize('target_size', [(256, 256), (128, 128), (64, 64),
+                                         (14, 7)])
+def test_resize_methods(target_size):
     inputs_x = torch.randn([2, 256, 128, 128])
-    target_upsample_sizes = [(128, 128), (256, 256)]
-    resize_methods_list = ['nearest', 'bilinear']
+    h, w = inputs_x.shape[-2:]
+    target_h, target_w = target_size
+    if (h <= target_h) or w <= target_w:
+        rs_mode = 'upsample'
+    else:
+        rs_mode = 'downsample'
 
-    for method in resize_methods_list:
-        merge_cell = BaseMergeCell(upsample_mode=method)
-        for target_size in target_upsample_sizes:
+    if rs_mode == 'upsample':
+        upsample_methods_list = ['nearest', 'bilinear']
+        for method in upsample_methods_list:
+            merge_cell = BaseMergeCell(upsample_mode=method)
             merge_cell_out = merge_cell._resize(inputs_x, target_size)
             gt_out = F.interpolate(inputs_x, size=target_size, mode=method)
             assert merge_cell_out.equal(gt_out)
-
-    target_domnsample_sizes = [(64, 64), (14, 7)]  # resize to a smaller size
-    for target_size in target_domnsample_sizes:
+    elif rs_mode == 'downsample':
         merge_cell = BaseMergeCell()
         merge_cell_out = merge_cell._resize(inputs_x, target_size)
-
-        if inputs_x.shape[-2] % target_size[-2] != 0 or inputs_x.shape[
-                -1] % target_size[-1] != 0:
-            h, w = inputs_x.shape[-2:]
-            target_h, target_w = target_size
-            pad_h = (h // target_h + 1) * target_h - h
-            pad_w = (w // target_w + 1) * target_w - w
+        if h % target_h != 0 or w % target_w != 0:
+            pad_h = math.ceil(h / target_h) * target_h - h
+            pad_w = math.ceil(w / target_w) * target_w - w
             pad_l = pad_w // 2
             pad_r = pad_w - pad_l
             pad_t = pad_h // 2
             pad_b = pad_h - pad_t
             pad = (pad_l, pad_r, pad_t, pad_b)
             inputs_x = F.pad(inputs_x, pad, mode='constant', value=0.0)
-        kernel_size = (inputs_x.shape[-2] // target_size[-2],
-                       inputs_x.shape[-1] // target_size[-1])
+        kernel_size = (inputs_x.shape[-2] // target_h,
+                       inputs_x.shape[-1] // target_w)
         gt_out = F.max_pool2d(
             inputs_x, kernel_size=kernel_size, stride=kernel_size)
+        print(merge_cell_out.shape, gt_out.shape)
         assert (merge_cell_out == gt_out).all()
-        assert merge_cell_out.shape[2:] == target_size
+        assert merge_cell_out.shape[-2:] == target_size

--- a/tests/test_ops/test_merge_cells.py
+++ b/tests/test_ops/test_merge_cells.py
@@ -3,10 +3,12 @@
 CommandLine:
     pytest tests/test_merge_cells.py
 """
+import math
+
 import pytest
 import torch
 import torch.nn.functional as F
-import math
+
 from mmcv.ops.merge_cells import (BaseMergeCell, ConcatCell, GlobalPoolingCell,
                                   SumCell)
 

--- a/tests/test_ops/test_merge_cells.py
+++ b/tests/test_ops/test_merge_cells.py
@@ -1,4 +1,3 @@
-# Copyright (c) OpenMMLab. All rights reserved.
 """
 CommandLine:
     pytest tests/test_merge_cells.py
@@ -11,7 +10,7 @@ from mmcv.ops.merge_cells import (BaseMergeCell, ConcatCell, GlobalPoolingCell,
 
 
 def test_sum_cell():
-    inputs_x = torch.randn([2, 256, 32, 32])
+    inputs_x = torch.randn([2, 256, 14, 7])
     inputs_y = torch.randn([2, 256, 16, 16])
     sum_cell = SumCell(256, 256)
     output = sum_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
@@ -19,11 +18,11 @@ def test_sum_cell():
     output = sum_cell(inputs_x, inputs_y, out_size=inputs_y.shape[-2:])
     assert output.size() == inputs_y.size()
     output = sum_cell(inputs_x, inputs_y)
-    assert output.size() == inputs_x.size()
+    assert output.size() == inputs_y.size()
 
 
 def test_concat_cell():
-    inputs_x = torch.randn([2, 256, 32, 32])
+    inputs_x = torch.randn([2, 256, 14, 7])
     inputs_y = torch.randn([2, 256, 16, 16])
     concat_cell = ConcatCell(256, 256)
     output = concat_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
@@ -31,11 +30,11 @@ def test_concat_cell():
     output = concat_cell(inputs_x, inputs_y, out_size=inputs_y.shape[-2:])
     assert output.size() == inputs_y.size()
     output = concat_cell(inputs_x, inputs_y)
-    assert output.size() == inputs_x.size()
+    assert output.size() == inputs_y.size()
 
 
 def test_global_pool_cell():
-    inputs_x = torch.randn([2, 256, 32, 32])
+    inputs_x = torch.randn([2, 256, 14, 7])
     inputs_y = torch.randn([2, 256, 32, 32])
     gp_cell = GlobalPoolingCell(with_out_conv=False)
     gp_cell_out = gp_cell(inputs_x, inputs_y, out_size=inputs_x.shape[-2:])
@@ -56,11 +55,28 @@ def test_resize_methods():
             merge_cell_out = merge_cell._resize(inputs_x, target_size)
             gt_out = F.interpolate(inputs_x, size=target_size, mode=method)
             assert merge_cell_out.equal(gt_out)
-
-    target_size = (64, 64)  # resize to a smaller size
+    """resize to a smaller size by which the inputs_x can't be divisible.
+    And There're different downsample scale on dim H & dim W.
+    """
+    target_size = (14, 7)
     merge_cell = BaseMergeCell()
     merge_cell_out = merge_cell._resize(inputs_x, target_size)
-    kernel_size = inputs_x.shape[-1] // target_size[-1]
+
+    if inputs_x.shape[-2] % target_size[-2] != 0 or inputs_x.shape[
+            -1] % target_size[-1] != 0:
+        h, w = inputs_x.shape[-2:]
+        h_t, w_t = target_size
+        padding_h = (h // h_t + 1) * h_t - h
+        padding_w = (w // w_t + 1) * w_t - w
+        padding_left = padding_w // 2
+        padding_right = padding_w - padding_left
+        padding_top = padding_h // 2
+        padding_bottom = padding_h - padding_top
+        pad = (padding_left, padding_right, padding_top, padding_bottom)
+        inputs_x = F.pad(inputs_x, pad, mode='constant', value=0.0)
+    kernel_size = (inputs_x.shape[-2] // target_size[-2],
+                   inputs_x.shape[-1] // target_size[-1])
     gt_out = F.max_pool2d(
         inputs_x, kernel_size=kernel_size, stride=kernel_size)
     assert (merge_cell_out == gt_out).all()
+    assert merge_cell_out.shape[2:] == target_size

--- a/tests/test_ops/test_merge_cells.py
+++ b/tests/test_ops/test_merge_cells.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 """
 CommandLine:
     pytest tests/test_merge_cells.py


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation 

Fix the bug met in using nasfpn which is mentioned at https://github.com/open-mmlab/mmdetection/issues/3401.

## Modification

Avoid the strong restrictions of _resize function in BaseMergeCell:
1. When Downsampling the feature map, the feature map's shape must be divisible by the target size. We pad zero around feature map before max_pool2d opt to make it always divisible. (line 102 ~ 107)
2. Considering the different downsampling scale of H and W, shape[-2] and shape[-1] are involed in the definition of kernel_size. (line 110)

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, inclu