### PR TITLE
[Fix] Skip CPU test in test_rotated_feature_align.py for parrots

### DIFF
--- a/tests/test_ops/test_rotated_feature_align.py
+++ b/tests/test_ops/test_rotated_feature_align.py
@@ -2,8 +2,8 @@
 import pytest
 import torch
 
-from mmcv.utils import IS_CUDA_AVAILABLE
 from mmcv.ops import rotated_feature_align
+from mmcv.utils import IS_CUDA_AVAILABLE
 
 
 @pytest.mark.skipif(

--- a/tests/test_ops/test_rotated_feature_align.py
+++ b/tests/test_ops/test_rotated_feature_align.py
@@ -2,12 +2,22 @@
 import pytest
 import torch
 
+from mmcv.utils import IS_CUDA_AVAILABLE
 from mmcv.ops import rotated_feature_align
 
 
 @pytest.mark.skipif(
     not torch.cuda.is_available(), reason='requires CUDA support')
-@pytest.mark.parametrize('device', ['cuda', 'cpu'])
+@pytest.mark.parametrize('device', [
+    pytest.param(
+        'cuda',
+        marks=pytest.mark.skipif(
+            not IS_CUDA_AVAILABLE, reason='requires CUDA support')),
+    pytest.param(
+        'cpu',
+        marks=pytest.mark.skipif(
+            torch.__version__ == 'parrots', reason='requires PyTorch support'))
+])
 def test_rotated_feature_align(device):
     feature = torch.tensor([[[[1.2924, -0.2172, -0.5222, 0.1172],
                               [0.9144, 1.2248, 1.3115, -0.9690],


### PR DESCRIPTION
Signed-off-by: del-zhenwu <dele.zhenwu@gmail.com>


## Motivation

Skip CPU test in `test_rotated_feature_align.py` for parrots

## Modification

Update tests/test_ops/test_rotated_feature_align.py

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
