### PR TITLE
[fix]:add warning to GradientCumulativeOptimizerHook

### DIFF
--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -130,6 +130,13 @@ class GradientCumulativeOptimizerHook(OptimizerHook):
         return False
 
     def _init(self, runner):
+        runner.logger.warning(
+            'When using IterBasedRunner and GradientCumulativeOptimizerHook, '
+            'if one wants to get almost equal result with '
+            '`samples_per_gpu=mn` by setting `samples_per_gpu=m` and '
+            '`cumulative_iters = n`, then iter need to times '
+            '`cumulative_iters` to get same optimize steps')
+
         if runner.iter % self.cumulative_iters != 0:
             runner.logger.warning(
                 'Resume iter number is not divisible by cumulative_iters in '


### PR DESCRIPTION
## Motivation

Add warning in `GradientCumulativeOptimizerHook`,just like issue #1952 mentioned.

## Modification

See file.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
