### PR TITLE
[Fix] Fix protobuf compatible error

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,6 +3,7 @@ lmdb
 onnx==1.7.0; python_version < '3.10'
 onnxoptimizer; python_version < '3.10'
 onnxruntime>=1.8.0; python_version < '3.10'
+protobuf~=3.19.0
 pytest
 PyTurboJPEG
 scipy


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix `TypeError: Descriptors can not be created directly` caused by the new version of protobuf.

https://github.com/open-mmlab/mmcv/runs/6603582273?check_suite_focus=true#step:13:95

References:

- https://discuss.streamlit.io/t/typeerror-descriptors-cannot-not-be-created-directly/25639/5
- https://discuss.streamlit.io/t/streamlit-run-with-protocbuf-error/25632/4

## Modification

- Update requirements/test.txt

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
