### PR TITLE
Fix batched_nms for rotated box and add type hint for nms.py

### DIFF
--- a/mmcv/ops/nms.py
+++ b/mmcv/ops/nms.py
@@ -322,7 +322,8 @@ def batched_nms(boxes: Tensor,
     else:
         # When using rotated boxes, only apply offsets on center.
         if boxes.size(-1) == 5:
-            max_coordinate = boxes[..., :2].max()
+            # Use max_center+max_wh as max_coordinate
+            max_coordinate = boxes[..., :2].max() + boxes[..., 2:4].max()
             offsets = idxs.to(boxes) * (
                 max_coordinate + torch.tensor(1).to(boxes))
             boxes_ctr_for_nms = boxes[..., :2] + offsets[:, None]

--- a/mmcv/ops/nms.py
+++ b/mmcv/ops/nms.py
@@ -322,7 +322,13 @@ def batched_nms(boxes: Tensor,
     else:
         # When using rotated boxes, only apply offsets on center.
         if boxes.size(-1) == 5:
-            # Use max_center+max_wh as max_coordinate
+            # Strictly, the maximum coordinates of the rotating box
+            # (x,y,w,h,a) should be calculated by polygon coordinates.
+            # But the conversion from rotated box to polygon will
+            # slow down the speed.
+            # So we use max(x,y) + max(w,h) as max coordinate
+            # which is larger than polygon max coordinate
+            # max(x1, y1, x2, y2,x3, y3, x4, y4)
             max_coordinate = boxes[..., :2].max() + boxes[..., 2:4].max()
             offsets = idxs.to(boxes) * (
                 max_coordinate + torch.tensor(1).to(boxes))

--- a/mmcv/ops/nms.py
+++ b/mmcv/ops/nms.py
@@ -35,8 +35,8 @@ class NMSop(torch.autograd.Function):
         return inds
 
     @staticmethod
-    def symbolic(g: Any, bboxes: Tensor, scores: Tensor, iou_threshold: float,
-                 offset: int, score_threshold: float, max_num: int) -> Tensor:
+    def symbolic(g, bboxes, scores, iou_threshold, offset, score_threshold,
+                 max_num):
         from ..onnx import is_custom_op_loaded
         has_custom_op = is_custom_op_loaded()
         # TensorRT nms plugin is aligned with original nms in ONNXRuntime
@@ -101,9 +101,8 @@ class SoftNMSop(torch.autograd.Function):
         return dets, inds
 
     @staticmethod
-    def symbolic(g: Any, boxes: Tensor, scores: Tensor, iou_threshold: float,
-                 sigma: float, min_score: float, method: int,
-                 offset: int) -> Tuple[Tensor, Tensor]:
+    def symbolic(g, boxes, scores, iou_threshold, sigma, min_score, method,
+                 offset):
         from packaging import version
         assert version.parse(torch.__version__) >= version.parse('1.7.0')
         nms_out = g.op(

--- a/mmcv/ops/nms.py
+++ b/mmcv/ops/nms.py
@@ -289,7 +289,7 @@ def batched_nms(boxes: Tensor,
             is None, otherwise it should specify nms type and other
             parameters like `iou_thr`. Possible keys includes the following.
 
-            - iou_thr (float): IoU threshold used for NMS.
+            - iou_threshold (float): IoU threshold used for NMS.
             - split_thr (float): threshold number of boxes. In some cases the
               number of boxes is large (e.g., 200k). To avoid OOM during
               training, the users could set `split_thr` to a small value.
@@ -391,7 +391,7 @@ def nms_match(dets: array_like_type,
 
     Args:
         dets (torch.Tensor | np.ndarray): Det boxes with scores, shape (N, 5).
-        iou_thr (float): IoU thresh for NMS.
+        iou_threshold (float): IoU thresh for NMS.
 
     Returns:
         list[torch.Tensor | np.ndarray]: The outer list corresponds different

--- a/mmcv/ops/nms.py
+++ b/mmcv/ops/nms.py
@@ -118,16 +118,16 @@ class SoftNMSop(torch.autograd.Function):
         return nms_out
 
 
-nms_input_type = Union[Tensor, np.ndarray]
+array_like_type = Union[Tensor, np.ndarray]
 
 
 @deprecated_api_warning({'iou_thr': 'iou_threshold'})
-def nms(boxes: nms_input_type,
-        scores: nms_input_type,
+def nms(boxes: array_like_type,
+        scores: array_like_type,
         iou_threshold: float,
         offset: int = 0,
         score_threshold: float = 0,
-        max_num: int = -1) -> Tuple[nms_input_type, nms_input_type]:
+        max_num: int = -1) -> Tuple[array_like_type, array_like_type]:
     """Dispatch to either CPU or GPU NMS implementations.
 
     The input can be either torch tensor or numpy array. GPU NMS will be used
@@ -182,13 +182,13 @@ def nms(boxes: nms_input_type,
 
 
 @deprecated_api_warning({'iou_thr': 'iou_threshold'})
-def soft_nms(boxes: nms_input_type,
-             scores: nms_input_type,
+def soft_nms(boxes: array_like_type,
+             scores: array_like_type,
              iou_threshold: float = 0.3,
              sigma: float = 0.5,
              min_score: float = 1e-3,
              method: str = 'linear',
-             offset: int = 0) -> Tuple[nms_input_type, nms_input_type]:
+             offset: int = 0) -> Tuple[array_like_type, array_like_type]:
     """Dispatch to only CPU Soft NMS implementations.
 
     The input can be either a torch tensor or numpy array.
@@ -381,8 +381,8 @@ def batched_nms(boxes: Tensor,
     return boxes, keep
 
 
-def nms_match(dets: nms_input_type,
-              iou_threshold: float) -> List[nms_input_type]:
+def nms_match(dets: array_like_type,
+              iou_threshold: float) -> List[array_like_type]:
     """Matched dets into different groups by NMS.
 
     NMS match is Similar to NMS but when a bbox is suppressed, nms match will

--- a/tests/test_ops/test_nms_rotated.py
+++ b/tests/test_ops/test_nms_rotated.py
@@ -70,15 +70,46 @@ class TestNmsRotated:
         assert np.allclose(dets.cpu().numpy()[:, :5], np_expect_dets)
         assert np.allclose(keep_inds.cpu().numpy(), np_expect_keep_inds)
 
+    def test_batched_nms(self):
         # test batched_nms with nms_rotated
         from mmcv.ops import batched_nms
 
+        np_boxes = np.array(
+            [[6.0, 3.0, 8.0, 7.0, 0.5, 0.7], [3.0, 6.0, 9.0, 11.0, 0.6, 0.8],
+             [3.0, 7.0, 10.0, 12.0, 0.3, 0.5], [1.0, 4.0, 13.0, 7.0, 0.6, 0.9]
+             ],
+            dtype=np.float32)
+        np_labels = np.array([1, 0, 1, 0], dtype=np.float32)
+
+        np_expect_agnostic_dets = np.array(
+            [[1.0, 4.0, 13.0, 7.0, 0.6], [3.0, 6.0, 9.0, 11.0, 0.6],
+             [6.0, 3.0, 8.0, 7.0, 0.5]],
+            dtype=np.float32)
+        np_expect_agnostic_keep_inds = np.array([3, 1, 0], dtype=np.int64)
+
+        np_expect_dets = np.array(
+            [[1.0, 4.0, 13.0, 7.0, 0.6], [3.0, 6.0, 9.0, 11.0, 0.6],
+             [6.0, 3.0, 8.0, 7.0, 0.5], [3.0, 7.0, 10.0, 12.0, 0.3]],
+            dtype=np.float32)
+        np_expect_keep_inds = np.array([3, 1, 0, 2], dtype=np.int64)
+
         nms_cfg = dict(type='nms_rotated', iou_threshold=0.5)
 
+        # test class_agnostic is True
         boxes, keep = batched_nms(
             torch.from_numpy(np_boxes[:, :5]),
             torch.from_numpy(np_boxes[:, -1]),
-            torch.from_numpy(np.array([0, 0, 0, 0])),
+            torch.from_numpy(np_labels),
+            nms_cfg,
+            class_agnostic=True)
+        assert np.allclose(boxes.cpu().numpy()[:, :5], np_expect_agnostic_dets)
+        assert np.allclose(keep.cpu().numpy(), np_expect_agnostic_keep_inds)
+
+        # test class_agnostic is False
+        boxes, keep = batched_nms(
+            torch.from_numpy(np_boxes[:, :5]),
+            torch.from_numpy(np_boxes[:, -1]),
+            torch.from_numpy(np_labels),
             nms_cfg,
             class_agnostic=False)
         assert np.allclose(boxes.cpu().numpy()[:, :5], np_expect_dets)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When set `class_agnostic=False` in `batched_nms`, it will add an offset to det boxes, for horizional bbox in xyxy, the code works fine. But in rotated box (x_ctr, y_ctr, w, h, angle), only center point need offset, so I add a branch to solve that.

Add type hint for nms.py. #1948 

## Modification

- Update mmcv/ops/nms.py
- Update tests/test_ops/test_nms_rotated.py

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
