### PR TITLE
[Enhance] Add type hints in /ops:

### DIFF
--- a/mmcv/ops/gather_points.py
+++ b/mmcv/ops/gather_points.py
@@ -37,7 +37,7 @@ class GatherPoints(Function):
         return output
 
     @staticmethod
-    def backward(ctx, grad_out):
+    def backward(ctx, grad_out: torch.Tensor) -> tuple:
         idx, C, N = ctx.for_backwards
         B, npoint = idx.size()
 

--- a/mmcv/ops/gather_points.py
+++ b/mmcv/ops/gather_points.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import torch
 from torch.autograd import Function
 
@@ -37,7 +39,7 @@ class GatherPoints(Function):
         return output
 
     @staticmethod
-    def backward(ctx, grad_out: torch.Tensor) -> tuple:
+    def backward(ctx, grad_out: torch.Tensor) -> Tuple[torch.Tensor, None]:
         idx, C, N = ctx.for_backwards
         B, npoint = idx.size()
 

--- a/mmcv/ops/group_points.py
+++ b/mmcv/ops/group_points.py
@@ -39,7 +39,7 @@ class QueryAndGroup(nn.Module):
     def __init__(self,
                  max_radius: float,
                  sample_num: int,
-                 min_radius: float = 0,
+                 min_radius: float = 0.,
                  use_xyz: bool = True,
                  return_grouped_xyz: bool = False,
                  normalize_xyz: bool = False,

--- a/mmcv/ops/group_points.py
+++ b/mmcv/ops/group_points.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 from torch import nn as nn
@@ -37,15 +37,15 @@ class QueryAndGroup(nn.Module):
     """
 
     def __init__(self,
-                 max_radius,
-                 sample_num,
-                 min_radius=0,
-                 use_xyz=True,
-                 return_grouped_xyz=False,
-                 normalize_xyz=False,
-                 uniform_sample=False,
-                 return_unique_cnt=False,
-                 return_grouped_idx=False):
+                 max_radius: float,
+                 sample_num: int,
+                 min_radius: float = 0,
+                 use_xyz: bool = True,
+                 return_grouped_xyz: bool = False,
+                 normalize_xyz: bool = False,
+                 uniform_sample: bool = False,
+                 return_unique_cnt: bool = False,
+                 return_grouped_idx: bool = False):
         super().__init__()
         self.max_radius = max_radius
         self.min_radius = min_radius
@@ -64,7 +64,12 @@ class QueryAndGroup(nn.Module):
             assert not self.normalize_xyz, \
                 'can not normalize grouped xyz when max_radius is None'
 
-    def forward(self, points_xyz, center_xyz, features=None):
+    def forward(
+        self,
+        points_xyz: torch.Tensor,
+        center_xyz: torch.Tensor,
+        features: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, Tuple]:
         """
         Args:
             points_xyz (torch.Tensor): (B, N, 3) xyz coordinates of the
@@ -75,7 +80,7 @@ class QueryAndGroup(nn.Module):
                 points.
 
         Returns:
-            torch.Tensor: (B, 3 + C, npoint, sample_num) Grouped
+            Tuple | torch.Tensor: (B, 3 + C, npoint, sample_num) Grouped
             concatenated coordinates and features of points.
         """
         # if self.max_radius is None, we will perform kNN instead of ball query
@@ -149,7 +154,7 @@ class GroupAll(nn.Module):
     def forward(self,
                 xyz: torch.Tensor,
                 new_xyz: torch.Tensor,
-                features: torch.Tensor = None):
+                features: Optional[torch.Tensor] = None) -> torch.Tensor:
         """
         Args:
             xyz (Tensor): (B, N, 3) xyz coordinates of the features.
@@ -210,8 +215,7 @@ class GroupingOperation(Function):
         return output
 
     @staticmethod
-    def backward(ctx,
-                 grad_out: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def backward(ctx, grad_out: torch.Tensor) -> Tuple[torch.Tensor, None]:
         """
         Args:
             grad_out (Tensor): (B, C, npoint, nsample) tensor of the gradients

--- a/mmcv/ops/knn.py
+++ b/mmcv/ops/knn.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 from torch.autograd import Function
 
@@ -19,7 +21,7 @@ class KNN(Function):
     def forward(ctx,
                 k: int,
                 xyz: torch.Tensor,
-                center_xyz: torch.Tensor = None,
+                center_xyz: Optional[torch.Tensor] = None,
                 transposed: bool = False) -> torch.Tensor:
         """
         Args:

--- a/mmcv/ops/masked_conv.py
+++ b/mmcv/ops/masked_conv.py
@@ -17,9 +17,7 @@ ext_module = ext_loader.load_ext(
 class MaskedConv2dFunction(Function):
 
     @staticmethod
-    def symbolic(g, features: torch.Tensor, mask: torch.Tensor,
-                 weight: torch.nn.Parameter, bias: torch.nn.Parameter,
-                 padding: int, stride: int):
+    def symbolic(g, features, mask, weight, bias, padding, stride):
         return g.op(
             'mmcv::MMCVMaskedConv2d',
             features,

--- a/mmcv/ops/masked_conv.py
+++ b/mmcv/ops/masked_conv.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import math
+from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -16,7 +17,9 @@ ext_module = ext_loader.load_ext(
 class MaskedConv2dFunction(Function):
 
     @staticmethod
-    def symbolic(g, features, mask, weight, bias, padding, stride):
+    def symbolic(g, features: torch.Tensor, mask: torch.Tensor,
+                 weight: torch.Tensor, bias: torch.Tensor, padding: int,
+                 stride: int):
         return g.op(
             'mmcv::MMCVMaskedConv2d',
             features,
@@ -27,7 +30,13 @@ class MaskedConv2dFunction(Function):
             stride_i=stride)
 
     @staticmethod
-    def forward(ctx, features, mask, weight, bias, padding=0, stride=1):
+    def forward(ctx,
+                features: torch.Tensor,
+                mask: torch.Tensor,
+                weight: torch.Tensor,
+                bias: torch.Tensor,
+                padding: int = 0,
+                stride: int = 1) -> torch.Tensor:
         assert mask.dim() == 3 and mask.size(0) == 1
         assert features.dim() == 4 and features.size(0) == 1
         assert features.size()[2:] == mask.size()[1:]
@@ -75,7 +84,7 @@ class MaskedConv2dFunction(Function):
 
     @staticmethod
     @once_differentiable
-    def backward(ctx, grad_output):
+    def backward(ctx, grad_output: torch.Tensor) -> tuple:
         return (None, ) * 5
 
 
@@ -90,18 +99,20 @@ class MaskedConv2d(nn.Conv2d):
     """
 
     def __init__(self,
-                 in_channels,
-                 out_channels,
-                 kernel_size,
-                 stride=1,
-                 padding=0,
-                 dilation=1,
-                 groups=1,
-                 bias=True):
+                 in_channels: int,
+                 out_channels: int,
+                 kernel_size: Union[int, Tuple[int, ...]],
+                 stride: int = 1,
+                 padding: int = 0,
+                 dilation: int = 1,
+                 groups: int = 1,
+                 bias: bool = True):
         super().__init__(in_channels, out_channels, kernel_size, stride,
                          padding, dilation, groups, bias)
 
-    def forward(self, input, mask=None):
+    def forward(self,
+                input: torch.Tensor,
+                mask: Optional[torch.Tensor] = None) -> torch.Tensor:
         if mask is None:  # fallback to the normal Conv2d
             return super().forward(input)
         else:

--- a/mmcv/ops/masked_conv.py
+++ b/mmcv/ops/masked_conv.py
@@ -18,8 +18,8 @@ class MaskedConv2dFunction(Function):
 
     @staticmethod
     def symbolic(g, features: torch.Tensor, mask: torch.Tensor,
-                 weight: torch.Tensor, bias: torch.Tensor, padding: int,
-                 stride: int):
+                 weight: torch.nn.Parameter, bias: torch.nn.Parameter,
+                 padding: int, stride: int):
         return g.op(
             'mmcv::MMCVMaskedConv2d',
             features,
@@ -33,8 +33,8 @@ class MaskedConv2dFunction(Function):
     def forward(ctx,
                 features: torch.Tensor,
                 mask: torch.Tensor,
-                weight: torch.Tensor,
-                bias: torch.Tensor,
+                weight: torch.nn.Parameter,
+                bias: torch.nn.Parameter,
                 padding: int = 0,
                 stride: int = 1) -> torch.Tensor:
         assert mask.dim() == 3 and mask.size(0) == 1

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -43,8 +43,8 @@ class BaseMergeCell(nn.Module):
     """
 
     def __init__(self,
-                 fused_channels: int = 256,
-                 out_channels: int = 256,
+                 fused_channels: Optional[int] = 256,
+                 out_channels: Optional[int] = 256,
                  with_out_conv: bool = True,
                  out_conv_cfg: dict = dict(
                      groups=1, kernel_size=3, padding=1, bias=True),
@@ -154,7 +154,10 @@ class ConcatCell(BaseMergeCell):
 
 class GlobalPoolingCell(BaseMergeCell):
 
-    def __init__(self, in_channels: int, out_channels: int, **kwargs):
+    def __init__(self,
+                 in_channels: Optional[int] = None,
+                 out_channels: Optional[int] = None,
+                 **kwargs):
         super().__init__(in_channels, out_channels, **kwargs)
         self.global_pool = nn.AdaptiveAvgPool2d((1, 1))
 

--- a/mmcv/ops/merge_cells.py
+++ b/mmcv/ops/merge_cells.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import math
 from abc import abstractmethod
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -19,7 +20,7 @@ class BaseMergeCell(nn.Module):
     another convolution layer.
 
     Args:
-        in_channels (int): number of input channels in out_conv layer.
+        fused_channels (int): number of input channels in out_conv layer.
         out_channels (int): number of output channels in out_conv layer.
         with_out_conv (bool): Whether to use out_conv layer
         out_conv_cfg (dict): Config dict for convolution layer, which should
@@ -42,18 +43,18 @@ class BaseMergeCell(nn.Module):
     """
 
     def __init__(self,
-                 fused_channels=256,
-                 out_channels=256,
-                 with_out_conv=True,
-                 out_conv_cfg=dict(
+                 fused_channels: int = 256,
+                 out_channels: int = 256,
+                 with_out_conv: bool = True,
+                 out_conv_cfg: dict = dict(
                      groups=1, kernel_size=3, padding=1, bias=True),
-                 out_norm_cfg=None,
-                 out_conv_order=('act', 'conv', 'norm'),
-                 with_input1_conv=False,
-                 with_input2_conv=False,
-                 input_conv_cfg=None,
-                 input_norm_cfg=None,
-                 upsample_mode='nearest'):
+                 out_norm_cfg: Optional[dict] = None,
+                 out_conv_order: tuple = ('act', 'conv', 'norm'),
+                 with_input1_conv: bool = False,
+                 with_input2_conv: bool = False,
+                 input_conv_cfg: Optional[dict] = None,
+                 input_norm_cfg: Optional[dict] = None,
+                 upsample_mode: str = 'nearest'):
         super().__init__()
         assert upsample_mode in ['nearest', 'bilinear']
         self.with_out_conv = with_out_conv
@@ -111,7 +112,10 @@ class BaseMergeCell(nn.Module):
             x = F.max_pool2d(x, kernel_size=kernel_size, stride=kernel_size)
             return x
 
-    def forward(self, x1, x2, out_size=None):
+    def forward(self,
+                x1: torch.Tensor,
+                x2: torch.Tensor,
+                out_size: Optional[tuple] = None) -> torch.Tensor:
         assert x1.shape[:2] == x2.shape[:2]
         assert out_size is None or len(out_size) == 2
         if out_size is None:  # resize to larger one
@@ -131,7 +135,7 @@ class BaseMergeCell(nn.Module):
 
 class SumCell(BaseMergeCell):
 
-    def __init__(self, in_channels, out_channels, **kwargs):
+    def __init__(self, in_channels: int, out_channels: int, **kwargs):
         super().__init__(in_channels, out_channels, **kwargs)
 
     def _binary_op(self, x1, x2):
@@ -140,7 +144,7 @@ class SumCell(BaseMergeCell):
 
 class ConcatCell(BaseMergeCell):
 
-    def __init__(self, in_channels, out_channels, **kwargs):
+    def __init__(self, in_channels: int, out_channels: int, **kwargs):
         super().__init__(in_channels * 2, out_channels, **kwargs)
 
     def _binary_op(self, x1, x2):
@@ -150,7 +154,7 @@ class ConcatCell(BaseMergeCell):
 
 class GlobalPoolingCell(BaseMergeCell):
 
-    def __init__(self, in_channels=None, out_channels=None, **kwargs):
+    def __init__(self, in_channels: int, out_channels: int, **kwargs):
         super().__init__(in_channels, out_channels, **kwargs)
         self.global_pool = nn.AdaptiveAvgPool2d((1, 1))
 

--- a/mmcv/ops/min_area_polygons.py
+++ b/mmcv/ops/min_area_polygons.py
@@ -1,10 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import torch
+
 from ..utils import ext_loader
 
 ext_module = ext_loader.load_ext('_ext', ['min_area_polygons'])
 
 
-def min_area_polygons(pointsets):
+def min_area_polygons(pointsets: torch.Tensor) -> torch.Tensor:
     """Find the smallest polygons that surrounds all points in the point sets.
 
     Args:

--- a/mmcv/ops/modulated_deform_conv.py
+++ b/mmcv/ops/modulated_deform_conv.py
@@ -20,10 +20,8 @@ ext_module = ext_loader.load_ext(
 class ModulatedDeformConv2dFunction(Function):
 
     @staticmethod
-    def symbolic(g, input: torch.Tensor, offset: torch.Tensor,
-                 mask: torch.Tensor, weight: nn.Parameter, bias: nn.Parameter,
-                 stride: int, padding: int, dilation: int, groups: int,
-                 deform_groups: int):
+    def symbolic(g, input, offset, mask, weight, bias, stride, padding,
+                 dilation, groups, deform_groups):
         input_tensors = [input, offset, mask, weight]
         if bias is not None:
             input_tensors.append(bias)

--- a/mmcv/ops/modulated_deform_conv.py
+++ b/mmcv/ops/modulated_deform_conv.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import math
+from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -19,8 +20,10 @@ ext_module = ext_loader.load_ext(
 class ModulatedDeformConv2dFunction(Function):
 
     @staticmethod
-    def symbolic(g, input, offset, mask, weight, bias, stride, padding,
-                 dilation, groups, deform_groups):
+    def symbolic(g, input: torch.Tensor, offset: torch.Tensor,
+                 mask: torch.Tensor, weight: nn.Parameter, bias: nn.Parameter,
+                 stride: int, padding: int, dilation: int, groups: int,
+                 deform_groups: int):
         input_tensors = [input, offset, mask, weight]
         if bias is not None:
             input_tensors.append(bias)
@@ -35,16 +38,16 @@ class ModulatedDeformConv2dFunction(Function):
 
     @staticmethod
     def forward(ctx,
-                input,
-                offset,
-                mask,
-                weight,
-                bias=None,
-                stride=1,
-                padding=0,
-                dilation=1,
-                groups=1,
-                deform_groups=1):
+                input: torch.Tensor,
+                offset: torch.Tensor,
+                mask: torch.Tensor,
+                weight: nn.Parameter,
+                bias: Optional[nn.Parameter] = None,
+                stride: int = 1,
+                padding: int = 0,
+                dilation: int = 1,
+                groups: int = 1,
+                deform_groups: int = 1) -> torch.Tensor:
         if input is not None and input.dim() != 4:
             raise ValueError(
                 f'Expected 4D tensor as input, got {input.dim()}D tensor \
@@ -66,7 +69,7 @@ class ModulatedDeformConv2dFunction(Function):
         # whatever the pytorch version is.
         input = input.type_as(offset)
         weight = weight.type_as(input)
-        bias = bias.type_as(input)
+        bias = bias.type_as(input)  # type: ignore
         ctx.save_for_backward(input, offset, mask, weight, bias)
         output = input.new_empty(
             ModulatedDeformConv2dFunction._output_size(ctx, input, weight))
@@ -95,7 +98,7 @@ class ModulatedDeformConv2dFunction(Function):
 
     @staticmethod
     @once_differentiable
-    def backward(ctx, grad_output):
+    def backward(ctx, grad_output: torch.Tensor) -> tuple:
         input, offset, mask, weight, bias = ctx.saved_tensors
         grad_input = torch.zeros_like(input)
         grad_offset = torch.zeros_like(offset)
@@ -159,15 +162,15 @@ class ModulatedDeformConv2d(nn.Module):
     @deprecated_api_warning({'deformable_groups': 'deform_groups'},
                             cls_name='ModulatedDeformConv2d')
     def __init__(self,
-                 in_channels,
-                 out_channels,
-                 kernel_size,
-                 stride=1,
-                 padding=0,
-                 dilation=1,
-                 groups=1,
-                 deform_groups=1,
-                 bias=True):
+                 in_channels: int,
+                 out_channels: int,
+                 kernel_size: Union[int, Tuple[int]],
+                 stride: int = 1,
+                 padding: int = 0,
+                 dilation: int = 1,
+                 groups: int = 1,
+                 deform_groups: int = 1,
+                 bias: Union[bool, str] = True):
         super().__init__()
         self.in_channels = in_channels
         self.out_channels = out_channels
@@ -199,7 +202,8 @@ class ModulatedDeformConv2d(nn.Module):
         if self.bias is not None:
             self.bias.data.zero_()
 
-    def forward(self, x, offset, mask):
+    def forward(self, x: torch.Tensor, offset: torch.Tensor,
+                mask: torch.Tensor) -> torch.Tensor:
         return modulated_deform_conv2d(x, offset, mask, self.weight, self.bias,
                                        self.stride, self.padding,
                                        self.dilation, self.groups,
@@ -238,13 +242,13 @@ class ModulatedDeformConv2dPack(ModulatedDeformConv2d):
             bias=True)
         self.init_weights()
 
-    def init_weights(self):
+    def init_weights(self) -> None:
         super().init_weights()
         if hasattr(self, 'conv_offset'):
             self.conv_offset.weight.data.zero_()
             self.conv_offset.bias.data.zero_()
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore
         out = self.conv_offset(x)
         o1, o2, mask = torch.chunk(out, 3, dim=1)
         offset = torch.cat((o1, o2), dim=1)

--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -24,7 +24,8 @@ class MultiScaleDeformableAttnFunction(Function):
 
     @staticmethod
     def forward(ctx, value: torch.Tensor, value_spatial_shapes: torch.Tensor,
-                value_level_start_index, sampling_locations: torch.Tensor,
+                value_level_start_index: torch.Tensor,
+                sampling_locations: torch.Tensor,
                 attention_weights: torch.Tensor,
                 im2col_step: torch.Tensor) -> torch.Tensor:
         """GPU version of multi-scale deformable attention.

--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -1,8 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-# mypy: ignore-errors
 import math
 import warnings
-from typing import Optional
+from typing import Optional, no_type_check
 
 import torch
 import torch.nn as nn
@@ -253,6 +252,7 @@ class MultiScaleDeformableAttention(BaseModule):
         xavier_init(self.output_proj, distribution='uniform', bias=0.)
         self._is_init = True
 
+    @no_type_check
     @deprecated_api_warning({'residual': 'identity'},
                             cls_name='MultiScaleDeformableAttention')
     def forward(self,
@@ -320,7 +320,7 @@ class MultiScaleDeformableAttention(BaseModule):
         value = self.value_proj(value)
         if key_padding_mask is not None:
             value = value.masked_fill(key_padding_mask[..., None], 0.0)
-        value = value.view(bs, num_value, self.num_heads, -1)  # type: ignore
+        value = value.view(bs, num_value, self.num_heads, -1)
         sampling_offsets = self.sampling_offsets(query).view(
             bs, num_query, self.num_heads, self.num_levels, self.num_points, 2)
         attention_weights = self.attention_weights(query).view(
@@ -331,13 +331,13 @@ class MultiScaleDeformableAttention(BaseModule):
                                                    self.num_heads,
                                                    self.num_levels,
                                                    self.num_points)
-        if reference_points.shape[-1] == 2:  # type: ignore
+        if reference_points.shape[-1] == 2:
             offset_normalizer = torch.stack(
                 [spatial_shapes[..., 1], spatial_shapes[..., 0]], -1)
             sampling_locations = reference_points[:, :, None, :, None, :] \
                 + sampling_offsets \
                 / offset_normalizer[None, None, None, :, None, :]
-        elif reference_points.shape[-1] == 4:  # type: ignore
+        elif reference_points.shape[-1] == 4:
             sampling_locations = reference_points[:, :, None, :, None, :2] \
                 + sampling_offsets / self.num_points \
                 * reference_points[:, :, None, :, None, 2:] \
@@ -352,10 +352,7 @@ class MultiScaleDeformableAttention(BaseModule):
                 attention_weights, self.im2col_step)
         else:
             output = multi_scale_deformable_attn_pytorch(
-                value,
-                spatial_shapes,  # type: ignore
-                sampling_locations,
-                attention_weights)
+                value, spatial_shapes, sampling_locations, attention_weights)
 
         output = self.output_proj(output)
 


### PR DESCRIPTION
## Modification

[Enhance] Add type hints in /ops:
`fused_bias_leakyrelu.py`, 'gather_points.py`, `group_points.py`.
There is no need to add type hints in `furthest_point_sample.py` and
`info.py`.
As for `focal_loss.py`, please see #1994.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
