### PR TITLE
Add type hints for mmcv/ops

### DIFF
--- a/mmcv/ops/ball_query.py
+++ b/mmcv/ops/ball_query.py
@@ -1,4 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from typing import Tuple
+
 import torch
 from torch.autograd import Function
 
@@ -49,7 +51,7 @@ class BallQuery(Function):
         return idx
 
     @staticmethod
-    def backward(ctx, a=None):
+    def backward(ctx, a=None) -> Tuple[None, None, None, None]:
         return None, None, None, None
 
 

--- a/mmcv/ops/border_align.py
+++ b/mmcv/ops/border_align.py
@@ -2,6 +2,8 @@
 # modified from
 # https://github.com/Megvii-BaseDetection/cvpods/blob/master/cvpods/layers/border_align.py
 
+from typing import Tuple
+
 import torch
 import torch.nn as nn
 from torch.autograd import Function
@@ -16,12 +18,14 @@ ext_module = ext_loader.load_ext(
 class BorderAlignFunction(Function):
 
     @staticmethod
-    def symbolic(g, input, boxes, pool_size):
+    def symbolic(g, input: torch.Tensor, boxes: torch.Tensor,
+                 pool_size: int) -> torch.Tensor:
         return g.op(
             'mmcv::MMCVBorderAlign', input, boxes, pool_size_i=pool_size)
 
     @staticmethod
-    def forward(ctx, input, boxes, pool_size):
+    def forward(ctx, input: torch.Tensor, boxes: torch.Tensor,
+                pool_size: int) -> torch.Tensor:
         ctx.pool_size = pool_size
         ctx.input_shape = input.size()
 
@@ -45,7 +49,8 @@ class BorderAlignFunction(Function):
 
     @staticmethod
     @once_differentiable
-    def backward(ctx, grad_output):
+    def backward(ctx,
+                 grad_output: torch.Tensor) -> Tuple[torch.Tensor, None, None]:
         boxes, argmax_idx = ctx.saved_tensors
         grad_input = grad_output.new_zeros(ctx.input_shape)
         # complex head architecture may cause grad_output uncontiguous

--- a/mmcv/ops/border_align.py
+++ b/mmcv/ops/border_align.py
@@ -18,8 +18,7 @@ ext_module = ext_loader.load_ext(
 class BorderAlignFunction(Function):
 
     @staticmethod
-    def symbolic(g, input: torch.Tensor, boxes: torch.Tensor,
-                 pool_size: int) -> torch.Tensor:
+    def symbolic(g, input, boxes, pool_size):
         return g.op(
             'mmcv::MMCVBorderAlign', input, boxes, pool_size_i=pool_size)
 

--- a/mmcv/ops/correlation.py
+++ b/mmcv/ops/correlation.py
@@ -1,4 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from typing import Tuple
+
 import torch
 from torch import Tensor, nn
 from torch.autograd import Function
@@ -15,14 +17,14 @@ class CorrelationFunction(Function):
 
     @staticmethod
     def forward(ctx,
-                input1,
-                input2,
-                kernel_size=1,
-                max_displacement=1,
-                stride=1,
-                padding=1,
-                dilation=1,
-                dilation_patch=1):
+                input1: Tensor,
+                input2: Tensor,
+                kernel_size: int = 1,
+                max_displacement: int = 1,
+                stride: int = 1,
+                padding: int = 1,
+                dilation: int = 1,
+                dilation_patch: int = 1) -> Tensor:
 
         ctx.save_for_backward(input1, input2)
 
@@ -60,7 +62,9 @@ class CorrelationFunction(Function):
 
     @staticmethod
     @once_differentiable
-    def backward(ctx, grad_output):
+    def backward(
+        ctx, grad_output: Tensor
+    ) -> Tuple[Tensor, Tensor, None, None, None, None, None, None]:
         input1, input2 = ctx.saved_tensors
 
         kH, kW = ctx.kernel_size

--- a/mmcv/ops/deform_conv.py
+++ b/mmcv/ops/deform_conv.py
@@ -22,8 +22,17 @@ ext_module = ext_loader.load_ext('_ext', [
 class DeformConv2dFunction(Function):
 
     @staticmethod
-    def symbolic(g, input, offset, weight, stride, padding, dilation, groups,
-                 deform_groups, bias, im2col_step):
+    def symbolic(g,
+                 input,
+                 offset,
+                 weight,
+                 stride,
+                 padding,
+                 dilation,
+                 groups,
+                 deform_groups,
+                 bias=False,
+                 im2col_step=32):
         return g.op(
             'mmcv::MMCVDeformConv2d',
             input,

--- a/mmcv/ops/deform_conv.py
+++ b/mmcv/ops/deform_conv.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -23,16 +23,16 @@ class DeformConv2dFunction(Function):
 
     @staticmethod
     def symbolic(g,
-                 input,
-                 offset,
-                 weight,
-                 stride,
-                 padding,
-                 dilation,
-                 groups,
-                 deform_groups,
-                 bias=False,
-                 im2col_step=32):
+                 input: Tensor,
+                 offset: Tensor,
+                 weight: Tensor,
+                 stride: Union[int, Tuple[int, ...]],
+                 padding: Union[int, Tuple[int, ...]],
+                 dilation: Union[int, Tuple[int, ...]],
+                 groups: int,
+                 deform_groups: int,
+                 bias: bool = False,
+                 im2col_step: int = 32) -> Tensor:
         return g.op(
             'mmcv::MMCVDeformConv2d',
             input,
@@ -48,16 +48,16 @@ class DeformConv2dFunction(Function):
 
     @staticmethod
     def forward(ctx,
-                input,
-                offset,
-                weight,
-                stride=1,
-                padding=0,
-                dilation=1,
-                groups=1,
-                deform_groups=1,
-                bias=False,
-                im2col_step=32):
+                input: Tensor,
+                offset: Tensor,
+                weight: Tensor,
+                stride: Union[int, Tuple[int, ...]] = 1,
+                padding: Union[int, Tuple[int, ...]] = 0,
+                dilation: Union[int, Tuple[int, ...]] = 1,
+                groups: int = 1,
+                deform_groups: int = 1,
+                bias: bool = False,
+                im2col_step: int = 32) -> Tensor:
         if input is not None and input.dim() != 4:
             raise ValueError(
                 f'Expected 4D tensor as input, got {input.dim()}D tensor \
@@ -111,7 +111,10 @@ class DeformConv2dFunction(Function):
 
     @staticmethod
     @once_differentiable
-    def backward(ctx, grad_output):
+    def backward(
+        ctx, grad_output: Tensor
+    ) -> Tuple[Optional[Tensor], Optional[Tensor], Optional[Tensor], None,
+               None, None, None, None, None, None]:
         input, offset, weight = ctx.saved_tensors
 
         grad_input = grad_offset = grad_weight = None
@@ -371,7 +374,7 @@ class DeformConv2dPack(DeformConv2d):
         self.conv_offset.weight.data.zero_()
         self.conv_offset.bias.data.zero_()
 
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:  # type: ignore
         offset = self.conv_offset(x)
         return deform_conv2d(x, offset, self.weight, self.stride, self.padding,
                              self.dilation, self.groups, self.deform_groups,

--- a/mmcv/ops/deform_conv.py
+++ b/mmcv/ops/deform_conv.py
@@ -22,17 +22,8 @@ ext_module = ext_loader.load_ext('_ext', [
 class DeformConv2dFunction(Function):
 
     @staticmethod
-    def symbolic(g,
-                 input: Tensor,
-                 offset: Tensor,
-                 weight: Tensor,
-                 stride: Union[int, Tuple[int, ...]],
-                 padding: Union[int, Tuple[int, ...]],
-                 dilation: Union[int, Tuple[int, ...]],
-                 groups: int,
-                 deform_groups: int,
-                 bias: bool = False,
-                 im2col_step: int = 32) -> Tensor:
+    def symbolic(g, input, offset, weight, stride, padding, dilation, groups,
+                 deform_groups, bias, im2col_step):
         return g.op(
             'mmcv::MMCVDeformConv2d',
             input,

--- a/mmcv/ops/deform_roi_pool.py
+++ b/mmcv/ops/deform_roi_pool.py
@@ -1,5 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from torch import nn
+from typing import Optional, Tuple
+
+from torch import Tensor, nn
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 from torch.nn.modules.utils import _pair
@@ -13,8 +15,9 @@ ext_module = ext_loader.load_ext(
 class DeformRoIPoolFunction(Function):
 
     @staticmethod
-    def symbolic(g, input, rois, offset, output_size, spatial_scale,
-                 sampling_ratio, gamma):
+    def symbolic(g, input: Tensor, rois: Tensor, offset: Optional[Tensor],
+                 output_size: Tuple[int, ...], spatial_scale: float,
+                 sampling_ratio: int, gamma: float) -> Tensor:
         return g.op(
             'mmcv::MMCVDeformRoIPool',
             input,
@@ -28,13 +31,13 @@ class DeformRoIPoolFunction(Function):
 
     @staticmethod
     def forward(ctx,
-                input,
-                rois,
-                offset,
-                output_size,
-                spatial_scale=1.0,
-                sampling_ratio=0,
-                gamma=0.1):
+                input: Tensor,
+                rois: Tensor,
+                offset: Optional[Tensor],
+                output_size: Tuple[int, ...],
+                spatial_scale: float = 1.0,
+                sampling_ratio: int = 0,
+                gamma: float = 0.1) -> Tensor:
         if offset is None:
             offset = input.new_zeros(0)
         ctx.output_size = _pair(output_size)
@@ -64,7 +67,9 @@ class DeformRoIPoolFunction(Function):
 
     @staticmethod
     @once_differentiable
-    def backward(ctx, grad_output):
+    def backward(
+        ctx, grad_output: Tensor
+    ) -> Tuple[Tensor, None, Tensor, None, None, None, None]:
         input, rois, offset = ctx.saved_tensors
         grad_input = grad_output.new_zeros(input.shape)
         grad_offset = grad_output.new_zeros(offset.shape)
@@ -92,17 +97,20 @@ deform_roi_pool = DeformRoIPoolFunction.apply
 class DeformRoIPool(nn.Module):
 
     def __init__(self,
-                 output_size,
-                 spatial_scale=1.0,
-                 sampling_ratio=0,
-                 gamma=0.1):
+                 output_size: Tuple[int, ...],
+                 spatial_scale: float = 1.0,
+                 sampling_ratio: int = 0,
+                 gamma: float = 0.1):
         super().__init__()
         self.output_size = _pair(output_size)
         self.spatial_scale = float(spatial_scale)
         self.sampling_ratio = int(sampling_ratio)
         self.gamma = float(gamma)
 
-    def forward(self, input, rois, offset=None):
+    def forward(self,
+                input: Tensor,
+                rois: Tensor,
+                offset: Optional[Tensor] = None) -> Tensor:
         return deform_roi_pool(input, rois, offset, self.output_size,
                                self.spatial_scale, self.sampling_ratio,
                                self.gamma)
@@ -111,12 +119,12 @@ class DeformRoIPool(nn.Module):
 class DeformRoIPoolPack(DeformRoIPool):
 
     def __init__(self,
-                 output_size,
-                 output_channels,
-                 deform_fc_channels=1024,
-                 spatial_scale=1.0,
-                 sampling_ratio=0,
-                 gamma=0.1):
+                 output_size: Tuple[int, ...],
+                 output_channels: int,
+                 deform_fc_channels: int = 1024,
+                 spatial_scale: float = 1.0,
+                 sampling_ratio: int = 0,
+                 gamma: float = 0.1):
         super().__init__(output_size, spatial_scale, sampling_ratio, gamma)
 
         self.output_channels = output_channels
@@ -134,7 +142,7 @@ class DeformRoIPoolPack(DeformRoIPool):
         self.offset_fc[-1].weight.data.zero_()
         self.offset_fc[-1].bias.data.zero_()
 
-    def forward(self, input, rois):
+    def forward(self, input: Tensor, rois: Tensor) -> Tensor:  # type: ignore
         assert input.size(1) == self.output_channels
         x = deform_roi_pool(input, rois, None, self.output_size,
                             self.spatial_scale, self.sampling_ratio,
@@ -151,12 +159,12 @@ class DeformRoIPoolPack(DeformRoIPool):
 class ModulatedDeformRoIPoolPack(DeformRoIPool):
 
     def __init__(self,
-                 output_size,
-                 output_channels,
-                 deform_fc_channels=1024,
-                 spatial_scale=1.0,
-                 sampling_ratio=0,
-                 gamma=0.1):
+                 output_size: Tuple[int, ...],
+                 output_channels: int,
+                 deform_fc_channels: int = 1024,
+                 spatial_scale: float = 1.0,
+                 sampling_ratio: int = 0,
+                 gamma: float = 0.1):
         super().__init__(output_size, spatial_scale, sampling_ratio, gamma)
 
         self.output_channels = output_channels
@@ -185,7 +193,7 @@ class ModulatedDeformRoIPoolPack(DeformRoIPool):
         self.mask_fc[2].weight.data.zero_()
         self.mask_fc[2].bias.data.zero_()
 
-    def forward(self, input, rois):
+    def forward(self, input: Tensor, rois: Tensor) -> Tensor:  # type: ignore
         assert input.size(1) == self.output_channels
         x = deform_roi_pool(input, rois, None, self.output_size,
                             self.spatial_scale, self.sampling_ratio,

--- a/mmcv/ops/deform_roi_pool.py
+++ b/mmcv/ops/deform_roi_pool.py
@@ -15,9 +15,8 @@ ext_module = ext_loader.load_ext(
 class DeformRoIPoolFunction(Function):
 
     @staticmethod
-    def symbolic(g, input: Tensor, rois: Tensor, offset: Optional[Tensor],
-                 output_size: Tuple[int, ...], spatial_scale: float,
-                 sampling_ratio: int, gamma: float) -> Tensor:
+    def symbolic(g, input, rois, offset, output_size, spatial_scale,
+                 sampling_ratio, gamma):
         return g.op(
             'mmcv::MMCVDeformRoIPool',
             input,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Add type hints for files in mmcv/ops.

## Modification

Add type hints for files in mmcv/ops:
- ball_query.py
- border_align.py
- correlation.py
- deform_conv.py,
- deform_roi_pool.py
- deprecated_wrappers.py [**NO type hints need to be added in this file**]

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
