### PR TITLE
[Docs] Update copyright years in docs

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -27,7 +27,7 @@ __version__ = locals()['__version__']
 # -- Project information -----------------------------------------------------
 
 project = 'mmcv'
-copyright = '2018-2021, OpenMMLab'
+copyright = '2018-2022, OpenMMLab'
 author = 'MMCV Authors'
 
 # The short X.Y version

--- a/docs/zh_cn/conf.py
+++ b/docs/zh_cn/conf.py
@@ -27,7 +27,7 @@ __version__ = locals()['__version__']
 # -- Project information -----------------------------------------------------
 
 project = 'mmcv'
-copyright = '2018-2021, OpenMMLab'
+copyright = '2018-2022, OpenMMLab'
 author = 'MMCV Authors'
 
 # The short X.Y version


### PR DESCRIPTION


## Modification

change the year from 2018-2021 to 2018-2022

![image](https://user-images.githubusercontent.com/25839884/172133616-66845313-b3a8-4729-92b0-e77108033f21.png)


