### PR TITLE
Add torch_meshgrid_ij wrapper due to PyTorch change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,22 @@ jobs:
       - name: Run unittests and generate coverage report
         run: |
           pip install -r requirements/test.txt
-          pytest tests/ --ignore=tests/test_runner --ignore=tests/test_device/test_ipu --ignore=tests/test_optimizer.py --ignore=tests/test_cnn --ignore=tests/test_parallel.py --ignore=tests/test_ops --ignore=tests/test_load_model_zoo.py --ignore=tests/test_utils/test_logging.py --ignore=tests/test_image/test_io.py --ignore=tests/test_utils/test_registry.py --ignore=tests/test_utils/test_parrots_jit.py --ignore=tests/test_utils/test_trace.py --ignore=tests/test_utils/test_hub.py --ignore=tests/test_device/test_mlu/test_mlu_parallel.py
+          pytest tests/ \
+              --ignore=tests/test_runner \
+              --ignore=tests/test_device/test_ipu \
+              --ignore=tests/test_optimizer.py \
+              --ignore=tests/test_cnn \
+              --ignore=tests/test_parallel.py \
+              --ignore=tests/test_ops \
+              --ignore=tests/test_load_model_zoo.py \
+              --ignore=tests/test_utils/test_logging.py \
+              --ignore=tests/test_image/test_io.py \
+              --ignore=tests/test_utils/test_registry.py \
+              --ignore=tests/test_utils/test_parrots_jit.py \
+              --ignore=tests/test_utils/test_trace.py \
+              --ignore=tests/test_utils/test_hub.py \
+              --ignore=tests/test_device/test_mlu/test_mlu_parallel.py \
+              --ignore=tests/test_utils/test_torch_ops.py
 
   build_without_ops:
     runs-on: ubuntu-18.04

--- a/mmcv/utils/__init__.py
+++ b/mmcv/utils/__init__.py
@@ -53,6 +53,7 @@ else:
     # yapf: enable
     from .registry import Registry, build_from_cfg
     from .seed import worker_init_fn
+    from .torch_ops import torch_meshgrid
     from .trace import is_jit_tracing
     __all__ = [
         'Config', 'ConfigDict', 'DictAction', 'collect_env', 'get_logger',
@@ -74,5 +75,6 @@ else:
         'assert_params_all_zeros', 'check_python_script',
         'is_method_overridden', 'is_jit_tracing', 'is_rocm_pytorch',
         '_get_cuda_home', 'load_url', 'has_method', 'IS_CUDA_AVAILABLE',
-        'worker_init_fn', 'IS_MLU_AVAILABLE', 'IS_IPU_AVAILABLE'
+        'worker_init_fn', 'IS_MLU_AVAILABLE', 'IS_IPU_AVAILABLE',
+        'torch_meshgrid'
     ]

--- a/mmcv/utils/torch_ops.py
+++ b/mmcv/utils/torch_ops.py
@@ -1,0 +1,13 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+from packaging import version
+
+_torch_version_meshgrid_indexing = version.parse(
+    torch.__version__) >= version.parse('1.10.0a0')
+
+
+def torch_meshgrid_ij(*tensors):
+    if _torch_version_meshgrid_indexing:
+        return torch.meshgrid(*tensors, indexing='ij')
+    else:
+        return torch.meshgrid(*tensors)  # Uses indexing='ij' by default

--- a/mmcv/utils/torch_ops.py
+++ b/mmcv/utils/torch_ops.py
@@ -1,7 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 
-from mmcv.utils import TORCH_VERSION, digit_version
+from .parrots_wrapper import TORCH_VERSION
+from .version_utils import digit_version
 
 _torch_version_meshgrid_indexing = (
     'parrots' not in TORCH_VERSION

--- a/mmcv/utils/torch_ops.py
+++ b/mmcv/utils/torch_ops.py
@@ -18,10 +18,10 @@ def torch_meshgrid(*tensors):
     PyTorch.
 
     Args:
-        tensors (list of Tensor): List of scalars or 1 dimensional tensors.
+        tensors (List[Tensor]): List of scalars or 1 dimensional tensors.
 
     Returns:
-        seq (sequence of Tensors): Sequence of meshgrid tensors.
+        Sequence[Tensor]: Sequence of meshgrid tensors.
     """
     if _torch_version_meshgrid_indexing:
         return torch.meshgrid(*tensors, indexing='ij')

--- a/mmcv/utils/torch_ops.py
+++ b/mmcv/utils/torch_ops.py
@@ -1,12 +1,27 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
-from packaging import version
 
-_torch_version_meshgrid_indexing = version.parse(
-    torch.__version__) >= version.parse('1.10.0a0')
+from mmcv.utils import TORCH_VERSION, digit_version
+
+_torch_version_meshgrid_indexing = (
+    'parrots' not in TORCH_VERSION
+    and digit_version(TORCH_VERSION) >= digit_version('1.10.0a0'))
 
 
-def torch_meshgrid_ij(*tensors):
+def torch_meshgrid(*tensors):
+    """A wrapper of torch.meshgrid to compat different PyTorch versions.
+
+    Since PyTorch 1.10.0a0, torch.meshgrid supports the arguments ``indexing``.
+    So we implement a wrapper here to avoid warning when using high-version
+    PyTorch and avoid compatibility issues when using previous versions of
+    PyTorch.
+
+    Args:
+        tensors (list of Tensor): List of scalars or 1 dimensional tensors.
+
+    Returns:
+        seq (sequence of Tensors): Sequence of meshgrid tensors.
+    """
     if _torch_version_meshgrid_indexing:
         return torch.meshgrid(*tensors, indexing='ij')
     else:

--- a/tests/test_utils/test_torch_ops.py
+++ b/tests/test_utils/test_torch_ops.py
@@ -1,0 +1,15 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import pytest
+import torch
+
+from mmcv.utils import torch_meshgrid
+
+
+def test_torch_meshgrid():
+    # torch_meshgrid should not throw warning
+    with pytest.warns(None) as record:
+        x = torch.tensor([1, 2, 3])
+        y = torch.tensor([4, 5, 6])
+        grid_x, grid_y = torch_meshgrid(x, y)
+
+    assert len(record) == 0


### PR DESCRIPTION
## Motivation

PyTorch is in the process of changing the behaviour of `torch.meshgrid`, and this results in a warning when using this method without an `indexing` argument as of PyTorch 1.10. The problem is that prior to PyTorch 1.10 these is no such argument, and thus for compatibility reasons it can't just be added. PyTorch 1.8.2 is an LTS release, so this issue will likely not go away any time soon, and eventually PyTorch will make a breaking change that changes the default behaviour of the method when called without an indexing argument:
https://pytorch.org/docs/stable/generated/torch.meshgrid.html
https://github.com/pytorch/pytorch/issues/50276

While mmcv has no calls to `torch.meshgrid`, many other repos do (this is not an exhaustive list):
https://github.com/open-mmlab/mmclassification/pull/860
https://github.com/open-mmlab/mmdetection/pull/8090
https://github.com/open-mmlab/mmtracking/pull/577
https://github.com/open-mmlab/mmpose/pull/1402

Thus, it would be best if mmcv could store a wrapper for `torch_meshgrid_ij` that deals with this difficulty, so that eventually all the other repos can just use the wrapper in mmcv instead of all defining their own or otherwise dealing with the issue.

## Modification

This PR adds a suitable `torch_meshgrid_ij` wrapper.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
