### PR TITLE
Import Error message refined.

### DIFF
--- a/mmcv/runner/hooks/logger/pavi.py
+++ b/mmcv/runner/hooks/logger/pavi.py
@@ -53,7 +53,10 @@ class PaviLoggerHook(LoggerHook):
         try:
             from pavi import SummaryWriter
         except ImportError:
-            raise ImportError('Please run "pip install pavi" to install pavi.')
+            raise ImportError(
+                'No module named pavi, please go to '
+                '"http://sdkdoc.parrots.sensetime.com/en/install.html" '
+                'get pavi install command.')
 
         self.run_name = runner.work_dir.split('/')[-1]
 


### PR DESCRIPTION
## Motivation

Update the error message when PAVI in not installed in MMCV pavi hook.

## Modification

Error message updated when failed to import SummaryWriter from PAVI.
