### PR TITLE
[Feat] different system logging level messages with different colors

### DIFF
--- a/mmcv/utils/logging.py
+++ b/mmcv/utils/logging.py
@@ -6,6 +6,32 @@ import torch.distributed as dist
 logger_initialized: dict = {}
 
 
+class ColorFormatter(logging.Formatter):
+    """Logging colored formatter."""
+    grey = '\x1b[38;21m'
+    blue = '\x1b[38;5;39m'
+    yellow = '\x1b[38;5;226m'
+    red = '\x1b[38;5;196m'
+    bold_red = '\x1b[31;1m'
+    reset = '\x1b[0m'
+
+    def __init__(self, fmt):
+        super().__init__()
+        self.fmt = fmt
+        self.FORMATS = {
+            logging.DEBUG: self.grey + self.fmt + self.reset,
+            logging.INFO: self.blue + self.fmt + self.reset,
+            logging.WARNING: self.yellow + self.fmt + self.reset,
+            logging.ERROR: self.red + self.fmt + self.reset,
+            logging.CRITICAL: self.bold_red + self.fmt + self.reset
+        }
+
+    def format(self, record):
+        log_fmt = self.FORMATS.get(record.levelno)
+        formatter = logging.Formatter(log_fmt)
+        return formatter.format(record)
+
+
 def get_logger(name, log_file=None, log_level=logging.INFO, file_mode='w'):
     """Initialize and get a logger by name.
 
@@ -67,8 +93,15 @@ def get_logger(name, log_file=None, log_level=logging.INFO, file_mode='w'):
 
     formatter = logging.Formatter(
         '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    color_formatter = ColorFormatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
     for handler in handlers:
-        handler.setFormatter(formatter)
+        if type(handler) is logging.StreamHandler:
+            handler.setFormatter(color_formatter)
+        else:
+            handler.setFormatter(formatter)
+
         handler.setLevel(log_level)
         logger.addHandler(handler)
 

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -91,8 +91,14 @@ def test_print_log_logger(caplog):
     print_log('welcome', logger='mmcv')
     assert caplog.record_tuples[-1] == ('mmcv', logging.INFO, 'welcome')
 
+    print_log('welcome', logger='mmcv', level=logging.WARNING)
+    assert caplog.record_tuples[-1] == ('mmcv', logging.WARNING, 'welcome')
+
     print_log('welcome', logger='mmcv', level=logging.ERROR)
     assert caplog.record_tuples[-1] == ('mmcv', logging.ERROR, 'welcome')
+
+    print_log('welcome', logger='mmcv', level=logging.CRITICAL)
+    assert caplog.record_tuples[-1] == ('mmcv', logging.CRITICAL, 'welcome')
 
     # the name can not be used to open the file a second time in windows,
     # so `delete` should be set as `False` and we need to manually remove it


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This MR is to make the different system logging level messages with different colors, to make the output information clearer, the expected output should be like this below:
![image](https://user-images.githubusercontent.com/12531708/175350148-fc7d95e6-37b3-4641-80d1-b47b299c501e.png)

## Modification

1. Add ColorFormmater Class
2. Initialize `logging.StreamHandler` with ColorFormatter

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
