### PR TITLE
[Feature] Support setting start epoch and interval epoch for PAVI Logger Hook

### DIFF
--- a/mmcv/runner/hooks/logger/pavi.py
+++ b/mmcv/runner/hooks/logger/pavi.py
@@ -19,10 +19,28 @@ class PaviLoggerHook(LoggerHook):
     """Class to visual model, log metrics (for internal use).
 
     Args:
-        init_kwargs (dict): A dict contains the initialization keys.
+        init_kwargs (dict): A dict contains the initialization keys as below:
+            - name (str, optional): Custom training name. Defaults to None,
+              which means current work_dir.
+            - project (str, optional): Project name. Defaults to "default".
+            - model (str, optional): Training model name. Defaults to current
+              model.
+            - session_text (str, optional): Session string in YAML format.
+              Defaults to current config.
+            - training_id (int, optional): Training ID in PAVI, if you want to
+              use an existing training. Defaults to None.
+            - compare_id (int, optional): Compare ID in PAVI, if you want to
+              add the task to an existing compare. Defaults to None.
+            - overwrite_last_training (bool, optional): Whether to upload data
+              to the training with the same name in the same project, rather
+              than creating a new one. Defaults to False.
         add_graph (bool): Whether to visual model. Default: False.
+        add_graph_defined (dict, optional): Define the params for adding graph.
+            Default: {'start_epoch': 0, 'interval_epoch': 1}.
         add_last_ckpt (bool): Whether to save checkpoint after run.
             Default: False.
+        add_ckpt_defined (dict, optional): Define the params for adding
+            checkpoint. Default: {'start_epoch': 0, 'interval_epoch': 1}.
         interval (int): Logging interval (every k iterations). Default: True.
         ignore_last (bool): Ignore the log of last iterations in each epoch
             if less than `interval`. Default: True.
@@ -35,16 +53,30 @@ class PaviLoggerHook(LoggerHook):
     def __init__(self,
                  init_kwargs: Optional[Dict] = None,
                  add_graph: bool = False,
+                 add_graph_defined: dict = {
+                     'start_epoch': 0,
+                     'interval_epoch': 1
+                 },
                  add_last_ckpt: bool = False,
+                 add_ckpt_defined: dict = {
+                     'start_epoch': 0,
+                     'interval_epoch': 1
+                 },
                  interval: int = 10,
                  ignore_last: bool = True,
                  reset_flag: bool = False,
                  by_epoch: bool = True,
-                 img_key: str = 'img_info'):
+                 img_key: str = 'img_info') -> None:
         super().__init__(interval, ignore_last, reset_flag, by_epoch)
         self.init_kwargs = init_kwargs
         self.add_graph = add_graph
+        self.add_graph_start_epoch = add_graph_defined.get('start_epoch', 0)
+        self.add_graph_interval_epoch = add_graph_defined.get(
+            'interval_epoch', 1)
         self.add_last_ckpt = add_last_ckpt
+        self.add_ckpt_start_epoch = add_ckpt_defined.get('start_epoch', 0)
+        self.add_ckpt_interval_epoch = add_ckpt_defined.get(
+            'interval_epoch', 0)
         self.img_key = img_key
 
     @master_only
@@ -59,8 +91,8 @@ class PaviLoggerHook(LoggerHook):
 
         if not self.init_kwargs:
             self.init_kwargs = dict()
-        self.init_kwargs['name'] = self.run_name
-        self.init_kwargs['model'] = runner._model_name
+        self.init_kwargs.setdefault('name', self.run_name)
+        self.init_kwargs.setdefault('model', runner._model_name)
         if runner.meta is not None:
             if 'config_dict' in runner.meta:
                 config_dict = runner.meta['config_dict']
@@ -83,7 +115,7 @@ class PaviLoggerHook(LoggerHook):
                 config_dict = json.loads(
                     mmcv.dump(config_dict, file_format='json'))
                 session_text = yaml.dump(config_dict)
-                self.init_kwargs['session_text'] = session_text
+                self.init_kwargs.setdefault('session_text', session_text)
         self.writer = SummaryWriter(**self.init_kwargs)
 
     def get_step(self, runner) -> int:
@@ -92,6 +124,19 @@ class PaviLoggerHook(LoggerHook):
             return self.get_epoch(runner)
         else:
             return self.get_iter(runner)
+
+    def _add_ckpt(self, runner) -> None:
+        ckpt_path = osp.join(runner.work_dir, 'latest.pth')
+        if osp.islink(ckpt_path):
+            ckpt_path = osp.join(runner.work_dir, os.readlink(ckpt_path))
+
+        if osp.isfile(ckpt_path):
+            # runner.epoch += 1 has been done before `after_run`.
+            iteration = runner.epoch if self.by_epoch else runner.iter
+            self.writer.add_snapshot_file(
+                tag=self.run_name,
+                snapshot_file_path=ckpt_path,
+                iteration=iteration)
 
     @master_only
     def log(self, runner) -> None:
@@ -103,24 +148,15 @@ class PaviLoggerHook(LoggerHook):
     @master_only
     def after_run(self, runner) -> None:
         if self.add_last_ckpt:
-            ckpt_path = osp.join(runner.work_dir, 'latest.pth')
-            if osp.islink(ckpt_path):
-                ckpt_path = osp.join(runner.work_dir, os.readlink(ckpt_path))
-
-            if osp.isfile(ckpt_path):
-                # runner.epoch += 1 has been done before `after_run`.
-                iteration = runner.epoch if self.by_epoch else runner.iter
-                return self.writer.add_snapshot_file(
-                    tag=self.run_name,
-                    snapshot_file_path=ckpt_path,
-                    iteration=iteration)
+            self._add_ckpt(runner)
 
         # flush the buffer and send a task ending signal to Pavi
         self.writer.close()
 
     @master_only
     def before_epoch(self, runner) -> None:
-        if runner.epoch == 0 and self.add_graph:
+        if self.add_graph and (runner.epoch % self.add_graph_interval_epoch
+                               == self.add_graph_start_epoch):
             if is_module_wrapper(runner.model):
                 _model = runner.model.module
             else:
@@ -130,3 +166,9 @@ class PaviLoggerHook(LoggerHook):
             image = data[self.img_key][0:1].to(device)
             with torch.no_grad():
                 self.writer.add_graph(_model, image)
+
+    @master_only
+    def after_train_epoch(self, runner) -> None:
+        if runner.epoch % self.add_ckpt_interval_epoch == \
+                self.add_ckpt_start_epoch:
+            self._add_ckpt(runner)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support setting start epoch and interval epoch for PAVI Logger Hook

## Modification

Add new param for PAVI logger Hook for setting start epoch and interval epoch.

## BC-breaking (Optional)

Nothing

## Use cases (Optional)

```py
hook = PaviLoggerHook(
        add_graph=False,
        add_graph_defined={
            'start_epoch': 0,
            'interval_epoch': 1
        },
        add_last_ckpt=True,
        add_ckpt_defined={
            'start_epoch': 1,
            'interval_epoch': 2
        })
    runner.register_hook(hook)
```

## Checklist

**Before PR**:

- [ √ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ √ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ √ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ √ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ √ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
