### PR TITLE
[Fix] Make `MMDistributedDataParallel` compatible with Pytorch1.12

### DIFF
--- a/mmcv/parallel/distributed.py
+++ b/mmcv/parallel/distributed.py
@@ -144,10 +144,14 @@ class MMDistributedDataParallel(DistributedDataParallel):
     def _run_ddp_forward(self, *inputs, **kwargs) -> Any:
         """Processes inputs and runs ``self.module.forward``.
 
-        Pytorch 1.12.0 deprecate using ``DistributedDataParallel.to_kwargs`` to
-        process inputs in ``DistributedDataParallel._run_ddp_forward``, which
-        causes BC breaking. Therefore, ``MMDistributedDataParallel`` override
-        this method to call :meth:`to_kwargs`.
+        Pytorch 1.12.0 performs ``self.module.forward`` in ``_run_ddp_forward``
+        and deprecates using ``DistributedDataParallel.to_kwargs`` to
+        process inputs, which leads to inputs cannot be processed by
+        :meth:`MMDistributedDataParallel.to_kwargs` anymore. Therefore,
+        ``MMDistributedDataParallel`` overrides this method to call
+        :meth:`to_kwargs` explicitly.
+
+        See more information in `<https://github.com/open-mmlab/mmsegmentation/issues/1742>`_.  # noqa: E501
 
         Returns:
             Any: Forward result of :attr:`module`.

--- a/mmcv/parallel/distributed.py
+++ b/mmcv/parallel/distributed.py
@@ -141,7 +141,6 @@ class MMDistributedDataParallel(DistributedDataParallel):
                 self.require_forward_param_sync = False
         return output
 
-
     def _run_ddp_forward(self, *inputs, **kwargs) -> Any:
         """Processes inputs and runs ``self.module.forward``.
 
@@ -157,8 +156,8 @@ class MMDistributedDataParallel(DistributedDataParallel):
             self._use_replicated_tensor_module else self.module
 
         if self.device_ids:
-            inputs, kwargs = self.to_kwargs(inputs, kwargs,
-                                            self.device_ids[0])
-            return module_to_run(*inputs[0], **kwargs[0])
+            inputs, kwargs = self.to_kwargs(  # type: ignore
+                inputs, kwargs, self.device_ids[0])
+            return module_to_run(*inputs[0], **kwargs[0])  # type: ignore
         else:
             return module_to_run(*inputs, **kwargs)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Related issue: https://github.com/open-mmlab/mmsegmentation/issues/1742

Make `MMDistributedDataParallel` compatible with Pytorch 1.12.
Since https://github.com/pytorch/pytorch/blob/67ece03c8cd632cce9523cd96efde6f2d1cc8121/torch/nn/parallel/distributed.py#L969
does not use  `MMDistributedDataParallel.to_kwargs` to process data. `MMDistributedDataParallel` should patch `torch.distributed.utils._to_kwargs` with `MMDistributedDataParallel.to_kwargs` during the forward process.

## Modification
Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)
Does the modification introduce changes that break the back-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
