### PR TITLE
[Enhancement] Improve ProfilerHook beaviour when using a relative (or empty) dir_name

### DIFF
--- a/mmcv/runner/hooks/profiler.py
+++ b/mmcv/runner/hooks/profiler.py
@@ -134,10 +134,13 @@ class ProfilerHook(Hook):
                                       'torch_tb_profiler')
                 if 'dir_name' not in trace_cfg:
                     trace_cfg['dir_name'] = osp.join(runner.work_dir,
-                                                     'profile')
+                                                     'tf_tracing_logs')
                 elif not osp.isabs(trace_cfg['dir_name']):
                     trace_cfg['dir_name'] = osp.join(runner.work_dir,
                                                      trace_cfg['dir_name'])
+                runner.logger.info(
+                    'tracing files of ProfilerHook will be saved to '
+                    f"{trace_cfg['dir_name']}.")
                 _on_trace_ready = torch.profiler.tensorboard_trace_handler(
                     **trace_cfg)
             else:

--- a/mmcv/runner/hooks/profiler.py
+++ b/mmcv/runner/hooks/profiler.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import os.path as osp
 import warnings
 from typing import Callable, List, Optional, Union
 
@@ -131,6 +132,12 @@ class ProfilerHook(Hook):
                     raise ImportError('please run "pip install '
                                       'torch-tb-profiler" to install '
                                       'torch_tb_profiler')
+                if 'dir_name' not in trace_cfg:
+                    trace_cfg['dir_name'] = osp.join(runner.work_dir,
+                                                     'profile')
+                elif not osp.isabs(trace_cfg['dir_name']):
+                    trace_cfg['dir_name'] = osp.join(runner.work_dir,
+                                                     trace_cfg['dir_name'])
                 _on_trace_ready = torch.profiler.tensorboard_trace_handler(
                     **trace_cfg)
             else:


### PR DESCRIPTION
## Motivation

Implements #2118

https://pytorch.org/docs/master/profiler.html?highlight=tensorboard_trace_handler#torch.profiler.tensorboard_trace_handler

## Modification

- Make `dir_name` optional for ProfilerHook configurations usin TensorBoard profiling output
- Make `dir_name` relative to `runner.work_dir` rather than the current working directory.

## Checklist

**Before PR**:

- [X] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [X] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
    - N/A
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
    - N/A
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
