### PR TITLE
DvcliveLoggerHook: use `by_epoch` for determining when to log.

### DIFF
--- a/mmcv/runner/hooks/logger/dvclive.py
+++ b/mmcv/runner/hooks/logger/dvclive.py
@@ -21,7 +21,10 @@ class DvcliveLoggerHook(LoggerHook):
             if less than `interval`. Default: True.
         reset_flag (bool): Whether to clear the output buffer after logging.
             Default: False.
-        by_epoch (bool): Whether EpochBasedRunner is used. Default: True.
+        by_epoch (bool): Whether EpochBasedRunner is used.
+            Determines whether `log` is called `after_train_iter` or
+            `after_train_epoch`.
+            Default: True.
         kwargs: Arguments for instantiating `Live`_.
 
     .. _dvclive:
@@ -54,16 +57,22 @@ class DvcliveLoggerHook(LoggerHook):
     def log(self, runner) -> None:
         tags = self.get_loggable_tags(runner)
         if tags:
-            self.dvclive.set_step(self.get_iter(runner))
+            self.dvclive.set_step(
+                self.get_epoch(runner) if self.by_epoch else self.
+                get_iter(runner))
             for k, v in tags.items():
                 self.dvclive.log(k, v)
 
-    @master_only
     def after_train_epoch(self, runner) -> None:
-        super().after_train_epoch(runner)
         if self.model_file is not None:
             runner.save_checkpoint(
                 Path(self.model_file).parent,
                 filename_tmpl=Path(self.model_file).name,
                 create_symlink=False,
             )
+        if self.by_epoch:
+            super().after_train_epoch(runner)
+
+    def after_train_iter(self, runner) -> None:
+        if not self.by_epoch:
+            super().after_train_iter(runner)

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -1543,11 +1543,12 @@ def test_neptune_hook():
     hook.run.stop.assert_called_with()
 
 
-def test_dvclive_hook():
+@pytest.mark.parametrize('by_epoch', [True, False])
+def test_dvclive_hook(by_epoch):
     sys.modules['dvclive'] = MagicMock()
     runner = _build_demo_runner()
 
-    hook = DvcliveLoggerHook()
+    hook = DvcliveLoggerHook(by_epoch=by_epoch)
     dvclive_mock = hook.dvclive
     loader = DataLoader(torch.ones((5, 2)))
 
@@ -1555,7 +1556,8 @@ def test_dvclive_hook():
     runner.run([loader, loader], [('train', 1), ('val', 1)])
     shutil.rmtree(runner.work_dir)
 
-    dvclive_mock.set_step.assert_called_with(6)
+    dvclive_mock.set_step.assert_called_with(1 if by_epoch else 6)
+    assert dvclive_mock.set_step.call_count == 1 if by_epoch else 5
     dvclive_mock.log.assert_called_with('momentum', 0.95)
 
 


### PR DESCRIPTION
Closes #2116 
Closes https://github.com/iterative/dvclive/issues/267