### PR TITLE
🎨 Delay the YAPF import until it's actually needed.

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -16,7 +16,6 @@ from importlib import import_module
 from pathlib import Path
 
 from addict import Dict
-from yapf.yapflib.yapf_api import FormatCode
 
 from .misc import import_modules_from_strings
 from .path import check_file_exist
@@ -417,6 +416,7 @@ class Config:
 
     @property
     def pretty_text(self):
+        from yapf.yapflib.yapf_api import FormatCode
 
         indent = 4
 


### PR DESCRIPTION
## Motivation

This avoids a hard dependency on lib2to3 which is not included in most minimal Python distributions such as in a container environment.

## Modification

The import is moved inside the function so yapf is only needed if the pretty-print functionality is actually in use.

## BC-breaking (Optional)

No compat effect.

## Use cases (Optional)

N/A other than making it easier to use MMCV in minimal environment.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
