### PR TITLE
[Feature] Add argument params to MlflowLoggerHook

### DIFF
--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -20,6 +20,8 @@ class MlflowLoggerHook(LoggerHook):
             will be created.
         tags (Dict[str], optional): Tags for the current run.
             Default None. If not None, set tags for the current run.
+        params (Dict[str], optional): Params for the current run.
+            Default None. If not None, set params for the current run.
         log_model (bool, optional): Whether to log an MLflow artifact.
             Default True. If True, log runner.model as an MLflow artifact
             for the current run.
@@ -37,6 +39,7 @@ class MlflowLoggerHook(LoggerHook):
     def __init__(self,
                  exp_name: Optional[str] = None,
                  tags: Optional[Dict] = None,
+                 params: Optional[Dict] = None,
                  log_model: bool = True,
                  interval: int = 10,
                  ignore_last: bool = True,
@@ -46,6 +49,7 @@ class MlflowLoggerHook(LoggerHook):
         self.import_mlflow()
         self.exp_name = exp_name
         self.tags = tags
+        self.params = params
         self.log_model = log_model
 
     def import_mlflow(self) -> None:
@@ -65,6 +69,8 @@ class MlflowLoggerHook(LoggerHook):
             self.mlflow.set_experiment(self.exp_name)
         if self.tags is not None:
             self.mlflow.set_tags(self.tags)
+        if self.params is not None:
+            self.mlflow.log_params(self.params)
 
     @master_only
     def log(self, runner) -> None:


### PR DESCRIPTION
Recreated #2188 since I did not use a feature branch.

## Motivation

I want to log (hyper)parametrers in MLFLow to be able to compare them between runs.

## Modification

Adds the argument "params" to MlflowLoggerHook. This works in the same way as the existing argument "tags" in that it runs mlflow.log_params() in before_run().

## BC-breaking (Optional)

No.

## Use cases (Optional)

See motivation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
