### PR TITLE
[Fix] Path mapping only once in storage backends

### DIFF
--- a/mmcv/fileio/file_client.py
+++ b/mmcv/fileio/file_client.py
@@ -74,7 +74,7 @@ class CephBackend(BaseStorageBackend):
         filepath = str(filepath)
         if self.path_mapping is not None:
             for k, v in self.path_mapping.items():
-                filepath = filepath.replace(k, v, max=1)
+                filepath = filepath.replace(k, v, 1)
         value = self._client.Get(filepath)
         value_buf = memoryview(value)
         return value_buf
@@ -129,7 +129,7 @@ class PetrelBackend(BaseStorageBackend):
         filepath = str(filepath)
         if self.path_mapping is not None:
             for k, v in self.path_mapping.items():
-                filepath = filepath.replace(k, v, max=1)
+                filepath = filepath.replace(k, v, 1)
         return filepath
 
     def _format_path(self, filepath: str) -> str:

--- a/mmcv/fileio/file_client.py
+++ b/mmcv/fileio/file_client.py
@@ -74,7 +74,7 @@ class CephBackend(BaseStorageBackend):
         filepath = str(filepath)
         if self.path_mapping is not None:
             for k, v in self.path_mapping.items():
-                filepath = filepath.replace(k, v)
+                filepath = filepath.replace(k, v, max=1)
         value = self._client.Get(filepath)
         value_buf = memoryview(value)
         return value_buf
@@ -129,7 +129,7 @@ class PetrelBackend(BaseStorageBackend):
         filepath = str(filepath)
         if self.path_mapping is not None:
             for k, v in self.path_mapping.items():
-                filepath = filepath.replace(k, v)
+                filepath = filepath.replace(k, v, max=1)
         return filepath
 
     def _format_path(self, filepath: str) -> str:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1. Avoid replacing `path` with the responding key in `path_mapping` many times.

## Modification

1. Add `1` in `filepath = filepath.replace(k, v)`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
