### PR TITLE
modified code for using ROCm backened within the PyTorch framework

### DIFF
--- a/mmcv/ops/csrc/common/cuda/carafe_cuda_kernel.cuh
+++ b/mmcv/ops/csrc/common/cuda/carafe_cuda_kernel.cuh
@@ -56,7 +56,7 @@ template <>
 __device__ __forceinline__ phalf warpReduceSum(phalf val) {
   for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2)
 #ifdef HIP_DIFF
-    __PHALF(val) += __shfl_down(FULL_MASK, val, offset);
+    __PHALF(val) += __shfl_down(val, offset);
 #else
     __PHALF(val) +=
         __shfl_down_sync(FULL_MASK, static_cast<__half>(__PHALF(val)), offset);

--- a/mmcv/ops/csrc/common/cuda/correlation_cuda.cuh
+++ b/mmcv/ops/csrc/common/cuda/correlation_cuda.cuh
@@ -83,9 +83,9 @@ __global__ void correlation_forward_cuda_kernel(
       // accumulate
       for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2)
 #ifdef HIP_DIFF
-          prod_sum += __shfl_down(float(prod_sum), offset);
+        prod_sum += __shfl_down(float(prod_sum), offset);
 #else
-          prod_sum += __shfl_down_sync(FULL_MASK, float(prod_sum), offset);
+        prod_sum += __shfl_down_sync(FULL_MASK, float(prod_sum), offset);
 #endif
       if (thread == 0) {
         output[n][ph][pw][h][w] = prod_sum;

--- a/mmcv/ops/csrc/common/cuda/correlation_cuda.cuh
+++ b/mmcv/ops/csrc/common/cuda/correlation_cuda.cuh
@@ -78,7 +78,11 @@ __global__ void correlation_forward_cuda_kernel(
       }
       // accumulate
       for (int offset = 16; offset > 0; offset /= 2)
-        prod_sum += __shfl_down_sync(FULL_MASK, float(prod_sum), offset);
+        #ifdef HIP_DIFF
+          prod_sum += __shfl_down(FULL_MASK, prod_sum, offset);
+        #else
+          prod_sum += __shfl_down_sync(FULL_MASK, float(prod_sum), offset);
+        #endif
       if (thread == 0) {
         output[n][ph][pw][h][w] = prod_sum;
       }

--- a/mmcv/ops/csrc/common/cuda/correlation_cuda.cuh
+++ b/mmcv/ops/csrc/common/cuda/correlation_cuda.cuh
@@ -79,7 +79,7 @@ __global__ void correlation_forward_cuda_kernel(
       // accumulate
       for (int offset = 16; offset > 0; offset /= 2)
         #ifdef HIP_DIFF
-          prod_sum += __shfl_down(FULL_MASK, prod_sum, offset);
+          prod_sum += __shfl_down(float(prod_sum), offset);
         #else
           prod_sum += __shfl_down_sync(FULL_MASK, float(prod_sum), offset);
         #endif

--- a/mmcv/ops/csrc/common/utils/spconv/tensorview/tensorview.h
+++ b/mmcv/ops/csrc/common/utils/spconv/tensorview/tensorview.h
@@ -27,7 +27,7 @@
 
 namespace tv {
 
-#ifdef __NVCC__
+#ifdef __CUDACC__
 #define TV_HOST_DEVICE_INLINE __forceinline__ __device__ __host__
 #define TV_DEVICE_INLINE __forceinline__ __device__
 #define TV_HOST_DEVICE __device__ __host__

--- a/mmcv/ops/csrc/pytorch/cuda/fused_spconv_ops_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/fused_spconv_ops_cuda.cu
@@ -1,9 +1,9 @@
 #include <cuda_runtime_api.h>
 #include <torch/script.h>
+#include "../spconv_utils.h"
 #include <utils/spconv/spconv/indice.h>
 #include <utils/spconv/spconv/reordering.h>
 
-#include "../spconv_utils.h"
 #include "pytorch_cuda_helper.hpp"
 
 torch::Tensor FusedIndiceConvBatchnormCUDAKernelLauncher(

--- a/mmcv/ops/csrc/pytorch/cuda/sparse_indice.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/sparse_indice.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <ATen/ATen.h>
+#include "../spconv_utils.h"
 #include <utils/spconv/spconv/indice.h>
 #include <utils/spconv/spconv/mp_helper.h>
 #include <utils/spconv/tensorview/helper_launch.h>
@@ -23,7 +24,6 @@
 #include <spconv/indice.cuh>
 #include <type_traits>
 
-#include "../spconv_utils.h"
 #include "pytorch_cuda_helper.hpp"
 
 namespace functor {

--- a/mmcv/ops/csrc/pytorch/cuda/sparse_maxpool.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/sparse_maxpool.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <ATen/ATen.h>
+#include "../spconv_utils.h"
 #include <utils/spconv/spconv/maxpool.h>
 #include <utils/spconv/spconv/mp_helper.h>
 #include <utils/spconv/tensorview/helper_launch.h>
@@ -23,7 +24,6 @@
 #include <type_traits>
 #include <utils/spconv/tensorview/helper_kernel.cuh>
 
-#include "../spconv_utils.h"
 #include "pytorch_cuda_helper.hpp"
 
 template <typename scalar_t, typename Index, int NumTLP, int NumILP>

--- a/mmcv/ops/csrc/pytorch/cuda/sparse_pool_ops_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/sparse_pool_ops_cuda.cu
@@ -1,8 +1,8 @@
 #include <cuda_runtime_api.h>
 #include <torch/script.h>
+#include "../spconv_utils.h"
 #include <utils/spconv/spconv/maxpool.h>
 
-#include "../spconv_utils.h"
 #include "pytorch_cuda_helper.hpp"
 
 torch::Tensor IndiceMaxpoolForwardCUDAKernelLauncher(torch::Tensor features,

--- a/mmcv/ops/csrc/pytorch/cuda/sparse_reordering.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/sparse_reordering.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <ATen/ATen.h>
+#include "../spconv_utils.h"
 #include <utils/spconv/spconv/mp_helper.h>
 #include <utils/spconv/spconv/reordering.h>
 #include <utils/spconv/tensorview/helper_launch.h>
@@ -24,7 +25,6 @@
 #include <type_traits>
 #include <utils/spconv/tensorview/helper_kernel.cuh>
 
-#include "../spconv_utils.h"
 #include "pytorch_cuda_helper.hpp"
 
 namespace functor {

--- a/mmcv/ops/csrc/pytorch/cuda/spconv_ops_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/spconv_ops_cuda.cu
@@ -1,9 +1,9 @@
 #include <cuda_runtime_api.h>
 #include <torch/script.h>
+#include "../spconv_utils.h"
 #include <utils/spconv/spconv/indice.h>
 #include <utils/spconv/spconv/reordering.h>
 
-#include "../spconv_utils.h"
 #include "pytorch_cuda_helper.hpp"
 
 template <unsigned NDim>

--- a/setup.py
+++ b/setup.py
@@ -290,6 +290,7 @@ def get_extensions():
                 glob.glob('./mmcv/ops/csrc/pytorch/cuda/*.cpp')
             extension = CUDAExtension
             include_dirs.append(os.path.abspath('./mmcv/ops/csrc/common'))
+            include_dirs.append(os.path.abspath('./mmcv/ops/csrc/pytorch'))
             include_dirs.append(os.path.abspath('./mmcv/ops/csrc/common/cuda'))
         elif (hasattr(torch, 'is_mlu_available') and
                 torch.is_mlu_available()) or \
@@ -419,7 +420,28 @@ setup(
     description='OpenMMLab Computer Vision Foundation',
     keywords='computer vision',
     packages=find_packages(),
-    include_package_data=True,
+    package_data = {   
+        'mmcv': [
+            'model_zoo/*.json',
+            'ops/csrc/common/cuda/*.cuh',
+            'ops/csrc/common/hip/*.cuh',
+            'ops/csrc/common/cuda/*.hpp',
+            'ops/csrc/common/hip/*.hpp',
+            'ops/csrc/common/*.hpp',
+            'ops/csrc/pytorch/*.cpp',
+            'ops/csrc/pytorch/cuda/*.cu',
+            'ops/csrc/pytorch/hip/*.hip',
+            'ops/csrc/pytorch/cuda/*.cpp',
+            'ops/csrc/pytorch/hip/*.cpp',
+            'ops/csrc/pytorch/cpu/*.cpp',
+            'ops/csrc/parrots/*.h',
+            'ops/csrc/parrots/*.cpp',
+            'ops/csrc/pytorch/mps/*.mm',
+            'mmcv/ops/csrc/common/mps/*.h',
+            'mmcv/ops/csrc/common/mps/*.mm'
+        ]
+    },
+
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: Apache Software License',

--- a/setup.py
+++ b/setup.py
@@ -420,28 +420,7 @@ setup(
     description='OpenMMLab Computer Vision Foundation',
     keywords='computer vision',
     packages=find_packages(),
-    package_data = {   
-        'mmcv': [
-            'model_zoo/*.json',
-            'ops/csrc/common/cuda/*.cuh',
-            'ops/csrc/common/hip/*.cuh',
-            'ops/csrc/common/cuda/*.hpp',
-            'ops/csrc/common/hip/*.hpp',
-            'ops/csrc/common/*.hpp',
-            'ops/csrc/pytorch/*.cpp',
-            'ops/csrc/pytorch/cuda/*.cu',
-            'ops/csrc/pytorch/hip/*.hip',
-            'ops/csrc/pytorch/cuda/*.cpp',
-            'ops/csrc/pytorch/hip/*.cpp',
-            'ops/csrc/pytorch/cpu/*.cpp',
-            'ops/csrc/parrots/*.h',
-            'ops/csrc/parrots/*.cpp',
-            'ops/csrc/pytorch/mps/*.mm',
-            'mmcv/ops/csrc/common/mps/*.h',
-            'mmcv/ops/csrc/common/mps/*.mm'
-        ]
-    },
-
+    include_package_data=True,
     classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Related issue: https://github.com/open-mmlab/mmcv/issues/1949 https://github.com/open-mmlab/mmcv/issues/2035
This PR enables HIP as a backened for pytorch only. 

## Modification

1. Added './mmcv/ops/csrc/pytorch' to the include directory as hipify in pytorch needed to hipify 'spconv_utils.h'.
2. rocblas has ambiguities for 'is_complex' ultimately from the order of the include-files in some files. The workaround in this PR is to add '#include spconv_utils.h' before the other file to break this ambiguity. This may go against the style guideline, unfortunately. Albeit, this issue has been reported and will be addressed with future versions of ROCm.
3. Added __shfl_down without mask in ./mmcv/ops/common/cuda/correlation_cuda.cuh since HIP does not have warp level granularity yet. The test in ./tests/test_ops/test_correlation.py passed.

## BC-breaking (Optional)

N/A

## Use cases (Optional)

Using MMCV with the pytorch framework on AMD GPUs.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
