### PR TITLE
[Feature] Support engine with MLU backend.

### DIFF
--- a/mmcv/engine/test.py
+++ b/mmcv/engine/test.py
@@ -19,7 +19,8 @@ from mmcv.utils import IS_MLU_AVAILABLE
 def single_gpu_test(model: nn.Module, data_loader: DataLoader) -> list:
     """Test model with a single mlu or gpu.
 
-    This method tests model with a single gpu and displays test progress bar.
+    This method tests model with a single device and displays test progress
+    bar.
 
     Args:
         model (nn.Module): Model to be tested.
@@ -56,20 +57,22 @@ def multi_gpu_test(model: nn.Module,
                    data_loader: DataLoader,
                    tmpdir: Optional[str] = None,
                    gpu_collect: bool = False) -> Optional[list]:
-    """Test model with multiple gpus.
+    """Test model with multiple devices (mlus or gpus).
 
-    This method tests model with multiple gpus and collects the results
-    under two different modes: gpu and cpu modes. By setting
-    ``gpu_collect=True``, it encodes results to gpu tensors and use gpu
-    communication for results collection. On cpu mode it saves the results on
-    different gpus to ``tmpdir`` and collects them by the rank 0 worker.
+    This method tests model with multiple devices and collects the results
+    under two different modes: gpu(mlu) and cpu modes. By setting
+    ``gpu_collect=True``, it encodes results to gpu or mlu tensors and use
+    device communication for results collection. On cpu mode it saves the
+    results on different devices to ``tmpdir`` and collects them by the
+    rank 0 worker.
 
     Args:
         model (nn.Module): Model to be tested.
         data_loader (nn.Dataloader): Pytorch data loader.
         tmpdir (str): Path of directory to save the temporary results from
-            different gpus under cpu mode.
-        gpu_collect (bool): Option to use either gpu or cpu to collect results.
+            different devices under cpu mode.
+        gpu_collect (bool): Option to use either device or cpu to collect
+            results.
 
     Returns:
         list: The prediction results.
@@ -114,7 +117,7 @@ def collect_results_cpu(result_part: list,
                         tmpdir: Optional[str] = None) -> Optional[list]:
     """Collect results under cpu mode.
 
-    On cpu mode, this function will save the results on different gpus to
+    On cpu mode, this function will save the results on different devices to
     ``tmpdir`` and collect them by the rank 0 worker.
 
     Args:
@@ -180,10 +183,10 @@ def collect_results_cpu(result_part: list,
 
 
 def collect_results_gpu(result_part: list, size: int) -> Optional[list]:
-    """Collect results under gpu mode.
+    """Collect results under gpu(mlu) mode.
 
-    On gpu mode, this function will encode results to gpu tensors and use gpu
-    communication for results collection.
+    On gpu(mlu) mode, this function will encode results to gpu or mlu tensors
+    and use device communication for results collection.
 
     Args:
         result_part (list): Result list containing result parts
@@ -221,7 +224,7 @@ def collect_results_gpu(result_part: list, size: int) -> Optional[list]:
         for recv, shape in zip(part_recv_list, shape_list):
             part_result = pickle.loads(recv[:shape[0]].cpu().numpy().tobytes())
             # When data is severely insufficient, an empty part_result
-            # on a certain gpu could makes the overall outputs empty.
+            # on a certain device could makes the overall outputs empty.
             if part_result:
                 part_list.append(part_result)
         # sort the results

--- a/mmcv/engine/test.py
+++ b/mmcv/engine/test.py
@@ -13,10 +13,11 @@ from torch.utils.data import DataLoader
 
 import mmcv
 from mmcv.runner import get_dist_info
+from mmcv.utils import IS_MLU_AVAILABLE
 
 
 def single_gpu_test(model: nn.Module, data_loader: DataLoader) -> list:
-    """Test model with a single gpu.
+    """Test model with a single mlu or gpu.
 
     This method tests model with a single gpu and displays test progress bar.
 
@@ -32,6 +33,13 @@ def single_gpu_test(model: nn.Module, data_loader: DataLoader) -> list:
     dataset = data_loader.dataset
     prog_bar = mmcv.ProgressBar(len(dataset))
     for data in data_loader:
+        if IS_MLU_AVAILABLE:
+            # Copy Tensors in data to mlu
+            data = {
+                idx:
+                data[idx].mlu() if hasattr(data[idx], 'mlu') else data[idx]
+                for idx in data
+            }
         with torch.no_grad():
             result = model(return_loss=False, **data)
         results.extend(result)
@@ -74,6 +82,13 @@ def multi_gpu_test(model: nn.Module,
         prog_bar = mmcv.ProgressBar(len(dataset))
     time.sleep(2)  # This line can prevent deadlock problem in some cases.
     for i, data in enumerate(data_loader):
+        if IS_MLU_AVAILABLE:
+            # Copy Tensors in data to mlu
+            data = {
+                idx:
+                data[idx].mlu() if hasattr(data[idx], 'mlu') else data[idx]
+                for idx in data
+            }
         with torch.no_grad():
             result = model(return_loss=False, **data)
         results.extend(result)
@@ -114,6 +129,7 @@ def collect_results_cpu(result_part: list,
     Returns:
         list: The collected results.
     """
+    default_device = 'mlu' if IS_MLU_AVAILABLE else 'cuda'
     rank, world_size = get_dist_info()
     # create a tmp dir if it is not specified
     if tmpdir is None:
@@ -122,12 +138,14 @@ def collect_results_cpu(result_part: list,
         dir_tensor = torch.full((MAX_LEN, ),
                                 32,
                                 dtype=torch.uint8,
-                                device='cuda')
+                                device=default_device)
         if rank == 0:
             mmcv.mkdir_or_exist('.dist_test')
             tmpdir = tempfile.mkdtemp(dir='.dist_test')
             tmpdir = torch.tensor(
-                bytearray(tmpdir.encode()), dtype=torch.uint8, device='cuda')
+                bytearray(tmpdir.encode()),
+                dtype=torch.uint8,
+                device=default_device)
             dir_tensor[:len(tmpdir)] = tmpdir
         dist.broadcast(dir_tensor, 0)
         tmpdir = dir_tensor.cpu().numpy().tobytes().decode().rstrip()
@@ -176,17 +194,21 @@ def collect_results_gpu(result_part: list, size: int) -> Optional[list]:
     Returns:
         list: The collected results.
     """
+    default_device = 'mlu' if IS_MLU_AVAILABLE else 'cuda'
     rank, world_size = get_dist_info()
     # dump result part to tensor with pickle
     part_tensor = torch.tensor(
-        bytearray(pickle.dumps(result_part)), dtype=torch.uint8, device='cuda')
+        bytearray(pickle.dumps(result_part)),
+        dtype=torch.uint8,
+        device=default_device)
     # gather all result part tensor shape
-    shape_tensor = torch.tensor(part_tensor.shape, device='cuda')
+    shape_tensor = torch.tensor(part_tensor.shape, device=default_device)
     shape_list = [shape_tensor.clone() for _ in range(world_size)]
     dist.all_gather(shape_list, shape_tensor)
     # padding result part tensor to max length
     shape_max = torch.tensor(shape_list).max()
-    part_send = torch.zeros(shape_max, dtype=torch.uint8, device='cuda')
+    part_send = torch.zeros(
+        shape_max, dtype=torch.uint8, device=default_device)
     part_send[:shape_tensor[0]] = part_tensor
     part_recv_list = [
         part_tensor.new_zeros(shape_max) for _ in range(world_size)


### PR DESCRIPTION
  * Support multi_gpu_test and single_gpu_test with MLU backend.

## Motivation

To support validate during network training, mmcv/engine needs to be modified for MLU devices.

## Modification

MLU devices will be automatically selected by mmcv/engine/test.py, and validate with MMDET or MMCV is available.

## BC-breaking (Optional)

No BC-breaking

## Use cases (Optional)

NO Use cases

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
