### PR TITLE
[Fix] cast the type of mask to enable training with amp

### DIFF
--- a/mmcv/ops/modulated_deform_conv.py
+++ b/mmcv/ops/modulated_deform_conv.py
@@ -69,6 +69,7 @@ class ModulatedDeformConv2dFunction(Function):
         input = input.type_as(offset)
         weight = weight.type_as(input)
         bias = bias.type_as(input)  # type: ignore
+        mask = mask.type_as(input)
         ctx.save_for_backward(input, offset, mask, weight, bias)
         output = input.new_empty(
             ModulatedDeformConv2dFunction._output_size(ctx, input, weight))


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix the bug in ModulatedDeformConv2dFunction to enable training with AMP.

The snippet of the error message is as below:
```
"/mnt/cache/xxx/mmediting/mmedit/models/editors/basicvsr_plusplus_net/basicvsr_plusplus_net.py", line 413, in forward
    return modulated_deform_conv2d(x, offset, mask, self.weight, self.bias,
  File "/mnt/cache/zengyanhong/mmcv/mmcv/ops/modulated_deform_conv.py", line 76, in forward
    ext_module.modulated_deform_conv_forward(
RuntimeError: expected scalar type Float but found Half
```
torch:  1.8.0+cu111


## Modification

cast the type of mask the same as input in ModulatedDeformConv2dFunction. 

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
