### PR TITLE
[Enhancement] wandb define_metric

### DIFF
--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -43,10 +43,15 @@ class WandbLoggerHook(LoggerHook):
             ``out_suffix`` will be uploaded to wandb.
             Default: ('.log.json', '.log', '.py').
             `New in version 1.4.3.`
-        define_metric_cfg (dict):
-            A dict of metrics and summary for wandb.define_metric.
-            Example. dict(bbox_mAP='max')
-            Default: None
+        define_metric_cfg (dict, optional): A dict of metrics and summaries for
+            wandb.define_metric. The key is metric and the value is summary.
+            For example, if setting
+            ``define_metric_cfg={'coco/bbox_mAP': 'max'}``, the maximum value
+            of``coco/bbox_mAP`` will be logged on wandb UI. See
+            `wandb docs <https://docs.wandb.ai/ref/python/run#define_metric>`_
+            for details.
+            Default: None.
+            `New in version 1.6.2.`
 
     .. _wandb:
         https://docs.wandb.ai
@@ -92,7 +97,7 @@ class WandbLoggerHook(LoggerHook):
         if self.define_metric_cfg is not None:
             for metric, summary in self.define_metric_cfg.items():
                 self.wandb.define_metric(  # type: ignore
-                    f'val/{metric}', summary=summary)
+                    metric, summary=summary)
 
     @master_only
     def log(self, runner) -> None:

--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -50,7 +50,7 @@ class WandbLoggerHook(LoggerHook):
              "none"].
             For example, if setting
             ``define_metric_cfg={'coco/bbox_mAP': 'max'}``, the maximum value
-            of``coco/bbox_mAP`` will be logged on wandb UI. See
+            of ``coco/bbox_mAP`` will be logged on wandb UI. See
             `wandb docs <https://docs.wandb.ai/ref/python/run#define_metric>`_
             for details.
             Default: None.

--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import os.path as osp
+import warnings
 from typing import Dict, Optional, Union
 
 from mmcv.utils import scandir
@@ -45,6 +46,8 @@ class WandbLoggerHook(LoggerHook):
             `New in version 1.4.3.`
         define_metric_cfg (dict, optional): A dict of metrics and summaries for
             wandb.define_metric. The key is metric and the value is summary.
+            The summary should be in ["min", "max", "mean" ,"best", "last",
+             "none"].
             For example, if setting
             ``define_metric_cfg={'coco/bbox_mAP': 'max'}``, the maximum value
             of``coco/bbox_mAP`` will be logged on wandb UI. See
@@ -94,8 +97,13 @@ class WandbLoggerHook(LoggerHook):
             self.wandb.init(**self.init_kwargs)  # type: ignore
         else:
             self.wandb.init()  # type: ignore
+        summary_choice = ['min', 'max', 'mean', 'best', 'last', 'none']
         if self.define_metric_cfg is not None:
             for metric, summary in self.define_metric_cfg.items():
+                if summary not in summary_choice:
+                    warnings.warn(
+                        f'summary should be in {summary_choice}. '
+                        f'metric={metric}, summary={summary} will be skipped.')
                 self.wandb.define_metric(  # type: ignore
                     metric, summary=summary)
 

--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -43,6 +43,10 @@ class WandbLoggerHook(LoggerHook):
             ``out_suffix`` will be uploaded to wandb.
             Default: ('.log.json', '.log', '.py').
             `New in version 1.4.3.`
+        define_metric_cfg (dict):
+            A dict of metrics and summary for wandb.define_metric.
+            Example. dict(bbox_mAP='max')
+            Default: None
 
     .. _wandb:
         https://docs.wandb.ai
@@ -57,7 +61,8 @@ class WandbLoggerHook(LoggerHook):
                  by_epoch: bool = True,
                  with_step: bool = True,
                  log_artifact: bool = True,
-                 out_suffix: Union[str, tuple] = ('.log.json', '.log', '.py')):
+                 out_suffix: Union[str, tuple] = ('.log.json', '.log', '.py'),
+                 define_metric_cfg: Optional[Dict] = None):
         super().__init__(interval, ignore_last, reset_flag, by_epoch)
         self.import_wandb()
         self.init_kwargs = init_kwargs
@@ -65,6 +70,7 @@ class WandbLoggerHook(LoggerHook):
         self.with_step = with_step
         self.log_artifact = log_artifact
         self.out_suffix = out_suffix
+        self.define_metric_cfg = define_metric_cfg
 
     def import_wandb(self) -> None:
         try:
@@ -83,6 +89,10 @@ class WandbLoggerHook(LoggerHook):
             self.wandb.init(**self.init_kwargs)  # type: ignore
         else:
             self.wandb.init()  # type: ignore
+        if self.define_metric_cfg is not None:
+            for metric, summary in self.define_metric_cfg.items():
+                self.wandb.define_metric(  # type: ignore
+                    f'val/{metric}', summary=summary)
 
     @master_only
     def log(self, runner) -> None:

--- a/mmcv/runner/hooks/logger/wandb.py
+++ b/mmcv/runner/hooks/logger/wandb.py
@@ -53,8 +53,8 @@ class WandbLoggerHook(LoggerHook):
             of ``coco/bbox_mAP`` will be logged on wandb UI. See
             `wandb docs <https://docs.wandb.ai/ref/python/run#define_metric>`_
             for details.
-            Default: None.
-            `New in version 1.6.2.`
+            Defaults to None.
+            `New in version 1.6.3.`
 
     .. _wandb:
         https://docs.wandb.ai

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -1616,6 +1616,7 @@ def test_wandb_hook():
     shutil.rmtree(runner.work_dir)
 
     hook.wandb.init.assert_called_with()
+    hook.wandb.define_metric.assert_called_with('val/loss', summary='min')
     hook.wandb.log.assert_called_with({
         'learning_rate': 0.02,
         'momentum': 0.95

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -1606,7 +1606,8 @@ def test_segmind_hook():
 def test_wandb_hook():
     sys.modules['wandb'] = MagicMock()
     runner = _build_demo_runner()
-    hook = WandbLoggerHook(log_artifact=True)
+    hook = WandbLoggerHook(
+        log_artifact=True, define_metric_cfg={'val/loss': 'min'})
     loader = DataLoader(torch.ones((5, 2)))
 
     runner.register_hook(hook)


### PR DESCRIPTION
## Motivation

Log best metric/loss with wandb.

## Use cases (Optional)

```
log_config = dict(
    interval=50,
    ignore_last=False,
    hooks=[
        dict(type='TextLoggerHook'),
        dict(type='WandbLoggerHook',
             define_metric_cfg=dict(bbox_mAP='max'),
             init_kwargs=dict(
                 project='example',
                 name='example001'
             ))
    ])
```

Example result

<img width="398" alt="スクリーンショット 2022-08-30 14 51 53" src="https://user-images.githubusercontent.com/24734142/187359850-ddc9e70c-085f-45bd-8422-8dd869d8450b.png">


## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
