### PR TITLE
Add support of TorchVision's Model Registration API on MMCV

### DIFF
--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -137,17 +137,27 @@ def get_torchvision_models():
         json_path = osp.join(mmcv.__path__[0],
                              'model_zoo/torchvision_0.12.json')
         model_urls = mmcv.load(json_path)
-        for cls_name, cls in torchvision.models.__dict__.items():
+        if digit_version(torchvision.__version__) < digit_version('0.14.0a0'):
+            weights_list = [
+                cls for cls_name, cls in torchvision.models.__dict__.items() if cls_name.endswith('_Weights')
+            ]
+        else:
+            weights_list = [
+                torchvision.models.get_model_weights(model)
+                for model in torchvision.models.list_models(torchvision.models)
+            ]
+
+        for cls in weights_list:
             # The name of torchvision model weights classes ends with
             # `_Weights` such as `ResNet18_Weights`. However, some model weight
             # classes, such as `MNASNet0_75_Weights` does not have any urls in
             # torchvision 0.13.0 and cannot be iterated. Here we simply check
             # `DEFAULT` attribute to ensure the class is not empty.
-            if (not cls_name.endswith('_Weights')
-                    or not hasattr(cls, 'DEFAULT')):
+            if not hasattr(cls, 'DEFAULT'):
                 continue
             # Since `cls.DEFAULT` can not be accessed by iterating cls, we set
             # default urls explicitly.
+            cls_name = cls.__name__
             cls_key = cls_name.replace('_Weights', '').lower()
             model_urls[f'{cls_key}.default'] = cls.DEFAULT.url
             for weight_enum in cls:

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -139,8 +139,7 @@ def get_torchvision_models():
         model_urls = mmcv.load(json_path)
         if digit_version(torchvision.__version__) < digit_version('0.14.0a0'):
             weights_list = [
-                cls
-                for cls_name, cls in torchvision.models.__dict__.items()
+                cls for cls_name, cls in torchvision.models.__dict__.items()
                 if cls_name.endswith('_Weights')
             ]
         else:

--- a/mmcv/runner/checkpoint.py
+++ b/mmcv/runner/checkpoint.py
@@ -139,7 +139,9 @@ def get_torchvision_models():
         model_urls = mmcv.load(json_path)
         if digit_version(torchvision.__version__) < digit_version('0.14.0a0'):
             weights_list = [
-                cls for cls_name, cls in torchvision.models.__dict__.items() if cls_name.endswith('_Weights')
+                cls
+                for cls_name, cls in torchvision.models.__dict__.items()
+                if cls_name.endswith('_Weights')
             ]
         else:
             weights_list = [


### PR DESCRIPTION
Hi OpenMMLab team,

First of all thank you very much for developing your awesome framework.

TorchVision has recently introduced a new [Model Registration API](https://pytorch.org/blog/easily-list-and-initialize-models-with-new-apis-in-torchvision/) which allows the easier listing of models and weights. Its aim is to eliminate the somehow hacky idiom of using `torchvision.models.__dict__` to retrieve models and weights.

In this PR, I'm updating your existing implementation introduced at https://github.com/open-mmlab/mmcv/issues/1848 to use our new API. Please note that I'm going for the minimum number of modifications necessary; the code may be further simplified but that might require additional discussion.

For full transparency, the new API is currently considered Beta. We've intentionally marked it as such to ensure that we can act upon the feedback of our partners and users. We are currently collecting feedback at https://github.com/pytorch/vision/issues/6365 and hoping to promote to stable before TorchVision v0.14. If you have any feedback or feature requests, we would be happy to discuss more. Finally, please note that if we end up making breaking changes on the API after you merge this PR, we will make sure to follow up with all the necessary fixes to keep the Open-MMLab users unaffected.

Looking forward to your feedback.