### PR TITLE
fix the bug of mmcv installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ For more details, please refer the the following tables.
 Another way is to compile locally by running
 
 ```python
-pip install 'mmcv>=2.0.0rc1'
+pip install "mmcv>=2.0.0rc1"
 ```
 
 Note that the local compiling may take up to 10 mins.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ i. Install the latest version.
 The rule for installing the latest `mmcv` is as follows:
 
 ```shell
-pip install 'mmcv>=2.0.0rc1' -f https://download.openmmlab.com/mmcv/dist/{cu_version}/{torch_version}/index.html
+pip install "mmcv>=2.0.0rc1" -f https://download.openmmlab.com/mmcv/dist/{cu_version}/{torch_version}/index.html
 ```
 
 Please replace `{cu_version}` and `{torch_version}` in the url to your desired one. For example,
@@ -104,7 +104,7 @@ pip install 'mmcv>=2.0.0rc1' -f https://download.openmmlab.com/mmcv/dist/cu111/t
 **Note**: mmcv is only compiled on PyTorch 1.x.0 because the compatibility usually holds between 1.x.0 and 1.x.1. If your PyTorch version is 1.x.1, you can install mmcv compiled with PyTorch 1.x.0 and it usually works well. For example, if your PyTorch version is 1.8.1 and CUDA version is 11.1, you can use the following command to install mmcv.
 
 ```shell
-pip install 'mmcv>=2.0.0rc1' -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.8.0/index.html
+pip install "mmcv>=2.0.0rc1" -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.8.0/index.html
 ```
 
 For more details, please refer the the following tables and delete `=={mmcv_version}`.


### PR DESCRIPTION
I can not install mmcv>=2.0.0rc1 with pip install 'mmcv>=2.0.0rc1' on win10, but with "mmcv>=2.0.0rc1" I can