### PR TITLE
[Feature] Support engine with NPU backend.

### DIFF
--- a/mmcv/device/__init__.py
+++ b/mmcv/device/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from . import ipu, mlu, mps
+from . import ipu, mlu, mps, npu
 from .scatter_gather import scatter, scatter_kwargs
 from .utils import get_device
 
-__all__ = ['mlu', 'ipu', 'mps', 'get_device', 'scatter', 'scatter_kwargs']
+__all__ = [
+    'npu', 'mlu', 'ipu', 'mps', 'get_device', 'scatter', 'scatter_kwargs'
+]

--- a/mmcv/device/npu/__init__.py
+++ b/mmcv/device/npu/__init__.py
@@ -1,0 +1,6 @@
+# Copyright Huawei Technologies Co., Ltd. All rights reserved.
+# Copyright (c) OpenMMLab. All rights reserved.
+from .data_parallel import NPUDataParallel
+from .distributed import NPUDistributedDataParallel
+
+__all__ = ['NPUDataParallel', 'NPUDistributedDataParallel']

--- a/mmcv/device/npu/_functions.py
+++ b/mmcv/device/npu/_functions.py
@@ -1,0 +1,25 @@
+# Copyright Huawei Technologies Co., Ltd. All rights reserved.
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import List, Union
+
+import torch
+
+
+def scatter(input: Union[List, torch.Tensor], devices: List) -> List:
+    """scatter copies tensor to NPU directly."""
+    if isinstance(input, list):
+        outputs = [scatter(_input, devices) for _input in input]
+        return outputs
+    elif isinstance(input, torch.Tensor):
+        output = input.contiguous()
+        return output.to('npu') if devices != [-1] else output
+    else:
+        raise Exception(f'Unknown type {type(input)}.')
+
+
+class Scatter:
+
+    @staticmethod
+    def forward(target_npus, input):
+        outputs = scatter(input, target_npus)
+        return tuple(outputs) if isinstance(outputs, list) else (outputs, )

--- a/mmcv/device/npu/data_parallel.py
+++ b/mmcv/device/npu/data_parallel.py
@@ -1,0 +1,59 @@
+# Copyright Huawei Technologies Co., Ltd. All rights reserved.
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import sys
+
+import torch
+
+from mmcv.parallel import MMDataParallel
+from .scatter_gather import scatter_kwargs
+
+
+def _check_balance(*args, **kwargs):
+    return
+
+
+# Since we do not have a similar hardware unit multi_processor
+# on the NPU, the corresponding# devices_properties does not
+# have this property and cannot be checked. So we masked the
+# _check_balance function in DataParallel to make initialization pass.
+for m in sys.modules:
+    if m.startswith('torch') or 'mmcv' in m:
+        if getattr(sys.modules[m], '_check_balance', None) is not None:
+            setattr(sys.modules[m], '_check_balance', _check_balance)
+
+
+class NPUDataParallel(MMDataParallel):
+    """The NPUDataParallel module that supports DataContainer.
+
+    NPUDataParallel is a class inherited from MMDataParall, which supports
+    NPU training and inference only.
+
+    The main differences with MMDataParallel:
+
+    - It only supports single-card of NPU, and only use first card to
+      run training and inference.
+
+    - It uses direct host-to-device copy instead of stream-background
+      scatter.
+
+    .. warning::
+        NPUDataParallel only supports single NPU training, if you need to
+        train with multiple NPUs, please use NPUDistributedDataParallel
+        instead. If you have multiple NPUs, you can toggle device_ids
+        parameters passed in for this function to specify the running device.
+
+    Args:
+        module (:class:`nn.Module`): Module to be encapsulated.
+        dim (int): Dimension used to scatter the data. Defaults to 0.
+    """
+
+    def __init__(self, *args, dim=0, **kwargs):
+        super().__init__(*args, dim=dim, **kwargs)
+        device_id = kwargs.get('device_ids', [0])[0]
+        self.device_ids = [device_id]
+        self.src_device_obj = torch.device(f'npu:{device_id}')
+        torch.npu.set_device(self.src_device_obj)
+
+    def scatter(self, inputs, kwargs, device_ids):
+        return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)

--- a/mmcv/device/npu/distributed.py
+++ b/mmcv/device/npu/distributed.py
@@ -1,0 +1,26 @@
+# Copyright Huawei Technologies Co., Ltd. All rights reserved.
+# Copyright (c) OpenMMLab. All rights reserved.
+
+from mmcv.parallel import MMDistributedDataParallel
+from .scatter_gather import scatter_kwargs
+
+
+class NPUDistributedDataParallel(MMDistributedDataParallel):
+    """The DDP module supports DataContainer.
+
+    NPUDDP has one difference from MMDDP which moves data to NPU with coping
+    instead of scattering.
+    """
+
+    def to_kwargs(self, inputs, kwargs, device_id):
+        # Use `self.to_kwargs` instead of `self.scatter` in pytorch1.8
+        # to move all tensors to device_id
+        return scatter_kwargs(inputs, kwargs, [device_id], dim=self.dim)
+
+    def scatter(self, inputs, kwargs, device_ids):
+        return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
+
+    def forward(self, *inputs, **kwargs):
+        if self.device_ids:
+            inputs, kwargs = self.scatter(inputs, kwargs, self.device_ids)
+        return super().forward(*inputs[0], **kwargs[0])

--- a/mmcv/device/npu/scatter_gather.py
+++ b/mmcv/device/npu/scatter_gather.py
@@ -1,0 +1,60 @@
+# Copyright Huawei Technologies Co., Ltd. All rights reserved.
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+
+from mmcv.parallel.data_container import DataContainer
+from ._functions import Scatter
+
+
+def scatter(inputs, target_npus, dim=0):
+    """Scatter inputs to target npu.
+
+    The only difference from original :func:`scatter` is to add support for
+    :type:`~mmcv.parallel.DataContainer`.
+    """
+
+    def scatter_map(obj):
+        if isinstance(obj, torch.Tensor):
+            if target_npus != [-1]:
+                obj = obj.to('npu')
+                return [obj]
+            else:
+                # for CPU inference we use self-implemented scatter
+                return Scatter.forward(target_npus, obj)
+        if isinstance(obj, DataContainer):
+            if obj.cpu_only:
+                return obj.data
+            else:
+                return Scatter.forward(target_npus, obj.data)
+        if isinstance(obj, tuple) and len(obj) > 0:
+            return list(zip(*map(scatter_map, obj)))
+        if isinstance(obj, list) and len(obj) > 0:
+            out = list(map(list, zip(*map(scatter_map, obj))))
+            return out
+        if isinstance(obj, dict) and len(obj) > 0:
+            out = list(map(type(obj), zip(*map(scatter_map, obj.items()))))
+            return out
+        return [obj for targets in target_npus]
+
+    # After scatter_map is called, a scatter_map cell will exist. This cell
+    # has a reference to the actual function scatter_map, which has references
+    # to a closure that has a reference to the scatter_map cell (because the
+    # fn is recursive). To avoid this reference cycle, we set the function to
+    # None, clearing the cell
+    try:
+        return scatter_map(inputs)
+    finally:
+        scatter_map = None
+
+
+def scatter_kwargs(inputs, kwargs, target_npus, dim=0):
+    """Scatter with support for kwargs dictionary."""
+    inputs = scatter(inputs, target_npus, dim) if inputs else []
+    kwargs = scatter(kwargs, target_npus, dim) if kwargs else []
+    if len(inputs) < len(kwargs):
+        inputs.extend([() for _ in range(len(kwargs) - len(inputs))])
+    elif len(kwargs) < len(inputs):
+        kwargs.extend([{} for _ in range(len(inputs) - len(kwargs))])
+    inputs = tuple(inputs)
+    kwargs = tuple(kwargs)
+    return inputs, kwargs

--- a/mmcv/device/utils.py
+++ b/mmcv/device/utils.py
@@ -1,14 +1,22 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from mmcv.utils import IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE, IS_MPS_AVAILABLE
+from mmcv.utils import (IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE, IS_MPS_AVAILABLE,
+                        IS_NPU_AVAILABLE)
 
 
 def get_device() -> str:
     """Returns the currently existing device type.
 
+    .. note::
+        Since npu provides tools to automatically convert cuda functions,
+        we need to make judgments on npu first to avoid entering
+        the cuda branch when using npu.
+
     Returns:
         str: cuda | mlu | mps | cpu.
     """
-    if IS_CUDA_AVAILABLE:
+    if IS_NPU_AVAILABLE:
+        return 'npu'
+    elif IS_CUDA_AVAILABLE:
         return 'cuda'
     elif IS_MLU_AVAILABLE:
         return 'mlu'

--- a/mmcv/runner/dist_utils.py
+++ b/mmcv/runner/dist_utils.py
@@ -13,7 +13,7 @@ from torch import distributed as dist
 from torch._utils import (_flatten_dense_tensors, _take_tensors,
                           _unflatten_dense_tensors)
 
-from mmcv.utils import IS_MLU_AVAILABLE
+from mmcv.utils import IS_MLU_AVAILABLE, IS_NPU_AVAILABLE
 
 
 def _find_free_port() -> str:
@@ -55,6 +55,14 @@ def _init_dist_pytorch(backend: str, **kwargs) -> None:
         torch.mlu.set_device(rank)
         dist.init_process_group(
             backend='cncl',
+            rank=rank,
+            world_size=int(os.environ['WORLD_SIZE']),
+            **kwargs)
+    elif IS_NPU_AVAILABLE:
+        import torch_npu  # noqa: F401
+        torch.npu.set_device(rank)
+        dist.init_process_group(
+            backend='hccl',
             rank=rank,
             world_size=int(os.environ['WORLD_SIZE']),
             **kwargs)

--- a/mmcv/runner/hooks/optimizer.py
+++ b/mmcv/runner/hooks/optimizer.py
@@ -9,7 +9,8 @@ import torch.nn as nn
 from torch import Tensor
 from torch.nn.utils import clip_grad
 
-from mmcv.utils import TORCH_VERSION, _BatchNorm, digit_version
+from mmcv.utils import (IS_NPU_AVAILABLE, TORCH_VERSION, _BatchNorm,
+                        digit_version)
 from ..dist_utils import allreduce_grads
 from ..fp16_utils import LossScaler, wrap_fp16_model
 from .hook import HOOKS, Hook
@@ -17,7 +18,10 @@ from .hook import HOOKS, Hook
 try:
     # If PyTorch version >= 1.6.0, torch.cuda.amp.GradScaler would be imported
     # and used; otherwise, auto fp16 will adopt mmcv's implementation.
-    from torch.cuda.amp import GradScaler
+    if IS_NPU_AVAILABLE:
+        from torch.npu.amp import GradScaler
+    else:
+        from torch.cuda.amp import GradScaler
 except ImportError:
     pass
 

--- a/mmcv/utils/__init__.py
+++ b/mmcv/utils/__init__.py
@@ -37,7 +37,7 @@ except ImportError:
     ]
 else:
     from .device_type import (IS_IPU_AVAILABLE, IS_MLU_AVAILABLE,
-                              IS_MPS_AVAILABLE)
+                              IS_MPS_AVAILABLE, IS_NPU_AVAILABLE)
     from .env import collect_env
     from .hub import load_url
     from .logging import get_logger, print_log
@@ -77,5 +77,5 @@ else:
         'is_method_overridden', 'is_jit_tracing', 'is_rocm_pytorch',
         '_get_cuda_home', 'load_url', 'has_method', 'IS_CUDA_AVAILABLE',
         'worker_init_fn', 'IS_MLU_AVAILABLE', 'IS_IPU_AVAILABLE',
-        'IS_MPS_AVAILABLE', 'torch_meshgrid'
+        'IS_MPS_AVAILABLE', 'IS_NPU_AVAILABLE', 'torch_meshgrid'
     ]

--- a/mmcv/utils/device_type.py
+++ b/mmcv/utils/device_type.py
@@ -38,3 +38,16 @@ def is_mps_available() -> bool:
 
 
 IS_MPS_AVAILABLE = is_mps_available()
+
+
+def is_npu_available() -> bool:
+    """Return True if npu devices exist."""
+    try:
+        import torch
+        import torch_npu
+        return (hasattr(torch, 'npu') and torch_npu.npu.is_available())
+    except Exception:
+        return False
+
+
+IS_NPU_AVAILABLE = is_npu_available()

--- a/tests/test_device/test_device_utils.py
+++ b/tests/test_device/test_device_utils.py
@@ -1,11 +1,14 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from mmcv.device import get_device
-from mmcv.utils import IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE, IS_MPS_AVAILABLE
+from mmcv.utils import (IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE, IS_MPS_AVAILABLE,
+                        IS_NPU_AVAILABLE)
 
 
 def test_get_device():
     current_device = get_device()
-    if IS_CUDA_AVAILABLE:
+    if IS_NPU_AVAILABLE:
+        assert current_device == 'npu'
+    elif IS_CUDA_AVAILABLE:
         assert current_device == 'cuda'
     elif IS_MLU_AVAILABLE:
         assert current_device == 'mlu'

--- a/tests/test_device/test_functions.py
+++ b/tests/test_device/test_functions.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 
 from mmcv.device._functions import Scatter, scatter
-from mmcv.utils import IS_MLU_AVAILABLE, IS_MPS_AVAILABLE
+from mmcv.utils import IS_MLU_AVAILABLE, IS_MPS_AVAILABLE, IS_NPU_AVAILABLE
 
 
 def test_scatter():
@@ -27,6 +27,17 @@ def test_scatter():
         outputs = scatter(input=inputs, devices=[0])
         for input, output in zip(inputs, outputs):
             assert torch.allclose(input.to('mlu'), output)
+
+    # if the device is NPU, copy the input from CPU to NPU
+    if IS_NPU_AVAILABLE:
+        input = torch.zeros([1, 3, 3, 3])
+        output = scatter(input=input, devices=[0])
+        assert torch.allclose(input.to('npu'), output)
+
+        inputs = [torch.zeros([1, 3, 3, 3]), torch.zeros([1, 4, 4, 4])]
+        outputs = scatter(input=inputs, devices=[0])
+        for input, output in zip(inputs, outputs):
+            assert torch.allclose(input.to('npu'), output)
 
     # if the device is MPS, copy the input from CPU to MPS
     if IS_MPS_AVAILABLE:

--- a/tests/test_device/test_npu/test_npu_parallel.py
+++ b/tests/test_device/test_npu/test_npu_parallel.py
@@ -1,0 +1,37 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from unittest.mock import MagicMock, patch
+
+import torch.nn as nn
+
+from mmcv.device.npu import NPUDataParallel, NPUDistributedDataParallel
+from mmcv.parallel import is_module_wrapper
+from mmcv.utils import IS_NPU_AVAILABLE
+
+
+def mock(*args, **kwargs):
+    pass
+
+
+@patch('torch.distributed._broadcast_coalesced', mock)
+@patch('torch.distributed.broadcast', mock)
+@patch('torch.nn.parallel.DistributedDataParallel._ddp_init_helper', mock)
+def test_is_module_wrapper():
+
+    class Model(nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(2, 2, 1)
+
+        def forward(self, x):
+            return self.conv(x)
+
+    model = Model()
+    assert not is_module_wrapper(model)
+
+    if IS_NPU_AVAILABLE:
+        npudp = NPUDataParallel(model)
+        assert is_module_wrapper(npudp)
+
+        npuddp = NPUDistributedDataParallel(model, process_group=MagicMock())
+        assert is_module_wrapper(npuddp)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Added ascending device support in mmcv.

## Modification

- The main modification points are as follows: 
    1. In ```mmcv/device/```, We've added our NPU devices. Since the NPU does not support the DataParallel mode, DP and DDP have been customized, the Scatter related methods have been rewritten, and the use case of MLU has been referenced, thanks.
    2. In ```mmcv/runner/dist_utils.py```, We have added NPU-related distributed initialization methods.
    3. In ```mmcv/runner/hooks/optimizer.py```, We've added the amp method on npu.
    4. In ```mmcv/utils/```, We've added NPU devices.

## BC-breaking (Optional)

None

## Use cases (Optional)

- test case
    - tests/test_device/test_device_utils.py
    - tests/test_device/test_functions.py
    - tests/test_device/test_npu/test_npu_parallel.py

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
