### PR TITLE
[Fix] Fix the calculation error of out_w in MaskedConv2dFunction

### DIFF
--- a/mmcv/ops/masked_conv.py
+++ b/mmcv/ops/masked_conv.py
@@ -53,7 +53,7 @@ class MaskedConv2dFunction(Function):
         out_w = int(
             math.floor(
                 torch.true_divide((features.size(3) + 2 * pad_w -
-                                   (kernel_h - 1) - 1), stride_w) + 1))
+                                   (kernel_w - 1) - 1), stride_w) + 1))
         mask_inds = torch.nonzero(mask[0] > 0, as_tuple=False)
         output = features.new_zeros(batch_size, out_channel, out_h, out_w)
         if mask_inds.numel() > 0:

--- a/mmcv/ops/masked_conv.py
+++ b/mmcv/ops/masked_conv.py
@@ -47,11 +47,13 @@ class MaskedConv2dFunction(Function):
 
         batch_size = features.size(0)
         out_h = int(
-            math.floor((features.size(2) + 2 * pad_h -
-                        (kernel_h - 1) - 1) / stride_h + 1))
+            math.floor(
+                torch.true_divide((features.size(2) + 2 * pad_h -
+                                   (kernel_h - 1) - 1), stride_h) + 1))
         out_w = int(
-            math.floor((features.size(3) + 2 * pad_w -
-                        (kernel_h - 1) - 1) / stride_w + 1))
+            math.floor(
+                torch.true_divide((features.size(3) + 2 * pad_w -
+                                   (kernel_h - 1) - 1), stride_w) + 1))
         mask_inds = torch.nonzero(mask[0] > 0, as_tuple=False)
         output = features.new_zeros(batch_size, out_channel, out_h, out_w)
         if mask_inds.numel() > 0:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix the calculation error of out_w in MaskedConv2dFunction and this function can not work in torch1.6 due to / operator. More details at https://app.circleci.com/pipelines/github/open-mmlab/mmcv/1574/workflows/3056e22f-a35d-4a55-995f-e66f3acdcc23/jobs/3077?invite=true#step-107-177.

## Modification

mmcv/ops/masked_conv.py

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
