### PR TITLE
[Fix]Optimize the display effect of ProgressBar.update()

### DIFF
--- a/mmcv/utils/progressbar.py
+++ b/mmcv/utils/progressbar.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import datetime
 import sys
 from collections.abc import Iterable
 from multiprocessing import Pool
@@ -44,8 +45,9 @@ class ProgressBar:
             percentage = self.completed / float(self.task_num)
             eta = int(elapsed * (1 - percentage) / percentage + 0.5)
             msg = f'\r[{{}}] {self.completed}/{self.task_num}, ' \
-                  f'{fps:.1f} task/s, elapsed: {int(elapsed + 0.5)}s, ' \
-                  f'ETA: {eta:5}s'
+                f'{fps:.1f} task/s, ' \
+                f'elapsed: {str(datetime.timedelta(seconds=int(elapsed)))}, ' \
+                f'ETA: {str(datetime.timedelta(seconds=int(eta)))}'
 
             bar_width = min(self.bar_width,
                             int(self.terminal_width - len(msg)) + 2,

--- a/tests/test_utils/test_progressbar.py
+++ b/tests/test_utils/test_progressbar.py
@@ -54,7 +54,7 @@ class TestProgressBar:
         reset_string_io(out)
         prog_bar.update()
         assert out.getvalue() == f'\r[{">" * 2 + " " * 18}] 1/10, 1.0 ' \
-                                 'task/s, elapsed: 0:00:01s, ETA: 0:00:09'
+                                 'task/s, elapsed: 0:00:01, ETA: 0:00:09'
 
     def test_adaptive_length(self):
         with patch.dict('os.environ', {'COLUMNS': '80'}):
@@ -69,7 +69,7 @@ class TestProgressBar:
             os.environ['COLUMNS'] = '30'
             reset_string_io(out)
             prog_bar.update()
-            assert len(out.getvalue()) == 48
+            assert len(out.getvalue()) == 54
 
             os.environ['COLUMNS'] = '60'
             reset_string_io(out)

--- a/tests/test_utils/test_progressbar.py
+++ b/tests/test_utils/test_progressbar.py
@@ -54,7 +54,7 @@ class TestProgressBar:
         reset_string_io(out)
         prog_bar.update()
         assert out.getvalue() == f'\r[{">" * 2 + " " * 18}] 1/10, 1.0 ' \
-                                 'task/s, elapsed: 1s, ETA:     9s'
+                                 'task/s, elapsed: 1s, ETA: 0:00:09'
 
     def test_adaptive_length(self):
         with patch.dict('os.environ', {'COLUMNS': '80'}):
@@ -87,9 +87,9 @@ def test_track_progress_list():
     ret = mmcv.track_progress(sleep_1s, [1, 2, 3], bar_width=3, file=out)
     assert out.getvalue() == (
         '[   ] 0/3, elapsed: 0s, ETA:'
-        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA:     2s'
-        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA:     1s'
-        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA:     0s\n')
+        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA: 0:00:02'
+        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA: 0:00:01'
+        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA: 0:00:00\n')
     assert ret == [1, 2, 3]
 
 
@@ -99,9 +99,9 @@ def test_track_progress_iterator():
         sleep_1s, ((i for i in [1, 2, 3]), 3), bar_width=3, file=out)
     assert out.getvalue() == (
         '[   ] 0/3, elapsed: 0s, ETA:'
-        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA:     2s'
-        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA:     1s'
-        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA:     0s\n')
+        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA: 0:00:02'
+        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA: 0:00:01'
+        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA: 0:00:00\n')
     assert ret == [1, 2, 3]
 
 
@@ -112,9 +112,9 @@ def test_track_iter_progress():
         ret.append(sleep_1s(num))
     assert out.getvalue() == (
         '[   ] 0/3, elapsed: 0s, ETA:'
-        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA:     2s'
-        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA:     1s'
-        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA:     0s\n')
+        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA: 0:00:02'
+        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA: 0:00:01'
+        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA: 0:00:00\n')
     assert ret == [1, 2, 3]
 
 
@@ -128,9 +128,9 @@ def test_track_enum_progress():
         count.append(i)
     assert out.getvalue() == (
         '[   ] 0/3, elapsed: 0s, ETA:'
-        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA:     2s'
-        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA:     1s'
-        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA:     0s\n')
+        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA: 0:00:02'
+        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA: 0:00:01'
+        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA: 0:00:00\n')
     assert ret == [1, 2, 3]
     assert count == [0, 1, 2]
 

--- a/tests/test_utils/test_progressbar.py
+++ b/tests/test_utils/test_progressbar.py
@@ -54,7 +54,7 @@ class TestProgressBar:
         reset_string_io(out)
         prog_bar.update()
         assert out.getvalue() == f'\r[{">" * 2 + " " * 18}] 1/10, 1.0 ' \
-                                 'task/s, elapsed: 1s, ETA: 0:00:09'
+                                 'task/s, elapsed: 0:00:01s, ETA: 0:00:09'
 
     def test_adaptive_length(self):
         with patch.dict('os.environ', {'COLUMNS': '80'}):
@@ -64,7 +64,7 @@ class TestProgressBar:
             time.sleep(1)
             reset_string_io(out)
             prog_bar.update()
-            assert len(out.getvalue()) == 66
+            assert len(out.getvalue()) == 72
 
             os.environ['COLUMNS'] = '30'
             reset_string_io(out)
@@ -87,9 +87,9 @@ def test_track_progress_list():
     ret = mmcv.track_progress(sleep_1s, [1, 2, 3], bar_width=3, file=out)
     assert out.getvalue() == (
         '[   ] 0/3, elapsed: 0s, ETA:'
-        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA: 0:00:02'
-        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA: 0:00:01'
-        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA: 0:00:00\n')
+        '\r[>  ] 1/3, 1.0 task/s, elapsed: 0:00:01, ETA: 0:00:02'
+        '\r[>> ] 2/3, 1.0 task/s, elapsed: 0:00:02, ETA: 0:00:01'
+        '\r[>>>] 3/3, 1.0 task/s, elapsed: 0:00:03, ETA: 0:00:00\n')
     assert ret == [1, 2, 3]
 
 
@@ -99,9 +99,9 @@ def test_track_progress_iterator():
         sleep_1s, ((i for i in [1, 2, 3]), 3), bar_width=3, file=out)
     assert out.getvalue() == (
         '[   ] 0/3, elapsed: 0s, ETA:'
-        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA: 0:00:02'
-        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA: 0:00:01'
-        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA: 0:00:00\n')
+        '\r[>  ] 1/3, 1.0 task/s, elapsed: 0:00:01, ETA: 0:00:02'
+        '\r[>> ] 2/3, 1.0 task/s, elapsed: 0:00:02, ETA: 0:00:01'
+        '\r[>>>] 3/3, 1.0 task/s, elapsed: 0:00:03, ETA: 0:00:00\n')
     assert ret == [1, 2, 3]
 
 
@@ -112,9 +112,9 @@ def test_track_iter_progress():
         ret.append(sleep_1s(num))
     assert out.getvalue() == (
         '[   ] 0/3, elapsed: 0s, ETA:'
-        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA: 0:00:02'
-        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA: 0:00:01'
-        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA: 0:00:00\n')
+        '\r[>  ] 1/3, 1.0 task/s, elapsed: 0:00:01, ETA: 0:00:02'
+        '\r[>> ] 2/3, 1.0 task/s, elapsed: 0:00:02, ETA: 0:00:01'
+        '\r[>>>] 3/3, 1.0 task/s, elapsed: 0:00:03, ETA: 0:00:00\n')
     assert ret == [1, 2, 3]
 
 
@@ -128,9 +128,9 @@ def test_track_enum_progress():
         count.append(i)
     assert out.getvalue() == (
         '[   ] 0/3, elapsed: 0s, ETA:'
-        '\r[>  ] 1/3, 1.0 task/s, elapsed: 1s, ETA: 0:00:02'
-        '\r[>> ] 2/3, 1.0 task/s, elapsed: 2s, ETA: 0:00:01'
-        '\r[>>>] 3/3, 1.0 task/s, elapsed: 3s, ETA: 0:00:00\n')
+        '\r[>  ] 1/3, 1.0 task/s, elapsed: 0:00:01, ETA: 0:00:02'
+        '\r[>> ] 2/3, 1.0 task/s, elapsed: 0:00:02, ETA: 0:00:01'
+        '\r[>>>] 3/3, 1.0 task/s, elapsed: 0:00:03, ETA: 0:00:00\n')
     assert ret == [1, 2, 3]
     assert count == [0, 1, 2]
 


### PR DESCRIPTION
## Motivation

The display effect of 'ETA' and 'elapsed' during the eval is not intuitive, like 48970s. This pull request makes their display the same as that during training, like 4:13:59

Before:
![before](https://user-images.githubusercontent.com/41566277/193434883-41eb27a9-7c24-4812-8e1c-09a9af241b58.png)


After:
![after](https://user-images.githubusercontent.com/41566277/193434896-81d3d159-0b73-4261-9d57-692cf39b5389.png)


## Modification

Modified mmcv->utils->progressbar.py->ProgressBar->updata->msg

## BC-breaking (Optional)

None

## Use cases (Optional)

None

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.