### PR TITLE
[Enhancement] Add ability to pass logger instance to frameworks

### DIFF
--- a/mmcv/runner/hooks/logger/dvclive.py
+++ b/mmcv/runner/hooks/logger/dvclive.py
@@ -22,7 +22,10 @@ class DvcliveLoggerHook(LoggerHook):
         reset_flag (bool): Whether to clear the output buffer after logging.
             Default: False.
         by_epoch (bool): Whether EpochBasedRunner is used. Default: True.
-        kwargs: Arguments for instantiating `Live`_.
+        dvclive (Live): Default None. An instance of the `Live`_ logger to use
+            instead of initializing a new one internally.
+        kwargs: Arguments for instantiating `Live`_ (ignored if `dvclive` is
+            provided).
 
     .. _dvclive:
         https://dvc.org/doc/dvclive
@@ -37,18 +40,19 @@ class DvcliveLoggerHook(LoggerHook):
                  ignore_last: bool = True,
                  reset_flag: bool = False,
                  by_epoch: bool = True,
+                 dvclive=None,
                  **kwargs):
         super().__init__(interval, ignore_last, reset_flag, by_epoch)
         self.model_file = model_file
-        self.import_dvclive(**kwargs)
+        self._import_dvclive(dvclive, **kwargs)
 
-    def import_dvclive(self, **kwargs) -> None:
+    def _import_dvclive(self, dvclive=None, **kwargs) -> None:
         try:
             from dvclive import Live
         except ImportError:
             raise ImportError(
                 'Please run "pip install dvclive" to install dvclive')
-        self.dvclive = Live(**kwargs)
+        self.dvclive = dvclive if dvclive is not None else Live(**kwargs)
 
     @master_only
     def log(self, runner) -> None:

--- a/mmcv/runner/hooks/logger/dvclive.py
+++ b/mmcv/runner/hooks/logger/dvclive.py
@@ -22,8 +22,8 @@ class DvcliveLoggerHook(LoggerHook):
         reset_flag (bool): Whether to clear the output buffer after logging.
             Default: False.
         by_epoch (bool): Whether EpochBasedRunner is used. Default: True.
-        dvclive (Live): Default None. An instance of the `Live`_ logger to use
-            instead of initializing a new one internally.
+        dvclive (Live, optional): An instance of the `Live`_ logger to use
+            instead of initializing a new one internally. Defaults to None. 
         kwargs: Arguments for instantiating `Live`_ (ignored if `dvclive` is
             provided).
 

--- a/mmcv/runner/hooks/logger/dvclive.py
+++ b/mmcv/runner/hooks/logger/dvclive.py
@@ -23,7 +23,7 @@ class DvcliveLoggerHook(LoggerHook):
             Default: False.
         by_epoch (bool): Whether EpochBasedRunner is used. Default: True.
         dvclive (Live, optional): An instance of the `Live`_ logger to use
-            instead of initializing a new one internally. Defaults to None. 
+            instead of initializing a new one internally. Defaults to None.
         kwargs: Arguments for instantiating `Live`_ (ignored if `dvclive` is
             provided).
 

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -1665,7 +1665,6 @@ def test_dvclive_hook_model_file(tmp_path):
     hook = DvcliveLoggerHook(model_file=osp.join(runner.work_dir, 'model.pth'))
     runner.register_hook(hook)
 
-    loader = torch.utils.data.DataLoader(torch.ones((5, 2)))
     loader = DataLoader(torch.ones((5, 2)))
 
     runner.run([loader, loader], [('train', 1), ('val', 1)])
@@ -1673,6 +1672,16 @@ def test_dvclive_hook_model_file(tmp_path):
     assert osp.exists(osp.join(runner.work_dir, 'model.pth'))
 
     shutil.rmtree(runner.work_dir)
+
+
+def test_dvclive_hook_pass_logger(tmp_path):
+    sys.modules['dvclive'] = MagicMock()
+    from dvclive import Live
+    logger = Live()
+
+    sys.modules['dvclive'] = MagicMock()
+    assert DvcliveLoggerHook().dvclive is not logger
+    assert DvcliveLoggerHook(dvclive=logger).dvclive is logger
 
 
 def test_clearml_hook():


### PR DESCRIPTION
## Motivation

Updating the [DVCLive hook](https://github.com/open-mmlab/mmcv/blob/master/mmcv/runner/hooks/logger/dvclive.py) according [the latest changes](https://github.com/iterative/dvclive/pull/318) in the way we use loggers in DVCLive.

## Modification

- Added a way to pass a `dvclive` instance into the hook

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
