### PR TITLE
[Fix] Add `swap_labe_pairs` in `RandomFlip`

### DIFF
--- a/mmcv/transforms/processing.py
+++ b/mmcv/transforms/processing.py
@@ -1130,7 +1130,7 @@ class RandomFlip(BaseTransform):
         flipped = np.concatenate([keypoints, meta_info], axis=-1)
         return flipped
 
-    def flip_seg_map(self, seg_map: dict, direction: str) -> None:
+    def flip_seg_map(self, seg_map: dict, direction: str) -> np.ndarray:
         """Flip segmentation map horizontally, vertically or diagonally.
 
         Args:


### PR DESCRIPTION
## Motivation

To handle datasets with left/right annotations when flip the seg map horizontally, like left arm and right arm in dataset.

## Modification

Add `swap_label_pairs` in `RandomFlip` __init__, and swap the labels of a seg map when `swap_label_pairs` is defined.

## BC-breaking (Optional)

No

## Use cases (Optional)

LIP dataset data augmentation

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
