### PR TITLE
[Fea]: add currently-npu-supported-ops in ops.md docs

### DIFF
--- a/docs/en/understand_mmcv/ops.md
+++ b/docs/en/understand_mmcv/ops.md
@@ -2,61 +2,61 @@
 
 We implement common ops used in detection, segmentation, etc.
 
-| Device                       | CPU | CUDA | MLU | MPS |
-| ---------------------------- | --- | ---- | --- | --- |
-| ActiveRotatedFilter          | √   | √    |     |     |
-| AssignScoreWithK             |     | √    |     |     |
-| BallQuery                    |     | √    |     |     |
-| BBoxOverlaps                 |     | √    | √   | √   |
-| BorderAlign                  |     | √    |     |     |
-| BoxIouRotated                | √   | √    |     |     |
-| BoxIouQuadri                 | √   | √    |     |     |
-| CARAFE                       |     | √    | √   |     |
-| ChamferDistance              |     | √    |     |     |
-| CrissCrossAttention          |     | √    |     |     |
-| ContourExpand                | √   |      |     |     |
-| ConvexIoU                    |     | √    |     |     |
-| CornerPool                   |     | √    |     |     |
-| Correlation                  |     | √    |     |     |
-| Deformable Convolution v1/v2 | √   | √    |     |     |
-| Deformable RoIPool           |     | √    | √   |     |
-| DiffIoURotated               |     | √    |     |     |
-| DynamicScatter               |     | √    |     |     |
-| FurthestPointSample          |     | √    |     |     |
-| FurthestPointSampleWithDist  |     | √    |     |     |
-| FusedBiasLeakyrelu           |     | √    |     |     |
-| GatherPoints                 |     | √    |     |     |
-| GroupPoints                  |     | √    |     |     |
-| Iou3d                        |     | √    | √   |     |
-| KNN                          |     | √    |     |     |
-| MaskedConv                   |     | √    | √   |     |
-| MergeCells                   |     | √    |     |     |
-| MinAreaPolygon               |     | √    |     |     |
-| ModulatedDeformConv2d        | √   | √    |     |     |
-| MultiScaleDeformableAttn     |     | √    | √   |     |
-| NMS                          | √   | √    | √   |     |
-| NMSRotated                   | √   | √    |     |     |
-| NMSQuadri                    | √   | √    |     |     |
-| PixelGroup                   | √   |      |     |     |
-| PointsInBoxes                | √   | √    |     |     |
-| PointsInPolygons             |     | √    |     |     |
-| PSAMask                      | √   | √    | √   |     |
-| RotatedFeatureAlign          | √   | √    |     |     |
-| RoIPointPool3d               |     | √    | √   |     |
-| RoIPool                      |     | √    | √   |     |
-| RoIAlignRotated              | √   | √    | √   |     |
-| RiRoIAlignRotated            |     | √    |     |     |
-| RoIAlign                     | √   | √    | √   |     |
-| RoIAwarePool3d               |     | √    | √   |     |
-| SAConv2d                     |     | √    |     |     |
-| SigmoidFocalLoss             |     | √    | √   |     |
-| SoftmaxFocalLoss             |     | √    |     |     |
-| SoftNMS                      |     | √    |     |     |
-| Sparse Convolution           |     | √    |     |     |
-| Synchronized BatchNorm       |     | √    |     |     |
-| ThreeInterpolate             |     | √    |     |     |
-| ThreeNN                      |     | √    | √   |     |
-| TINShift                     |     | √    | √   |     |
-| UpFirDn2d                    |     | √    |     |     |
-| Voxelization                 | √   | √    |     |     |
-| PrRoIPool                    |     | √    |     |     |
+| Device                       | CPU | CUDA | MLU | MPS | NPU |
+| ---------------------------- | --- | ---- | --- | --- | --- |
+| ActiveRotatedFilter          | √   | √    |     |     |     |
+| AssignScoreWithK             |     | √    |     |     |     |
+| BallQuery                    |     | √    |     |     |     |
+| BBoxOverlaps                 |     | √    | √   | √   |     |
+| BorderAlign                  |     | √    |     |     |     |
+| BoxIouRotated                | √   | √    |     |     |     |
+| BoxIouQuadri                 | √   | √    |     |     |     |
+| CARAFE                       |     | √    | √   |     |     |
+| ChamferDistance              |     | √    |     |     |     |
+| CrissCrossAttention          |     | √    |     |     |     |
+| ContourExpand                | √   |      |     |     |     |
+| ConvexIoU                    |     | √    |     |     |     |
+| CornerPool                   |     | √    |     |     |     |
+| Correlation                  |     | √    |     |     |     |
+| Deformable Convolution v1/v2 | √   | √    |     |     |     |
+| Deformable RoIPool           |     | √    | √   |     |     |
+| DiffIoURotated               |     | √    |     |     |     |
+| DynamicScatter               |     | √    |     |     |     |
+| FurthestPointSample          |     | √    |     |     |     |
+| FurthestPointSampleWithDist  |     | √    |     |     |     |
+| FusedBiasLeakyrelu           |     | √    |     |     |     |
+| GatherPoints                 |     | √    |     |     |     |
+| GroupPoints                  |     | √    |     |     |     |
+| Iou3d                        |     | √    | √   |     |     |
+| KNN                          |     | √    |     |     |     |
+| MaskedConv                   |     | √    | √   |     | √   |
+| MergeCells                   |     | √    |     |     |     |
+| MinAreaPolygon               |     | √    |     |     |     |
+| ModulatedDeformConv2d        | √   | √    |     |     | √   |
+| MultiScaleDeformableAttn     |     | √    | √   |     |     |
+| NMS                          | √   | √    | √   |     | √   |
+| NMSRotated                   | √   | √    |     |     |     |
+| NMSQuadri                    | √   | √    |     |     |     |
+| PixelGroup                   | √   |      |     |     |     |
+| PointsInBoxes                | √   | √    |     |     |     |
+| PointsInPolygons             |     | √    |     |     |     |
+| PSAMask                      | √   | √    | √   |     |     |
+| RotatedFeatureAlign          | √   | √    |     |     |     |
+| RoIPointPool3d               |     | √    | √   |     |     |
+| RoIPool                      |     | √    | √   |     |     |
+| RoIAlignRotated              | √   | √    | √   |     |     |
+| RiRoIAlignRotated            |     | √    |     |     |     |
+| RoIAlign                     | √   | √    | √   |     |     |
+| RoIAwarePool3d               |     | √    | √   |     |     |
+| SAConv2d                     |     | √    |     |     |     |
+| SigmoidFocalLoss             |     | √    | √   |     | √   |
+| SoftmaxFocalLoss             |     | √    |     |     | √   |
+| SoftNMS                      |     | √    |     |     |     |
+| Sparse Convolution           |     | √    |     |     |     |
+| Synchronized BatchNorm       |     | √    |     |     |     |
+| ThreeInterpolate             |     | √    |     |     |     |
+| ThreeNN                      |     | √    | √   |     |     |
+| TINShift                     |     | √    | √   |     |     |
+| UpFirDn2d                    |     | √    |     |     |     |
+| Voxelization                 | √   | √    |     |     |     |
+| PrRoIPool                    |     | √    |     |     |     |

--- a/docs/zh_cn/understand_mmcv/ops.md
+++ b/docs/zh_cn/understand_mmcv/ops.md
@@ -2,61 +2,61 @@
 
 MMCV 提供了检测、分割等任务中常用的算子
 
-| Device                       | CPU | CUDA | MLU | MPS |
-| ---------------------------- | --- | ---- | --- | --- |
-| ActiveRotatedFilter          | √   | √    |     |     |
-| AssignScoreWithK             |     | √    |     |     |
-| BallQuery                    |     | √    |     |     |
-| BBoxOverlaps                 |     | √    | √   | √   |
-| BorderAlign                  |     | √    |     |     |
-| BoxIouRotated                | √   | √    |     |     |
-| BoxIouQuadri                 | √   | √    |     |     |
-| CARAFE                       |     | √    | √   |     |
-| ChamferDistance              |     | √    |     |     |
-| CrissCrossAttention          |     | √    |     |     |
-| ContourExpand                | √   |      |     |     |
-| ConvexIoU                    |     | √    |     |     |
-| CornerPool                   |     | √    |     |     |
-| Correlation                  |     | √    |     |     |
-| Deformable Convolution v1/v2 | √   | √    |     |     |
-| Deformable RoIPool           |     | √    | √   |     |
-| DiffIoURotated               |     | √    |     |     |
-| DynamicScatter               |     | √    |     |     |
-| FurthestPointSample          |     | √    |     |     |
-| FurthestPointSampleWithDist  |     | √    |     |     |
-| FusedBiasLeakyrelu           |     | √    |     |     |
-| GatherPoints                 |     | √    |     |     |
-| GroupPoints                  |     | √    |     |     |
-| Iou3d                        |     | √    | √   |     |
-| KNN                          |     | √    |     |     |
-| MaskedConv                   |     | √    | √   |     |
-| MergeCells                   |     | √    |     |     |
-| MinAreaPolygon               |     | √    |     |     |
-| ModulatedDeformConv2d        | √   | √    |     |     |
-| MultiScaleDeformableAttn     |     | √    | √   |     |
-| NMS                          | √   | √    | √   |     |
-| NMSRotated                   | √   | √    |     |     |
-| NMSQuadri                    | √   | √    |     |     |
-| PixelGroup                   | √   |      |     |     |
-| PointsInBoxes                | √   | √    |     |     |
-| PointsInPolygons             |     | √    |     |     |
-| PSAMask                      | √   | √    | √   |     |
-| RotatedFeatureAlign          | √   | √    |     |     |
-| RoIPointPool3d               |     | √    | √   |     |
-| RoIPool                      |     | √    | √   |     |
-| RoIAlignRotated              | √   | √    | √   |     |
-| RiRoIAlignRotated            |     | √    |     |     |
-| RoIAlign                     | √   | √    | √   |     |
-| RoIAwarePool3d               |     | √    | √   |     |
-| SAConv2d                     |     | √    |     |     |
-| SigmoidFocalLoss             |     | √    | √   |     |
-| SoftmaxFocalLoss             |     | √    |     |     |
-| SoftNMS                      |     | √    |     |     |
-| Sparse Convolution           |     | √    |     |     |
-| Synchronized BatchNorm       |     | √    |     |     |
-| ThreeInterpolate             |     | √    |     |     |
-| ThreeNN                      |     | √    | √   |     |
-| TINShift                     |     | √    | √   |     |
-| UpFirDn2d                    |     | √    |     |     |
-| Voxelization                 | √   | √    |     |     |
-| PrRoIPool                    |     | √    |     |     |
+| Device                       | CPU | CUDA | MLU | MPS | NPU |
+| ---------------------------- | --- | ---- | --- | --- | --- |
+| ActiveRotatedFilter          | √   | √    |     |     |     |
+| AssignScoreWithK             |     | √    |     |     |     |
+| BallQuery                    |     | √    |     |     |     |
+| BBoxOverlaps                 |     | √    | √   | √   |     |
+| BorderAlign                  |     | √    |     |     |     |
+| BoxIouRotated                | √   | √    |     |     |     |
+| BoxIouQuadri                 | √   | √    |     |     |     |
+| CARAFE                       |     | √    | √   |     |     |
+| ChamferDistance              |     | √    |     |     |     |
+| CrissCrossAttention          |     | √    |     |     |     |
+| ContourExpand                | √   |      |     |     |     |
+| ConvexIoU                    |     | √    |     |     |     |
+| CornerPool                   |     | √    |     |     |     |
+| Correlation                  |     | √    |     |     |     |
+| Deformable Convolution v1/v2 | √   | √    |     |     |     |
+| Deformable RoIPool           |     | √    | √   |     |     |
+| DiffIoURotated               |     | √    |     |     |     |
+| DynamicScatter               |     | √    |     |     |     |
+| FurthestPointSample          |     | √    |     |     |     |
+| FurthestPointSampleWithDist  |     | √    |     |     |     |
+| FusedBiasLeakyrelu           |     | √    |     |     |     |
+| GatherPoints                 |     | √    |     |     |     |
+| GroupPoints                  |     | √    |     |     |     |
+| Iou3d                        |     | √    | √   |     |     |
+| KNN                          |     | √    |     |     |     |
+| MaskedConv                   |     | √    | √   |     | √   |
+| MergeCells                   |     | √    |     |     |     |
+| MinAreaPolygon               |     | √    |     |     |     |
+| ModulatedDeformConv2d        | √   | √    |     |     | √   |
+| MultiScaleDeformableAttn     |     | √    | √   |     |     |
+| NMS                          | √   | √    | √   |     | √   |
+| NMSRotated                   | √   | √    |     |     |     |
+| NMSQuadri                    | √   | √    |     |     |     |
+| PixelGroup                   | √   |      |     |     |     |
+| PointsInBoxes                | √   | √    |     |     |     |
+| PointsInPolygons             |     | √    |     |     |     |
+| PSAMask                      | √   | √    | √   |     |     |
+| RotatedFeatureAlign          | √   | √    |     |     |     |
+| RoIPointPool3d               |     | √    | √   |     |     |
+| RoIPool                      |     | √    | √   |     |     |
+| RoIAlignRotated              | √   | √    | √   |     |     |
+| RiRoIAlignRotated            |     | √    |     |     |     |
+| RoIAlign                     | √   | √    | √   |     |     |
+| RoIAwarePool3d               |     | √    | √   |     |     |
+| SAConv2d                     |     | √    |     |     |     |
+| SigmoidFocalLoss             |     | √    | √   |     | √   |
+| SoftmaxFocalLoss             |     | √    |     |     | √   |
+| SoftNMS                      |     | √    |     |     |     |
+| Sparse Convolution           |     | √    |     |     |     |
+| Synchronized BatchNorm       |     | √    |     |     |     |
+| ThreeInterpolate             |     | √    |     |     |     |
+| ThreeNN                      |     | √    | √   |     |     |
+| TINShift                     |     | √    | √   |     |     |
+| UpFirDn2d                    |     | √    |     |     |     |
+| Voxelization                 | √   | √    |     |     |     |
+| PrRoIPool                    |     | √    |     |     |     |


### PR DESCRIPTION
## Description

Nowadays we have been developing mmcv.ops on ascend-npu device, and some developments have been finished. This PR is used for updating the ops  in the docs(ops.md) , which is already for npu-device.

