### PR TITLE
[Fix]:fix the bug when input mask is not '0-1-tensor', support random…

### DIFF
--- a/mmcv/ops/masked_conv.py
+++ b/mmcv/ops/masked_conv.py
@@ -58,6 +58,8 @@ class MaskedConv2dFunction(Function):
             if mask.size()[1:] != output.size()[2:]:
                 raise ValueError(
                     'The mask is inconsistent with the shape of output_conv.')
+            mask = mask > 0
+            mask = mask.type(output.dtype)
             output = output * mask
             return output
 


### PR DESCRIPTION
## BugFix

At first, we only consider the input mask is a '0-1' tensor, which is filled by value 0 or value 1, then the mask is multiplied to the conv output. However, the mask is a random float tensor in some actual tests case. so we have to translate it into '0-1' tensor inside the op by ourself.    

