### PR TITLE
fix roi align symbolic for torch>1.13

### DIFF
--- a/mmcv/ops/roi_align.py
+++ b/mmcv/ops/roi_align.py
@@ -23,12 +23,12 @@ class RoIAlignFunction(Function):
         from torch.onnx.symbolic_opset9 import sub
 
         def _select(g, self, dim, index):
-            return g.op("Gather", self, index, axis_i=dim)
+            return g.op('Gather', self, index, axis_i=dim)
 
         # batch_indices = rois[:, 0].long()
         batch_indices = _select(
             g, rois, 1,
-            g.op("Constant", value_t=torch.tensor([0], dtype=torch.long)))
+            g.op('Constant', value_t=torch.tensor([0], dtype=torch.long)))
         batch_indices = g.op('Squeeze', batch_indices, axes_i=[1])
         batch_indices = g.op(
             'Cast', batch_indices, to_i=TensorProtoDataType.INT64)
@@ -36,7 +36,7 @@ class RoIAlignFunction(Function):
         rois = _select(
             g, rois, 1,
             g.op(
-                "Constant",
+                'Constant',
                 value_t=torch.tensor([1, 2, 3, 4], dtype=torch.long)))
 
         if aligned:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Torch>=1.13 would not wrap Graph into GraphContext, so we can not reuse some tools in `torch.onnx`.

## Modification

Update roi_align symbolic.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
