### PR TITLE
[Enhancement] Support value_proj_ratio in MultiScaleDeformableAttention

### DIFF
--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -195,8 +195,8 @@ class MultiScaleDeformableAttention(BaseModule):
                  dropout: float = 0.1,
                  batch_first: bool = False,
                  norm_cfg: Optional[dict] = None,
-                 value_proj_ratio: float = 1.0,
-                 init_cfg: Optional[mmengine.ConfigDict] = None):
+                 init_cfg: Optional[mmengine.ConfigDict] = None,
+                 value_proj_ratio: float = 1.0):
         super().__init__(init_cfg)
         if embed_dims % num_heads != 0:
             raise ValueError(f'embed_dims must be divisible by num_heads, '

--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -183,7 +183,7 @@ class MultiScaleDeformableAttention(BaseModule):
         init_cfg (obj:`mmcv.ConfigDict`): The Config for initialization.
             Default: None.
         value_proj_ratio (float): The expansion ratio of value_proj.
-            Default: 4.
+            Default: 1.0.
     """
 
     def __init__(self,

--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -189,6 +189,7 @@ class MultiScaleDeformableAttention(BaseModule):
                  num_heads: int = 8,
                  num_levels: int = 4,
                  num_points: int = 4,
+                 value_proj_ratio: float = 1.0,
                  im2col_step: int = 64,
                  dropout: float = 0.1,
                  batch_first: bool = False,
@@ -228,8 +229,9 @@ class MultiScaleDeformableAttention(BaseModule):
             embed_dims, num_heads * num_levels * num_points * 2)
         self.attention_weights = nn.Linear(embed_dims,
                                            num_heads * num_levels * num_points)
-        self.value_proj = nn.Linear(embed_dims, embed_dims)
-        self.output_proj = nn.Linear(embed_dims, embed_dims)
+        self.value_proj_size = int(embed_dims * value_proj_ratio)
+        self.value_proj = nn.Linear(embed_dims, self.value_proj_size)
+        self.output_proj = nn.Linear(self.value_proj_size, embed_dims)
         self.init_weights()
 
     def init_weights(self) -> None:

--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -180,10 +180,10 @@ class MultiScaleDeformableAttention(BaseModule):
             or (n, batch, embed_dim). Default to False.
         norm_cfg (dict): Config dict for normalization layer.
             Default: None.
-        value_proj_ratio (float): The expansion ratio of value_proj.
-            Default: 4.
         init_cfg (obj:`mmcv.ConfigDict`): The Config for initialization.
             Default: None.
+        value_proj_ratio (float): The expansion ratio of value_proj.
+            Default: 4.
     """
 
     def __init__(self,

--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -229,8 +229,8 @@ class MultiScaleDeformableAttention(BaseModule):
             embed_dims, num_heads * num_levels * num_points * 2)
         self.attention_weights = nn.Linear(embed_dims,
                                            num_heads * num_levels * num_points)
-        self.value_proj_size = int(embed_dims * value_proj_ratio)
-        self.value_proj = nn.Linear(embed_dims, self.value_proj_size)
+        value_proj_size = int(embed_dims * value_proj_ratio)
+        self.value_proj = nn.Linear(embed_dims, value_proj_size)
         self.output_proj = nn.Linear(self.value_proj_size, embed_dims)
         self.init_weights()
 

--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -180,6 +180,8 @@ class MultiScaleDeformableAttention(BaseModule):
             or (n, batch, embed_dim). Default to False.
         norm_cfg (dict): Config dict for normalization layer.
             Default: None.
+        value_proj_ratio (float): The expansion ratio of value_proj.
+            Default: 4.
         init_cfg (obj:`mmcv.ConfigDict`): The Config for initialization.
             Default: None.
     """
@@ -189,11 +191,11 @@ class MultiScaleDeformableAttention(BaseModule):
                  num_heads: int = 8,
                  num_levels: int = 4,
                  num_points: int = 4,
-                 value_proj_ratio: float = 1.0,
                  im2col_step: int = 64,
                  dropout: float = 0.1,
                  batch_first: bool = False,
                  norm_cfg: Optional[dict] = None,
+                 value_proj_ratio: float = 1.0,
                  init_cfg: Optional[mmengine.ConfigDict] = None):
         super().__init__(init_cfg)
         if embed_dims % num_heads != 0:

--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -233,7 +233,7 @@ class MultiScaleDeformableAttention(BaseModule):
                                            num_heads * num_levels * num_points)
         value_proj_size = int(embed_dims * value_proj_ratio)
         self.value_proj = nn.Linear(embed_dims, value_proj_size)
-        self.output_proj = nn.Linear(self.value_proj_size, embed_dims)
+        self.output_proj = nn.Linear(value_proj_size, embed_dims)
         self.init_weights()
 
     def init_weights(self) -> None:

--- a/tests/test_ops/test_ms_deformable_attn.py
+++ b/tests/test_ops/test_ms_deformable_attn.py
@@ -64,7 +64,6 @@ def test_multiscale_deformable_attention(device):
         num_levels=2,
         num_heads=3,
         value_proj_ratio=value_proj_ratio)
-    assert msda.value_proj_size == int(embed_dims * value_proj_ratio)
     msda.init_weights()
     msda.to(device)
     msda(

--- a/tests/test_ops/test_ms_deformable_attn.py
+++ b/tests/test_ops/test_ms_deformable_attn.py
@@ -55,8 +55,16 @@ def test_multiscale_deformable_attention(device):
         level_start_index=level_start_index)
 
     # test with value_spatial_shapes
+    embed_dims = 6
+    value_proj_ratio = 0.5
+    query = torch.rand(num_query, bs, embed_dims).to(device)
+    key = torch.rand(num_query, bs, embed_dims).to(device)
     msda = MultiScaleDeformableAttention(
-        embed_dims=3, num_levels=2, num_heads=3, value_spatial_shapes=0.5)
+        embed_dims=embed_dims,
+        num_levels=2,
+        num_heads=3,
+        value_proj_ratio=value_proj_ratio)
+    assert msda.value_proj_size == int(embed_dims * value_proj_ratio)
     msda.init_weights()
     msda.to(device)
     msda(

--- a/tests/test_ops/test_ms_deformable_attn.py
+++ b/tests/test_ops/test_ms_deformable_attn.py
@@ -54,7 +54,7 @@ def test_multiscale_deformable_attention(device):
         spatial_shapes=spatial_shapes,
         level_start_index=level_start_index)
 
-    # test with value_spatial_shapes
+    # test with value_proj_ratio
     embed_dims = 6
     value_proj_ratio = 0.5
     query = torch.rand(num_query, bs, embed_dims).to(device)

--- a/tests/test_ops/test_ms_deformable_attn.py
+++ b/tests/test_ops/test_ms_deformable_attn.py
@@ -54,6 +54,19 @@ def test_multiscale_deformable_attention(device):
         spatial_shapes=spatial_shapes,
         level_start_index=level_start_index)
 
+    # test with value_spatial_shapes
+    msda = MultiScaleDeformableAttention(
+        embed_dims=3, num_levels=2, num_heads=3, value_spatial_shapes=0.5)
+    msda.init_weights()
+    msda.to(device)
+    msda(
+        query,
+        key,
+        key,
+        reference_points=reference_points,
+        spatial_shapes=spatial_shapes,
+        level_start_index=level_start_index)
+
 
 def test_forward_multi_scale_deformable_attn_pytorch():
     N, M, D = 1, 2, 2


### PR DESCRIPTION
## Motivation

Modified for use with ViT-Adapter.
https://github.com/czczup/ViT-Adapter/blob/main/detection/ops/modules/ms_deform_attn.py#L29

# Related PR

https://github.com/open-mmlab/mmclassification/pull/1209
https://github.com/open-mmlab/mmdetection/pull/9354

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
