### PR TITLE
feat: add conf_path in PetrelBackend

### DIFF
--- a/mmcv/fileio/file_client.py
+++ b/mmcv/fileio/file_client.py
@@ -95,6 +95,7 @@ class PetrelBackend(BaseStorageBackend):
         path_mapping (dict, optional): Path mapping dict from local path to
             Petrel path. When ``path_mapping={'src': 'dst'}``, ``src`` in
             ``filepath`` will be replaced by ``dst``. Default: None.
+        conf_path (str, optional): Petrel client config path. Default: None.
         enable_mc (bool, optional): Whether to enable memcached support.
             Default: True.
 
@@ -108,6 +109,7 @@ class PetrelBackend(BaseStorageBackend):
 
     def __init__(self,
                  path_mapping: Optional[dict] = None,
+                 conf_path: str = None,
                  enable_mc: bool = True):
         try:
             from petrel_client import client
@@ -115,7 +117,7 @@ class PetrelBackend(BaseStorageBackend):
             raise ImportError('Please install petrel_client to enable '
                               'PetrelBackend.')
 
-        self._client = client.Client(enable_mc=enable_mc)
+        self._client = client.Client(conf_path=conf_path, enable_mc=enable_mc)
         assert isinstance(path_mapping, dict) or path_mapping is None
         self.path_mapping = path_mapping
 

--- a/mmcv/fileio/file_client.py
+++ b/mmcv/fileio/file_client.py
@@ -95,9 +95,10 @@ class PetrelBackend(BaseStorageBackend):
         path_mapping (dict, optional): Path mapping dict from local path to
             Petrel path. When ``path_mapping={'src': 'dst'}``, ``src`` in
             ``filepath`` will be replaced by ``dst``. Default: None.
-        conf_path (str, optional): Petrel client config path. Default: None.
         enable_mc (bool, optional): Whether to enable memcached support.
             Default: True.
+        conf_path (str, optional): Config path of Petrel client. Default: None.
+            `New in version 1.7.1`.
 
     Examples:
         >>> filepath1 = 's3://path/of/file'
@@ -109,8 +110,8 @@ class PetrelBackend(BaseStorageBackend):
 
     def __init__(self,
                  path_mapping: Optional[dict] = None,
-                 conf_path: str = None,
-                 enable_mc: bool = True):
+                 enable_mc: bool = True,
+                 conf_path: str = None):
         try:
             from petrel_client import client
         except ImportError:

--- a/tests/test_fileclient.py
+++ b/tests/test_fileclient.py
@@ -79,12 +79,12 @@ class MockS3Client:
 class MockPetrelClient:
 
     def __init__(self,
-                 conf_path=None,
                  enable_mc=True,
-                 enable_multi_cluster=False):
-        self.conf_path = conf_path
+                 enable_multi_cluster=False,
+                 conf_path=None):
         self.enable_mc = enable_mc
         self.enable_multi_cluster = enable_multi_cluster
+        self.conf_path = conf_path
 
     def Get(self, filepath):
         with open(filepath, 'rb') as f:

--- a/tests/test_fileclient.py
+++ b/tests/test_fileclient.py
@@ -78,7 +78,11 @@ class MockS3Client:
 
 class MockPetrelClient:
 
-    def __init__(self, enable_mc=True, enable_multi_cluster=False):
+    def __init__(self,
+                 conf_path=None,
+                 enable_mc=True,
+                 enable_multi_cluster=False):
+        self.conf_path = conf_path
         self.enable_mc = enable_mc
         self.enable_multi_cluster = enable_multi_cluster
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Add conf_path in PetrelBackend initial parameters to set user-defined petrel client config path.

## Modification

Add conf_path in PetrelBackend initial parameters to set user-defined petrel client config path.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
