### PR TITLE
add npu adapter for deformableroipool

### DIFF
--- a/docs/en/understand_mmcv/ops.md
+++ b/docs/en/understand_mmcv/ops.md
@@ -19,7 +19,7 @@ We implement common ops used in detection, segmentation, etc.
 | CornerPool                   |     | √    |     |     |        |
 | Correlation                  |     | √    |     |     |        |
 | Deformable Convolution v1/v2 | √   | √    |     |     |        |
-| Deformable RoIPool           |     | √    | √   |     |        |
+| Deformable RoIPool           |     | √    | √   |     | √      |
 | DiffIoURotated               |     | √    |     |     |        |
 | DynamicScatter               |     | √    |     |     |        |
 | FurthestPointSample          |     | √    |     |     |        |

--- a/docs/zh_cn/understand_mmcv/ops.md
+++ b/docs/zh_cn/understand_mmcv/ops.md
@@ -19,7 +19,7 @@ MMCV 提供了检测、分割等任务中常用的算子
 | CornerPool                   |     | √    |     |     |        |
 | Correlation                  |     | √    |     |     |        |
 | Deformable Convolution v1/v2 | √   | √    |     |     |        |
-| Deformable RoIPool           |     | √    | √   |     |        |
+| Deformable RoIPool           |     | √    | √   |     | √      |
 | DiffIoURotated               |     | √    |     |     |        |
 | DynamicScatter               |     | √    |     |     |        |
 | FurthestPointSample          |     | √    |     |     |        |

--- a/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
@@ -36,10 +36,10 @@ void deform_roi_pool_forward_npu(Tensor input, Tensor rois, Tensor offset,
 }
 
 void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input, Tensor rois,
-                                   Tensor offset, Tensor grad_input,
-                                   Tensor grad_offset, int pooled_height,
-                                   int pooled_width, float spatial_scale,
-                                   int sampling_ratio, float gamma) {
+                                  Tensor offset, Tensor grad_input,
+                                  Tensor grad_offset, int pooled_height,
+                                  int pooled_width, float spatial_scale,
+                                  int sampling_ratio, float gamma) {
   c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
   at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
   int64_t sampling_ratio_ = (int64_t)sampling_ratio;

--- a/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
@@ -1,0 +1,66 @@
+#include "pytorch_npu_helper.hpp"
+
+using namespace NPU_NAME_SPACE;
+using namespace std;
+
+void deform_roi_pool_forward_impl(Tensor input, Tensor rois, Tensor offset,
+                                  Tensor output, int pooled_height,
+                                  int pooled_width, float spatial_scale,
+                                  int sampling_ratio, float gamma);
+
+void deform_roi_pool_backward_impl(Tensor grad_output, Tensor input,
+                                   Tensor rois, Tensor offset,
+                                   Tensor grad_input, Tensor grad_offset,
+                                   int pooled_height, int pooled_width,
+                                   float spatial_scale, int sampling_ratio,
+                                   float gamma);
+
+void deform_roi_pool_forward_npu(Tensor input, Tensor rois, Tensor offset,
+                                  Tensor output, int pooled_height,
+                                  int pooled_width, float spatial_scale,
+                                  int sampling_ratio, float gamma){
+  c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
+  at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
+  int64_t sampling_ratio_ = (int64_t)sampling_ratio;
+  OpCommand cmd;
+  cmd.Name("DeformRoiPool")
+       .Input(input)
+       .Input(rois)
+       .Input(offset)
+       .Output(output)
+       .Attr("spatial_scale", spatial_scale)
+       .Attr("output_size", output_size)
+       .Attr("sampling_ratio", sampling_ratio_)
+       .Attr("gamma", gamma)
+       .Run();
+}
+
+void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input,
+                                   Tensor rois, Tensor offset,
+                                   Tensor grad_input, Tensor grad_offset,
+                                   int pooled_height, int pooled_width,
+                                   float spatial_scale, int sampling_ratio,
+                                   float gamma){
+  c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
+  at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
+  int64_t sampling_ratio_ = (int64_t)sampling_ratio;
+  OpCommand cmd;
+  cmd.Name("DeformRoiPoolGrad")
+       .Input(grad_input)
+       .Input(input)
+       .Input(rois)
+       .Input(offset)
+       .Output(grad_output)
+       .Output(grad_offset)
+       .Attr("output_size", output_size)
+       .Attr("spatial_scale", spatial_scale)
+       .Attr("sample_ratio", sampling_ratio_)
+       .Attr("gamma", gamma)
+       .Run();
+}
+
+REGISTER_NPU_IMPL(deform_roi_pool_forward_impl,
+                  deform_roi_pool_forward_npu);
+
+REGISTER_NPU_IMPL(deform_roi_pool_backward_impl,
+                  deform_roi_pool_backward_npu);

--- a/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
@@ -19,20 +19,20 @@ void deform_roi_pool_forward_npu(Tensor input, Tensor rois, Tensor offset,
                                  Tensor output, int pooled_height,
                                  int pooled_width, float spatial_scale,
 -                                int sampling_ratio, float gamma) {
-    c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
-    at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
-    int64_t sampling_ratio_ = (int64_t)sampling_ratio;
-    OpCommand cmd;
-    cmd.Name("DeformRoiPool")
-        .Input(input)
-        .Input(rois)
-        .Input(offset)
-        .Output(output)
-        .Attr("spatial_scale", spatial_scale)
-        .Attr("output_size", output_size)
-        .Attr("sampling_ratio", sampling_ratio_)
-        .Attr("gamma", gamma)
-        .Run();
+  c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
+  at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
+  int64_t sampling_ratio_ = (int64_t)sampling_ratio;
+  OpCommand cmd;
+  cmd.Name("DeformRoiPool")
+      .Input(input)
+      .Input(rois)
+      .Input(offset)
+      .Output(output)
+      .Attr("spatial_scale", spatial_scale)
+      .Attr("output_size", output_size)
+      .Attr("sampling_ratio", sampling_ratio_)
+      .Attr("gamma", gamma)
+      .Run();
 }
 
 void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input, Tensor rois,
@@ -40,22 +40,22 @@ void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input, Tensor rois,
 +                                  Tensor grad_offset, int pooled_height,
 +                                  int pooled_width, float spatial_scale,
 +                                  int sampling_ratio, float gamma) {
-    c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
-    at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
-    int64_t sampling_ratio_ = (int64_t)sampling_ratio;
-    OpCommand cmd;
-    cmd.Name("DeformRoiPoolGrad")
-        .Input(grad_input)
-        .Input(input)
-        .Input(rois)
-        .Input(offset)
-        .Output(grad_output)
-        .Output(grad_offset)
-        .Attr("output_size", output_size)
-        .Attr("spatial_scale", spatial_scale)
-        .Attr("sample_ratio", sampling_ratio_)
-        .Attr("gamma", gamma)
-        .Run();
+  c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
+  at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
+  int64_t sampling_ratio_ = (int64_t)sampling_ratio;
+  OpCommand cmd;
+  cmd.Name("DeformRoiPoolGrad")
+      .Input(grad_input)
+      .Input(input)
+      .Input(rois)
+      .Input(offset)
+      .Output(grad_output)
+      .Output(grad_offset)
+      .Attr("output_size", output_size)
+      .Attr("spatial_scale", spatial_scale)
+      .Attr("sample_ratio", sampling_ratio_)
+      .Attr("gamma", gamma)
+      .Run();
 }
 
 REGISTER_NPU_IMPL(deform_roi_pool_forward_impl, deform_roi_pool_forward_npu);

--- a/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
@@ -16,47 +16,49 @@ void deform_roi_pool_backward_impl(Tensor grad_output, Tensor input,
                                    float gamma);
 
 void deform_roi_pool_forward_npu(Tensor input, Tensor rois, Tensor offset,
-                                  Tensor output, int pooled_height,
-                                  int pooled_width, float spatial_scale,
-                                  int sampling_ratio, float gamma){
-  c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
-  at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
-  int64_t sampling_ratio_ = (int64_t)sampling_ratio;
-  OpCommand cmd;
-  cmd.Name("DeformRoiPool")
-       .Input(input)
-       .Input(rois)
-       .Input(offset)
-       .Output(output)
-       .Attr("spatial_scale", spatial_scale)
-       .Attr("output_size", output_size)
-       .Attr("sampling_ratio", sampling_ratio_)
-       .Attr("gamma", gamma)
-       .Run();
+                                 Tensor output, int pooled_height,
+                                 int pooled_width, float spatial_scale,
+                                 int sampling_ratio, float gamma)
+{
+    c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
+    at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
+    int64_t sampling_ratio_ = (int64_t)sampling_ratio;
+    OpCommand cmd;
+    cmd.Name("DeformRoiPool")
+        .Input(input)
+        .Input(rois)
+        .Input(offset)
+        .Output(output)
+        .Attr("spatial_scale", spatial_scale)
+        .Attr("output_size", output_size)
+        .Attr("sampling_ratio", sampling_ratio_)
+        .Attr("gamma", gamma)
+        .Run();
 }
 
 void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input,
-                                   Tensor rois, Tensor offset,
-                                   Tensor grad_input, Tensor grad_offset,
-                                   int pooled_height, int pooled_width,
-                                   float spatial_scale, int sampling_ratio,
-                                   float gamma){
-  c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
-  at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
-  int64_t sampling_ratio_ = (int64_t)sampling_ratio;
-  OpCommand cmd;
-  cmd.Name("DeformRoiPoolGrad")
-       .Input(grad_input)
-       .Input(input)
-       .Input(rois)
-       .Input(offset)
-       .Output(grad_output)
-       .Output(grad_offset)
-       .Attr("output_size", output_size)
-       .Attr("spatial_scale", spatial_scale)
-       .Attr("sample_ratio", sampling_ratio_)
-       .Attr("gamma", gamma)
-       .Run();
+                                  Tensor rois, Tensor offset,
+                                  Tensor grad_input, Tensor grad_offset,
+                                  int pooled_height, int pooled_width,
+                                  float spatial_scale, int sampling_ratio,
+                                  float gamma)
+{
+    c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
+    at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
+    int64_t sampling_ratio_ = (int64_t)sampling_ratio;
+    OpCommand cmd;
+    cmd.Name("DeformRoiPoolGrad")
+        .Input(grad_input)
+        .Input(input)
+        .Input(rois)
+        .Input(offset)
+        .Output(grad_output)
+        .Output(grad_offset)
+        .Attr("output_size", output_size)
+        .Attr("spatial_scale", spatial_scale)
+        .Attr("sample_ratio", sampling_ratio_)
+        .Attr("gamma", gamma)
+        .Run();
 }
 
 REGISTER_NPU_IMPL(deform_roi_pool_forward_impl,

--- a/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
@@ -18,8 +18,7 @@ void deform_roi_pool_backward_impl(Tensor grad_output, Tensor input,
 void deform_roi_pool_forward_npu(Tensor input, Tensor rois, Tensor offset,
                                  Tensor output, int pooled_height,
                                  int pooled_width, float spatial_scale,
-                                 int sampling_ratio, float gamma)
-{
+                                 int sampling_ratio, float gamma){
     c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
     at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
     int64_t sampling_ratio_ = (int64_t)sampling_ratio;
@@ -41,8 +40,7 @@ void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input,
                                   Tensor grad_input, Tensor grad_offset,
                                   int pooled_height, int pooled_width,
                                   float spatial_scale, int sampling_ratio,
-                                  float gamma)
-{
+                                  float gamma){
     c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
     at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
     int64_t sampling_ratio_ = (int64_t)sampling_ratio;

--- a/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
@@ -18,7 +18,7 @@ void deform_roi_pool_backward_impl(Tensor grad_output, Tensor input,
 void deform_roi_pool_forward_npu(Tensor input, Tensor rois, Tensor offset,
                                  Tensor output, int pooled_height,
                                  int pooled_width, float spatial_scale,
--                                int sampling_ratio, float gamma) {
+                                 int sampling_ratio, float gamma) {
   c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
   at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
   int64_t sampling_ratio_ = (int64_t)sampling_ratio;
@@ -36,10 +36,10 @@ void deform_roi_pool_forward_npu(Tensor input, Tensor rois, Tensor offset,
 }
 
 void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input, Tensor rois,
-+                                  Tensor offset, Tensor grad_input,
-+                                  Tensor grad_offset, int pooled_height,
-+                                  int pooled_width, float spatial_scale,
-+                                  int sampling_ratio, float gamma) {
+                                   Tensor offset, Tensor grad_input,
+                                   Tensor grad_offset, int pooled_height,
+                                   int pooled_width, float spatial_scale,
+                                   int sampling_ratio, float gamma) {
   c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
   at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
   int64_t sampling_ratio_ = (int64_t)sampling_ratio;

--- a/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
@@ -18,7 +18,7 @@ void deform_roi_pool_backward_impl(Tensor grad_output, Tensor input,
 void deform_roi_pool_forward_npu(Tensor input, Tensor rois, Tensor offset,
                                  Tensor output, int pooled_height,
                                  int pooled_width, float spatial_scale,
--                                int sampling_ratio, float gamma){
+-                                int sampling_ratio, float gamma) {
     c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
     at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
     int64_t sampling_ratio_ = (int64_t)sampling_ratio;
@@ -39,7 +39,7 @@ void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input, Tensor rois,
 +                                  Tensor offset, Tensor grad_input,
 +                                  Tensor grad_offset, int pooled_height,
 +                                  int pooled_width, float spatial_scale,
-+                                  int sampling_ratio, float gamma){
++                                  int sampling_ratio, float gamma) {
     c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
     at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
     int64_t sampling_ratio_ = (int64_t)sampling_ratio;

--- a/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
@@ -18,7 +18,7 @@ void deform_roi_pool_backward_impl(Tensor grad_output, Tensor input,
 void deform_roi_pool_forward_npu(Tensor input, Tensor rois, Tensor offset,
                                  Tensor output, int pooled_height,
                                  int pooled_width, float spatial_scale,
-                                 int sampling_ratio, float gamma){
+-                                int sampling_ratio, float gamma){
     c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
     at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
     int64_t sampling_ratio_ = (int64_t)sampling_ratio;
@@ -35,12 +35,11 @@ void deform_roi_pool_forward_npu(Tensor input, Tensor rois, Tensor offset,
         .Run();
 }
 
-void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input,
-                                  Tensor rois, Tensor offset,
-                                  Tensor grad_input, Tensor grad_offset,
-                                  int pooled_height, int pooled_width,
-                                  float spatial_scale, int sampling_ratio,
-                                  float gamma){
+void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input, Tensor rois,
++                                  Tensor offset, Tensor grad_input,
++                                  Tensor grad_offset, int pooled_height,
++                                  int pooled_width, float spatial_scale,
++                                  int sampling_ratio, float gamma){
     c10::SmallVector<int64_t, 2> output_sizes = {pooled_height, pooled_width};
     at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
     int64_t sampling_ratio_ = (int64_t)sampling_ratio;
@@ -59,8 +58,6 @@ void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input,
         .Run();
 }
 
-REGISTER_NPU_IMPL(deform_roi_pool_forward_impl,
-                  deform_roi_pool_forward_npu);
+REGISTER_NPU_IMPL(deform_roi_pool_forward_impl, deform_roi_pool_forward_npu);
 
-REGISTER_NPU_IMPL(deform_roi_pool_backward_impl,
-                  deform_roi_pool_backward_npu);
+REGISTER_NPU_IMPL(deform_roi_pool_backward_impl, deform_roi_pool_backward_npu);

--- a/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/deform_roi_pool.cpp
@@ -23,7 +23,7 @@ void deform_roi_pool_forward_npu(Tensor input, Tensor rois, Tensor offset,
   at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
   int64_t sampling_ratio_ = (int64_t)sampling_ratio;
   OpCommand cmd;
-  cmd.Name("DeformRoiPool")
+  cmd.Name("DeformableRoiPool")
       .Input(input)
       .Input(rois)
       .Input(offset)
@@ -44,7 +44,7 @@ void deform_roi_pool_backward_npu(Tensor grad_output, Tensor input, Tensor rois,
   at::IntArrayRef output_size = at::IntArrayRef(output_sizes);
   int64_t sampling_ratio_ = (int64_t)sampling_ratio;
   OpCommand cmd;
-  cmd.Name("DeformRoiPoolGrad")
+  cmd.Name("DeformableRoiPoolGrad")
       .Input(grad_input)
       .Input(input)
       .Input(rois)

--- a/tests/test_ops/test_deform_roi_pool.py
+++ b/tests/test_ops/test_deform_roi_pool.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import torch
 
-from mmcv.utils import IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE
+from mmcv.utils import IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE, IS_NPU_AVAILABLE
 
 _USING_PARROTS = True
 try:
@@ -134,6 +134,10 @@ class TestDeformRoIPool:
             'mlu',
             marks=pytest.mark.skipif(
                 not IS_MLU_AVAILABLE, reason='requires MLU support'))
+        pytest.param(
+            'npu',
+            marks=pytest.mark.skipif(
+                not IS_NPU_AVAILABLE, reason='requires NPU support'))
     ])
     @pytest.mark.parametrize('dtype', [
         torch.float,

--- a/tests/test_ops/test_deform_roi_pool.py
+++ b/tests/test_ops/test_deform_roi_pool.py
@@ -133,7 +133,7 @@ class TestDeformRoIPool:
         pytest.param(
             'mlu',
             marks=pytest.mark.skipif(
-                not IS_MLU_AVAILABLE, reason='requires MLU support'))
+                not IS_MLU_AVAILABLE, reason='requires MLU support')),
         pytest.param(
             'npu',
             marks=pytest.mark.skipif(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This PR contains a npu-adapter of mmcv ops-deformableroipool. we can run these ops(above) on ascend-npu device by these adapters.

## Modification

deform_roi_pool.cpp is added to the PR which is used for deformroipool npu-adaptation, while  test_deform_roi_pool.py is modified by the PR.
