### PR TITLE
[Feature] Parrots with mlu adaptation, ops: nms, focal_loss_sigmoid and roi_align

### DIFF
--- a/mmcv/ops/csrc/common/mlu/roiaware_pool3d_mlu_kernel.mlu
+++ b/mmcv/ops/csrc/common/mlu/roiaware_pool3d_mlu_kernel.mlu
@@ -255,8 +255,8 @@ __mlu_global__ void MLUUnion1KernelPtsIdxOfVoxels(
       } else {
         __bang_half2float((float *)temp_buffer4, (half *)nram_pts_in_flag,
                           compute_pts_num);
-        __bang_move((void *)fp_nram_pts_in_flag, (void *)temp_buffer4,
-                    compute_pts_num * sizeof(float));
+        // __bang_move((void *)fp_nram_pts_in_flag, (void *)temp_buffer4,
+        //             compute_pts_num * sizeof(float));
 #if __BANG_ARCH__ >= 322
         __bang_half2int32_tz((int *)temp_buffer1, (half *)local_X,
                              compute_pts_num, 0);
@@ -324,8 +324,9 @@ __mlu_global__ void MLUUnion1KernelPtsIdxOfVoxels(
       }
       __bang_collect((float *)temp_buffer4, (float *)nram_pts_idx_seq,
                      (float *)fp_nram_pts_in_flag, compute_pts_num);
-      int pts_num_in_cur_roi =
-          (int)__bang_count((float *)fp_nram_pts_in_flag, compute_pts_num);
+      // int pts_num_in_cur_roi =
+          // (int)__bang_count((float *)fp_nram_pts_in_flag, compute_pts_num);
+      int pts_num_in_cur_roi = 1;  // just for declare placeholder
       int *pts_idx_cur_voxels =
           (int *)pts_idx_of_voxels +
           roi_index * out_x * out_y * out_z * max_pts_each_voxel;
@@ -454,8 +455,9 @@ __mlu_global__ void MLUUnion1KernelRoiawarePool3dForward(
                           channel_idx * align_max_pts_each_voxel,
                       (float *)nram_max_pts_feature_tmp,
                       align_max_pts_each_voxel);
-            int max_idx = (int)__bang_findfirst1(
-                (float *)nram_max_pts_feature_tmp, align_max_pts_each_voxel);
+            // int max_idx = (int)__bang_findfirst1(
+                // (float *)nram_max_pts_feature_tmp, align_max_pts_each_voxel);
+            int max_idx = 1; // juse declare placeholder
             nram_pooled_features_cur_voxel[channel_idx] =
                 (max_val == -INFINITY) ? 0 : max_val;
             nram_argmax_cur_voxel[channel_idx] =

--- a/mmcv/ops/csrc/common/mlu/roiaware_pool3d_mlu_kernel.mlu
+++ b/mmcv/ops/csrc/common/mlu/roiaware_pool3d_mlu_kernel.mlu
@@ -324,9 +324,8 @@ __mlu_global__ void MLUUnion1KernelPtsIdxOfVoxels(
       }
       __bang_collect((float *)temp_buffer4, (float *)nram_pts_idx_seq,
                      (float *)fp_nram_pts_in_flag, compute_pts_num);
-      // int pts_num_in_cur_roi =
-          // (int)__bang_count((float *)fp_nram_pts_in_flag, compute_pts_num);
-      int pts_num_in_cur_roi = 1;  // just for declare placeholder
+      int pts_num_in_cur_roi =
+          (int)__bang_count((float *)fp_nram_pts_in_flag, compute_pts_num);
       int *pts_idx_cur_voxels =
           (int *)pts_idx_of_voxels +
           roi_index * out_x * out_y * out_z * max_pts_each_voxel;
@@ -455,9 +454,8 @@ __mlu_global__ void MLUUnion1KernelRoiawarePool3dForward(
                           channel_idx * align_max_pts_each_voxel,
                       (float *)nram_max_pts_feature_tmp,
                       align_max_pts_each_voxel);
-            // int max_idx = (int)__bang_findfirst1(
-                // (float *)nram_max_pts_feature_tmp, align_max_pts_each_voxel);
-            int max_idx = 1; // juse declare placeholder
+            int max_idx = (int)__bang_findfirst1(
+                (float *)nram_max_pts_feature_tmp, align_max_pts_each_voxel);
             nram_pooled_features_cur_voxel[channel_idx] =
                 (max_val == -INFINITY) ? 0 : max_val;
             nram_argmax_cur_voxel[channel_idx] =

--- a/mmcv/ops/csrc/common/mlu/roiaware_pool3d_mlu_kernel.mlu
+++ b/mmcv/ops/csrc/common/mlu/roiaware_pool3d_mlu_kernel.mlu
@@ -255,8 +255,8 @@ __mlu_global__ void MLUUnion1KernelPtsIdxOfVoxels(
       } else {
         __bang_half2float((float *)temp_buffer4, (half *)nram_pts_in_flag,
                           compute_pts_num);
-        // __bang_move((void *)fp_nram_pts_in_flag, (void *)temp_buffer4,
-        //             compute_pts_num * sizeof(float));
+        __bang_move((void *)fp_nram_pts_in_flag, (void *)temp_buffer4,
+                    compute_pts_num * sizeof(float));
 #if __BANG_ARCH__ >= 322
         __bang_half2int32_tz((int *)temp_buffer1, (half *)local_X,
                              compute_pts_num, 0);

--- a/mmcv/ops/csrc/common/parrots_device_registry.hpp
+++ b/mmcv/ops/csrc/common/parrots_device_registry.hpp
@@ -1,0 +1,68 @@
+#ifndef PARROTS_DEVICE_REGISTRY_H
+#define PARROTS_DEVICE_REGISTRY_H
+
+#define MAX_DEVICE_TYPES 8  // currently x86, cuda, camb, hip, ascend
+
+#include <part/devices.hpp>
+#include <parrots/extension.hpp>
+
+namespace parrots {
+
+// declare Registry
+template <typename F, F f>
+class DeviceRegistry;
+
+// Template specialization
+template <typename Ret, typename... Args, Ret (*f)(Args...)>
+class DeviceRegistry<Ret (*)(Args...), f> {
+ public:
+  using FunctionType = Ret (*)(Args...);
+
+  void registerArch(const Arch& device, FunctionType function) {
+    funcs_[size_t(device)] = function;
+  }
+
+  FunctionType find(const Arch& device) const {
+    return funcs_[size_t(device)];
+  }
+
+  static DeviceRegistry& instance() {
+    static DeviceRegistry instance;
+    return instance;
+  }
+
+ private:
+  DeviceRegistry() {
+    for (size_t i = 0; i < MAX_DEVICE_TYPES; i++) {
+      funcs_[i] = nullptr;
+    }
+  };
+  FunctionType funcs_[MAX_DEVICE_TYPES];
+};
+
+// dispatch
+template <typename R, typename... Args>
+auto Dispatch(const R& registry, string_t name, Context& ctx, Args&&... args) {
+  auto arch = ctx.getProxy().arch();
+  auto f_ptr = registry.find(arch);
+  PARROTS_CHECKARGS(f_ptr != nullptr)
+      << name + ": implementation for arch " + archName(arch) + " not found.\n";
+  return f_ptr(ctx, std::forward<Args>(args)...);
+}
+
+#define DEVICE_REGISTRY(key) DeviceRegistry<decltype(&(key)), key>::instance()
+
+#define REGISTER_DEVICE_IMPL(key, device, arch, value) \
+  struct key##_##device##_registerer {                 \
+    key##_##device##_registerer() {                    \
+      DEVICE_REGISTRY(key).registerArch(arch, value);  \
+    }                                                  \
+  };                                                   \
+  static key##_##device##_registerer _##key##_##device##_registerer;
+
+#define DISPATCH_DEVICE_IMPL(key, ...) \
+  Dispatch(DEVICE_REGISTRY(key), #key, __VA_ARGS__)
+
+#endif  // PARROTS_DEVICE_REGISTRY
+
+}  // namespace parrots

--- a/mmcv/ops/csrc/common/parrots_device_registry.hpp
+++ b/mmcv/ops/csrc/common/parrots_device_registry.hpp
@@ -3,8 +3,8 @@
 
 #define MAX_DEVICE_TYPES 8  // currently x86, cuda, camb, hip, ascend
 
-#include <part/devices.hpp>
 #include <parrots/extension.hpp>
+#include <part/devices.hpp>
 
 namespace parrots {
 
@@ -22,9 +22,7 @@ class DeviceRegistry<Ret (*)(Args...), f> {
     funcs_[size_t(device)] = function;
   }
 
-  FunctionType find(const Arch& device) const {
-    return funcs_[size_t(device)];
-  }
+  FunctionType find(const Arch& device) const { return funcs_[size_t(device)]; }
 
   static DeviceRegistry& instance() {
     static DeviceRegistry instance;

--- a/mmcv/ops/csrc/common/parrots_mlu_helper.hpp
+++ b/mmcv/ops/csrc/common/parrots_mlu_helper.hpp
@@ -75,12 +75,17 @@ inline int itemsize(parrots::ValueType vt) {
 
 inline int itemsize(const DArrayLite& x) { return itemsize(x.elemType()); }
 
-inline int getDeviceAttr(const cnrtDeviceAttr_t& attr) {
-  int ordinal = -1;
-  cnrtGetDevice(&ordinal);
-  int value = 0;
-  cnrtDeviceGetAttribute(&value, attr, ordinal);
-  return value;
+constexpr uint32_t rem_for_stack = 128 * 1024;
+
+inline uint32_t getDeviceAttr(cnrtDeviceAttr_t attr) {
+  int dev_ordinal = 0;
+  int device_attr = 1;
+  cnrtGetDevice(&dev_ordinal);
+  cnrtDeviceGetAttribute(&device_attr, attr, dev_ordinal);
+  if (attr == cnrtAttrNramSizePerMcore) {
+    device_attr -= rem_for_stack;
+  }
+  return device_attr;
 }
 
 #endif  // PARROTS_USE_CAMB

--- a/mmcv/ops/csrc/common/parrots_mlu_helper.hpp
+++ b/mmcv/ops/csrc/common/parrots_mlu_helper.hpp
@@ -1,0 +1,88 @@
+#ifndef PARROTS_MLU_HELPER
+#define PARROTS_MLU_HELPER
+
+#include <parrots/extension.hpp>
+
+#ifdef PARROTS_USE_CAMB
+
+#include <cnrt.h>
+
+#ifdef __BANG_ARCH__
+#define MAX_NRAM_SIZE \
+  (__MLU_NRAM_SIZE__ * 1024 - REM_FOR_STACK)  // 128KB reserved for cncc
+#define MAX_SRAM_SIZE \
+  (__MLU_SRAM_SIZE__ * 1024 - REM_FOR_STACK)  // 128KB reserved for cncc
+#else
+#define MAX_NRAM_SIZE (384 * 1024)   // 384KB,  initialization value
+#define MAX_SRAM_SIZE (1920 * 1024)  // 1920KB, initialization value
+#endif
+
+
+#define NFU_ALIGN_SIZE 128
+#define PAD_UP(x, y) (((x) / (y) + (int)((x) % (y) > 0)) * (y))
+#define PAD_DOWN(x, y) (((x) / (y)) * (y))
+#define CEIL_ALIGN(x, y) (((x) + (y)-1) / (y) * (y))
+
+
+using parrots::DArrayLite;
+using parrots::Prim;
+
+inline cnrtDataType_t getCnrtDataType(parrots::ValueType vt) {
+  switch (vt.prim()) {
+    case Prim::Float16:
+      return cnrtFloat16;
+    case Prim::Float32:
+      return cnrtFloat32;
+    case Prim::Int16:
+      return cnrtInt16;
+    case Prim::Int32:
+      return cnrtInt32;
+    case Prim::Int64:
+      return cnrtInt64;
+    case Prim::Int8:
+      return cnrtInt8;
+    case Prim::Uint8:
+      return cnrtUInt8;
+    case Prim::Bool:
+      return cnrtBool;
+    default:
+      PARROTS_NOTSUPPORTED << "Unsupported data type for CNRT: " << vt.name();
+  }
+}
+
+inline int itemsize(parrots::ValueType vt) {
+  switch (vt.prim()) {
+    case Prim::Float16:
+      return 2;
+    case Prim::Float32:
+      return 4;
+    case Prim::Int16:
+      return 2;
+    case Prim::Int32:
+      return 4;
+    case Prim::Int64:
+      return 8;
+    case Prim::Int8:
+      return 1;
+    case Prim::Uint8:
+      return 1;
+    case Prim::Bool:
+      return 1;
+    default:
+      PARROTS_NOTSUPPORTED << "Unsupported data type for CNRT: " << vt.name();
+  }
+}
+
+inline int itemsize(const DArrayLite& x) { return itemsize(x.elemType()); }
+
+inline int getDeviceAttr(const cnrtDeviceAttr_t& attr) {
+  int ordinal = -1;
+  cnrtGetDevice(&ordinal);
+  int value = 0;
+  cnrtDeviceGetAttribute(&value, attr, ordinal);
+  return value;
+}
+
+#endif  // PARROTS_USE_CAMB
+
+#endif  // !PARROTS_MLU_HELPER

--- a/mmcv/ops/csrc/common/parrots_mlu_helper.hpp
+++ b/mmcv/ops/csrc/common/parrots_mlu_helper.hpp
@@ -17,12 +17,10 @@
 #define MAX_SRAM_SIZE (1920 * 1024)  // 1920KB, initialization value
 #endif
 
-
 #define NFU_ALIGN_SIZE 128
 #define PAD_UP(x, y) (((x) / (y) + (int)((x) % (y) > 0)) * (y))
 #define PAD_DOWN(x, y) (((x) / (y)) * (y))
 #define CEIL_ALIGN(x, y) (((x) + (y)-1) / (y) * (y))
-
 
 using parrots::DArrayLite;
 using parrots::Prim;

--- a/mmcv/ops/csrc/parrots/common/parrots_focal_loss.cpp
+++ b/mmcv/ops/csrc/parrots/common/parrots_focal_loss.cpp
@@ -1,0 +1,34 @@
+
+#include "parrots_focal_loss.h"
+
+using namespace parrots;
+
+void sigmoid_focal_loss_forward_impl(Context &ctx, const SSElement &attr,
+                                     const OperatorBase::in_list_t &ins,
+                                     OperatorBase::out_list_t &outs) {
+  return DISPATCH_DEVICE_IMPL(sigmoid_focal_loss_forward_impl, ctx, attr, ins,
+                              outs);
+}
+
+void sigmoid_focal_loss_backward_impl(Context &ctx, const SSElement &attr,
+                                      const OperatorBase::in_list_t &ins,
+                                      OperatorBase::out_list_t &outs) {
+  return DISPATCH_DEVICE_IMPL(sigmoid_focal_loss_backward_impl, ctx, attr, ins,
+                              outs);
+}
+
+PARROTS_EXTENSION_REGISTER(sigmoid_focal_loss_forward)
+    .attr("gamma")
+    .attr("alpha")
+    .input(3)
+    .output(1)
+    .apply(sigmoid_focal_loss_forward_impl)
+    .done();
+
+PARROTS_EXTENSION_REGISTER(sigmoid_focal_loss_backward)
+    .attr("gamma")
+    .attr("alpha")
+    .input(3)
+    .output(1)
+    .apply(sigmoid_focal_loss_backward_impl)
+    .done();

--- a/mmcv/ops/csrc/parrots/common/parrots_focal_loss.h
+++ b/mmcv/ops/csrc/parrots/common/parrots_focal_loss.h
@@ -1,0 +1,16 @@
+#ifndef PARROTS_FOCAL_LOSS_H
+#define PARROTS_FOCAL_LOSS_H
+
+#include <parrots_device_registry.hpp>
+
+using namespace parrots;
+
+void sigmoid_focal_loss_forward_impl(Context &ctx, const SSElement &attr,
+                                     const OperatorBase::in_list_t &ins,
+                                     OperatorBase::out_list_t &outs);
+
+void sigmoid_focal_loss_backward_impl(Context &ctx, const SSElement &attr,
+                                      const OperatorBase::in_list_t &ins,
+                                      OperatorBase::out_list_t &outs);
+
+#endif  // PARROTS_FOCAL_LOSS_H

--- a/mmcv/ops/csrc/parrots/common/parrots_nms.cpp
+++ b/mmcv/ops/csrc/parrots/common/parrots_nms.cpp
@@ -1,0 +1,18 @@
+
+#include "parrots_nms.h"
+
+using namespace parrots;
+
+void nms_impl(Context &ctx, const SSElement &attr,
+              const OperatorBase::in_list_t &ins,
+              OperatorBase::out_list_t &outs) {
+  return DISPATCH_DEVICE_IMPL(nms_impl, ctx, attr, ins, outs);
+}
+
+PARROTS_EXTENSION_REGISTER(nms)
+    .attr("iou_threshold")
+    .attr("offset")
+    .input(2)
+    .output(1)
+    .apply(nms_impl)
+    .done();

--- a/mmcv/ops/csrc/parrots/common/parrots_nms.h
+++ b/mmcv/ops/csrc/parrots/common/parrots_nms.h
@@ -1,0 +1,12 @@
+#ifndef PARROTS_NMS_H
+#define PARROTS_NMS_H
+
+#include <parrots_device_registry.hpp>
+
+using namespace parrots;
+
+void nms_impl(Context &ctx, const SSElement &attr,
+              const OperatorBase::in_list_t &ins,
+              OperatorBase::out_list_t &outs);
+
+#endif  // PARROTS_NMS_H

--- a/mmcv/ops/csrc/parrots/common/parrots_roi_align.cpp
+++ b/mmcv/ops/csrc/parrots/common/parrots_roi_align.cpp
@@ -1,0 +1,40 @@
+
+#include "parrots_roi_align.h"
+
+using namespace parrots;
+
+void roi_align_forward_impl(Context &ctx, const SSElement &attr,
+                            const OperatorBase::in_list_t &ins,
+                            OperatorBase::out_list_t &outs) {
+  return DISPATCH_DEVICE_IMPL(roi_align_forward_impl, ctx, attr, ins, outs);
+}
+
+void roi_align_backward_impl(Context &ctx, const SSElement &attr,
+                             const OperatorBase::in_list_t &ins,
+                             OperatorBase::out_list_t &outs) {
+  return DISPATCH_DEVICE_IMPL(roi_align_backward_impl, ctx, attr, ins, outs);
+}
+
+PARROTS_EXTENSION_REGISTER(roi_align_forward)
+    .attr("aligned_height")
+    .attr("aligned_width")
+    .attr("spatial_scale")
+    .attr("sampling_ratio")
+    .attr("pool_mode")
+    .attr("aligned")
+    .input(2)
+    .output(3)
+    .apply(roi_align_forward_impl)
+    .done();
+
+PARROTS_EXTENSION_REGISTER(roi_align_backward)
+    .attr("aligned_height")
+    .attr("aligned_width")
+    .attr("spatial_scale")
+    .attr("sampling_ratio")
+    .attr("pool_mode")
+    .attr("aligned")
+    .input(4)
+    .output(1)
+    .apply(roi_align_backward_impl)
+    .done();

--- a/mmcv/ops/csrc/parrots/common/parrots_roi_align.h
+++ b/mmcv/ops/csrc/parrots/common/parrots_roi_align.h
@@ -1,0 +1,16 @@
+#ifndef PARROTS_ROI_ALIGN_H
+#define PARROTS_ROI_ALIGN_H
+
+#include <parrots_device_registry.hpp>
+
+using namespace parrots;
+
+void roi_align_forward_impl(Context &ctx, const SSElement &attr,
+                            const OperatorBase::in_list_t &ins,
+                            OperatorBase::out_list_t &outs);
+
+void roi_align_backward_impl(Context &ctx, const SSElement &attr,
+                             const OperatorBase::in_list_t &ins,
+                             OperatorBase::out_list_t &outs);
+
+#endif  // PARROTS_ROI_ALIGN_H

--- a/mmcv/ops/csrc/parrots/cpu/nms_cpu.cpp
+++ b/mmcv/ops/csrc/parrots/cpu/nms_cpu.cpp
@@ -1,0 +1,29 @@
+#include <parrots/compute/aten.hpp>
+#include <parrots/darray/darraymath.hpp>
+
+#include "parrots_nms.h"
+
+using namespace parrots;
+
+using at::Tensor;
+Tensor nms_cpu(Tensor boxes, Tensor scores, float iou_threshold, int offset);
+
+void nms_parrots_cpu(HostContext &ctx, const SSElement &attr,
+                     const OperatorBase::in_list_t &ins,
+                     OperatorBase::out_list_t &outs) {
+  float iou_threshold;
+  int offset;
+  SSAttrs(attr)
+      .get("iou_threshold", iou_threshold)
+      .get("offset", offset)
+      .done();
+
+  at::Tensor boxes, scores;
+  boxes = buildATensor(ctx, ins[0]);
+  scores = buildATensor(ctx, ins[1]);
+  auto out = nms_cpu(boxes, scores, iou_threshold, offset);
+  updateDArray(ctx, out, outs[0]);
+  return;
+}
+
+REGISTER_DEVICE_IMPL(nms_impl, CPU, Arch::X86, nms_parrots_cpu);

--- a/mmcv/ops/csrc/parrots/cpu/roi_align_cpu.cpp
+++ b/mmcv/ops/csrc/parrots/cpu/roi_align_cpu.cpp
@@ -1,0 +1,83 @@
+
+#include <parrots/compute/aten.hpp>
+#include <parrots/darray/darraymath.hpp>
+#include <parrots/foundation/darrayutil.hpp>
+
+#include "parrots_roi_align.h"
+
+using namespace parrots;
+
+using at::Tensor;
+void ROIAlignForwardCPULauncher(Tensor input, Tensor rois, Tensor output,
+                                Tensor argmax_y, Tensor argmax_x,
+                                int aligned_height, int aligned_width,
+                                float spatial_scale, int sampling_ratio,
+                                int pool_mode, bool aligned);
+
+void ROIAlignBackwardCPULauncher(Tensor grad_output, Tensor rois,
+                                 Tensor argmax_y, Tensor argmax_x,
+                                 Tensor grad_input, int aligned_height,
+                                 int aligned_width, float spatial_scale,
+                                 int sampling_ratio, int pool_mode,
+                                 bool aligned);
+
+void roi_align_forward_cpu_parrots(HostContext& ctx, const SSElement& attr,
+                                   const OperatorBase::in_list_t& ins,
+                                   OperatorBase::out_list_t& outs) {
+  int aligned_height;
+  int aligned_width;
+  float spatial_scale;
+  int sampling_ratio;
+  int pool_mode;
+  bool aligned;
+  SSAttrs(attr)
+      .get<int>("aligned_height", aligned_height)
+      .get<int>("aligned_width", aligned_width)
+      .get<float>("spatial_scale", spatial_scale)
+      .get<int>("sampling_ratio", sampling_ratio)
+      .get<int>("pool_mode", pool_mode)
+      .get<bool>("aligned", aligned)
+      .done();
+
+  const auto& input = buildATensor(ctx, ins[0]);
+  const auto& rois = buildATensor(ctx, ins[1]);
+  auto output = buildATensor(ctx, outs[0]);
+  auto argmax_y = buildATensor(ctx, outs[1]);
+  auto argmax_x = buildATensor(ctx, outs[2]);
+
+  ROIAlignForwardCPULauncher(input, rois, output, argmax_y, argmax_x,
+                             aligned_height, aligned_width, spatial_scale,
+                             sampling_ratio, pool_mode, aligned);
+}
+
+void roi_align_backward_cpu_parrots(HostContext& ctx, const SSElement& attr,
+                                    const OperatorBase::in_list_t& ins,
+                                    OperatorBase::out_list_t& outs) {
+  int aligned_height;
+  int aligned_width;
+  float spatial_scale;
+  int sampling_ratio;
+  int pool_mode;
+  bool aligned;
+  SSAttrs(attr)
+      .get<int>("aligned_height", aligned_height)
+      .get<int>("aligned_width", aligned_width)
+      .get<float>("spatial_scale", spatial_scale)
+      .get<int>("sampling_ratio", sampling_ratio)
+      .get<int>("pool_mode", pool_mode)
+      .get<bool>("aligned", aligned)
+      .done();
+  const auto& grad_output = buildATensor(ctx, ins[0]);
+  const auto& rois = buildATensor(ctx, ins[1]);
+  const auto& argmax_y = buildATensor(ctx, ins[2]);
+  const auto& argmax_x = buildATensor(ctx, ins[3]);
+  auto grad_input = buildATensor(ctx, outs[0]);
+  ROIAlignBackwardCPULauncher(grad_output, rois, argmax_y, argmax_x, grad_input,
+                              aligned_height, aligned_width, spatial_scale,
+                              sampling_ratio, pool_mode, aligned);
+}
+
+REGISTER_DEVICE_IMPL(roi_align_forward_impl, CPU, Arch::X86,
+                     roi_align_forward_cpu_parrots);
+REGISTER_DEVICE_IMPL(roi_align_backward_impl, CPU, Arch::X86,
+                     roi_align_backward_cpu_parrots);

--- a/mmcv/ops/csrc/parrots/mlu/focal_loss_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/focal_loss_mlu.cpp
@@ -1,0 +1,363 @@
+#include <parrots/darray/darraymath.hpp>
+
+#include "parrots_mlu_helper.hpp"
+
+#ifdef PARROTS_USE_CAMB
+
+using namespace parrots;
+
+void KernelFocalLossSigmoidForward(cnrtDim3_t k_dim, cnrtFunctionType_t k_type,
+                                   cnrtQueue_t queue, cnrtDataType_t d_type,
+                                   const void* input, const void* target,
+                                   const void* weight, const int32_t N,
+                                   const int32_t C, const float alpha,
+                                   const float gamma, void* output);
+
+void KernelFocalLossSigmoidBackward(cnrtDim3_t k_dim, cnrtFunctionType_t k_type,
+                                    cnrtQueue_t queue,
+                                    const cnrtDataType_t d_type,
+                                    const void* input, const void* target,
+                                    const void* weight, const float gamma,
+                                    const float alpha, const int32_t dim_n,
+                                    const int32_t deal_n, const int32_t dim_c,
+                                    void* output);
+
+namespace sigmoid_forward {
+
+// policy function
+static void policyFunc(cnrtDim3_t* k_dim, cnrtFunctionType_t* k_type,
+                       const DArrayLite& input, const DArrayLite& target,
+                       const DArrayLite& weight) {
+  auto N = input.dim(0);
+  auto C = input.dim(1);
+
+  auto nram_size = getDeviceAttr(cnrtAttrNramSizePerMcore);
+  auto c_align_size = PAD_UP((C * itemsize(input)), NFU_ALIGN_SIZE);
+  const int split_target_num = 2;
+  const int split_pipeline_num = 6;
+  auto scalar_size = NFU_ALIGN_SIZE;
+  auto weight_size = c_align_size;
+  const int target_data_width = itemsize(Prim::Int32);
+
+  // n_seg * c_align_size * split_pipeline_num + n_seg * target.itemsize() *
+  // split_target_num
+  //     + weight_size + scalar_size <= nram_size
+  auto n_seg = (nram_size - weight_size - scalar_size) /
+               (c_align_size * split_pipeline_num +
+                target_data_width * split_target_num);
+  auto seg_num = (N + n_seg - 1) / n_seg;
+
+  auto core_dim = getDeviceAttr(cnrtAttrMcorePerCluster);
+  auto cluster_num = getDeviceAttr(cnrtAttrClusterCount);
+  auto core_num = core_dim * cluster_num;
+
+  k_dim->x = *k_type;
+  k_dim->y =
+      seg_num > core_num ? cluster_num : (seg_num + core_dim - 1) / core_dim;
+  k_dim->z = 1;
+}
+
+void sigmoidFocalLossForwardMLUKernelLauncher(
+    CambContext& ctx, const DArrayLite& input, const DArrayLite& target,
+    const DArrayLite& weight, DArrayLite& output, float gamma, float alpha) {
+  // params check
+  PARROTS_CHECKARGS(gamma >= 0)
+      << "gamma should be greater than or equal to 0. "
+      << "But now gamma is " << gamma << ".";
+
+  // check dtype
+  PARROTS_CHECKARGS((input.elemType() == Prim::Float32) ||
+                    (input.elemType() == Prim::Float16))
+      << "Data type of input should be Float or Half. But now input type is "
+      << input.elemType() << ".";
+
+  PARROTS_CHECKARGS(target.elemType() == Prim::Int32 ||
+                    target.elemType() == Prim::Int64)
+      << "target type should be int32 or int64. But now target type is "
+      << target.elemType() << ".";
+
+  PARROTS_CHECKARGS(output.elemType() == input.elemType())
+      << "Data types of input and output should be the same. But now input "
+         "type is "
+      << input.elemType() << ", output type is " << output.elemType() << ".";
+
+  // check weight
+  if (weight.size() > 0) {
+    PARROTS_CHECKARGS(weight.elemType() == input.elemType())
+        << "Data types of input and weight should be the same. But now "
+           "input type is "
+        << input.elemType() << ", weight type is " << weight.elemType() << ".";
+  }
+
+  const DArrayLite* target_ptr = &target;
+  DArrayLite target_tmp;
+  if (target.elemType() == Prim::Int64) {
+    target_tmp = ctx.createDArrayLite(target.spec().withElemType(Prim::Int32));
+    cast(ctx, target, target_tmp);
+    target_ptr = &target_tmp;
+  }
+
+  auto nram_size = getDeviceAttr(cnrtAttrNramSizePerMcore);
+  auto input_N = input.dim(0);
+  auto input_C = input.dim(1);
+  auto split_target_num = 2;
+  int split_pipeline_num = 6;
+  const int has_weight = (int)(weight.size() > 0);
+  const int target_data_width = itemsize(target_ptr->elemType());
+  // target supports only INT on MLU device
+  // while it keeps LONG on host side, so target.itemsize()/2
+  auto threshold_C = PAD_DOWN((nram_size - NFU_ALIGN_SIZE -
+                               split_target_num * target_data_width) /
+                                  (split_pipeline_num + has_weight),
+                              NFU_ALIGN_SIZE) /
+                     itemsize(input);
+  PARROTS_CHECKARGS(threshold_C >= input_C)
+      << "input.size(1) should be in the range of [0, " << threshold_C
+      << "], but now input.dim(1) is " << input_C << ".";
+
+  if (input.size() == 0 || target_ptr->size() == 0 || output.size() == 0) {
+    // return if zero-element
+    return;
+  }
+
+  // calculate task dimension
+  cnrtDim3_t k_dim;
+  cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  policyFunc(&k_dim, &k_type, input, *target_ptr, weight);
+  auto core_dim = getDeviceAttr(cnrtAttrMcorePerCluster);
+
+  // get compute queue
+  auto queue = getStreamNative<CambDevice>(ctx.getStream());
+  auto weight_ptr = weight.size() > 0 ? weight.data() : nullptr;
+  // get dtype of input
+  cnrtDataType_t d_type = getCnrtDataType(input.elemType());
+
+  // launch kernel
+  KernelFocalLossSigmoidForward(k_dim, k_type, queue, d_type, input.data(),
+                                target_ptr->data(), weight_ptr, input_N,
+                                input_C, alpha, gamma, output.data());
+}
+
+void sigmoid_focal_loss_forward_camb_parrots(CambContext& ctx,
+                                             const SSElement& attr,
+                                             const OperatorBase::in_list_t& ins,
+                                             OperatorBase::out_list_t& outs) {
+  float gamma;
+  float alpha;
+  SSAttrs(attr).get<float>("gamma", gamma).get<float>("alpha", alpha).done();
+
+  // get inputs and outputs
+  const auto& input = ins[0];
+  const auto& target = ins[1];
+  const auto& weight = ins[2];
+  auto& output = outs[0];
+
+  sigmoidFocalLossForwardMLUKernelLauncher(ctx, input, target, weight, output,
+                                           gamma, alpha);
+}
+
+PARROTS_EXTENSION_REGISTER(sigmoid_focal_loss_forward)
+    .attr("gamma")
+    .attr("alpha")
+    .input(3)
+    .output(1)
+    .apply(sigmoid_focal_loss_forward_camb_parrots)
+    .done();
+
+}  // namespace sigmoid_forward
+
+namespace sigmoid_backeard {
+
+// Policy Function
+static void policyFunc(cnrtDim3_t* k_dim, cnrtFunctionType_t* k_type) {
+  // set Union1 Job
+  *k_type = CNRT_FUNC_TYPE_UNION1;
+  k_dim->x = getDeviceAttr(cnrtAttrMcorePerCluster);
+  k_dim->y = getDeviceAttr(cnrtAttrClusterCount);
+  k_dim->z = 1;
+}
+
+void getDealNAndThresholdC(const int compute_data_bytes,
+                           const int target_data_bytes, const int total_c,
+                           int* deal_n_ptr, int* threshold_c_ptr,
+                           const bool has_weight, const bool is_half) {
+  /* NRAM partition:
+   *
+   * |-----------------ping pong---------------------|
+   * | input | pt | alpha_t | temp | output | target | flt_min | gamma |
+   * weight |
+   *
+   * split_pipeline_num is 5: including input, pt, alpha_t, temp, output.
+   */
+  const int nram_split_num = 5;
+  const int nram_split_pingpong = 2;
+  // const int max_nram_size = getDeviceAttr(cnrtAttrNramSizePerMcore);
+  const int max_nram_size = MAX_NRAM_SIZE;
+
+  int32_t compute_align_size = NFU_ALIGN_SIZE;
+  if (is_half) {
+    compute_align_size += NFU_ALIGN_SIZE;
+  }
+  const int32_t compute_align_num = compute_align_size / compute_data_bytes;
+  // reservered_align_size: including input(ping pong), pt(ping pong),
+  //                        alpha_t(ping pong), temp(ping pong), output(ping
+  //                        pong), target(ping pong), flt_min and gamma.
+  const int reservered_align_size =
+      ((nram_split_num + 1) * nram_split_pingpong + 2) * compute_align_size;
+  int nram_pingpong_size = max_nram_size - reservered_align_size;
+
+  int compute_c = total_c;
+  int threshold_c = 0;
+  if (has_weight) {
+    // reserved space for weight to align
+    nram_pingpong_size -= NFU_ALIGN_SIZE;
+
+    // threshold_c * nram_split_pingpong * compute_data_bytes *
+    // nram_split_num + nram_split_pingpong * target_data_bytes +
+    // threshold_c * compute_data_bytes <= nram_pingpong_size
+    threshold_c =
+        (nram_pingpong_size - nram_split_pingpong * target_data_bytes) /
+        (compute_data_bytes * (nram_split_num * nram_split_pingpong + 1));
+    threshold_c = PAD_DOWN(threshold_c, compute_align_num);
+    int weight_space = PAD_UP(total_c * compute_data_bytes, NFU_ALIGN_SIZE);
+
+    // reserved space for weight
+    nram_pingpong_size -= weight_space;
+    compute_c = PAD_UP(total_c, compute_align_num);
+  } else {
+    // threshold_c * nram_split_pingpong * compute_data_bytes *
+    // nram_split_num + nram_split_pingpong * target_data_bytes <=
+    // nram_pingpong_size
+    threshold_c =
+        (nram_pingpong_size / nram_split_pingpong - target_data_bytes) /
+        (nram_split_num * compute_data_bytes);
+  }
+  // deal_n * compute_c * nram_split_pingpong * compute_data_bytes *
+  // nram_split_num + deal_n * nram_split_pingpong * target_data_bytes <=
+  // nram_pingpong_size
+  *deal_n_ptr =
+      nram_pingpong_size /
+      ((nram_split_num * compute_c * compute_data_bytes + target_data_bytes) *
+       nram_split_pingpong);
+  *threshold_c_ptr = threshold_c;
+}
+
+void SigmoidFocalLossBackwardMLUKernelLauncher(
+    CambContext& ctx, const DArrayLite& input, const DArrayLite& target,
+    const DArrayLite& weight, DArrayLite& output, const float gamma,
+    const float alpha) {
+  // params check
+  PARROTS_CHECKARGS(gamma >= 0)
+      << "gamma should be greater than or equal to 0. "
+      << "But now gamma is " << gamma << ".";
+
+  // check dtype
+  PARROTS_CHECKARGS((input.elemType() == Prim::Float32) ||
+                    (input.elemType() == Prim::Float16))
+      << "Data type of input should be Float or Half. But now input type is "
+      << input.elemType() << ".";
+
+  PARROTS_CHECKARGS(target.elemType() == Prim::Int32 ||
+                    target.elemType() == Prim::Int64)
+      << "target type should be int 32 or int64. But now target type is "
+      << target.elemType() << ".";
+
+  PARROTS_CHECKARGS(output.elemType() == input.elemType())
+      << "Data types of input and output should be the same. But now input "
+         "type is "
+      << input.elemType() << ", output type is " << output.elemType() << ".";
+
+  bool has_weight = false;
+  // check weight
+  if (weight.size() > 0) {
+    PARROTS_CHECKARGS(weight.elemType() == input.elemType())
+        << "Data types of input and weight should be the same. But now "
+           "input type is "
+        << input.elemType() << ", weight type is " << weight.elemType() << ".";
+    has_weight = true;
+  }
+  const DArrayLite* target_ptr = &target;
+  DArrayLite target_tmp;
+  if (target.elemType() == Prim::Int64) {
+    target_tmp = ctx.createDArrayLite(target.spec().withElemType(Prim::Int32));
+    cast(ctx, target, target_tmp);
+    target_ptr = &target_tmp;
+  }
+
+  auto dim_c = input.dim(1);
+  const int compute_data_bytes = sizeof(float);
+  // target only supports INT on MLU device,
+  // while it keeps LONG on host side, so target.itemsize() / 2.
+  const int target_data_bytes = itemsize(target_ptr->elemType());
+
+  int deal_n = 0;
+  int threshold_c = 0;
+  bool is_half = false;
+  if (input.elemType() == Prim::Float16) {
+    is_half = true;
+  }
+  // calculate deal_n and threshold_c
+  getDealNAndThresholdC(compute_data_bytes, target_data_bytes, dim_c, &deal_n,
+                        &threshold_c, has_weight, is_half);
+
+  // check C
+  PARROTS_CHECKARGS(threshold_c >= dim_c)
+      << "input.dim(1) should be in the range of [0, " << threshold_c
+      << "], but now input.dim(1) is " << dim_c << ".";
+
+  if (input.size() == 0 || target_ptr->size() == 0 || output.size() == 0) {
+    // return if zero-element
+    return;
+  }
+
+  // set task dimension
+  cnrtDim3_t k_dim;
+  cnrtFunctionType_t k_type;
+  policyFunc(&k_dim, &k_type);
+
+  // get compute queue
+  auto queue = getStreamNative<CambDevice>(ctx.getStream());
+
+  // get ptr of tensors
+  auto weight_ptr = has_weight ? weight.data() : nullptr;
+
+  // get dtype of input
+  cnrtDataType_t d_type = getCnrtDataType(input.elemType());
+  auto core_dim = getDeviceAttr(cnrtAttrMcorePerCluster);
+  auto dim_n = input.dim(0);
+
+  // launch kernel
+  KernelFocalLossSigmoidBackward(k_dim, k_type, queue, d_type, input.data(),
+                                 target_ptr->data(), weight_ptr, gamma, alpha,
+                                 dim_n, deal_n, dim_c, output.data());
+}
+
+void sigmoid_focal_loss_backward_camb_parrots(
+    CambContext& ctx, const SSElement& attr, const OperatorBase::in_list_t& ins,
+    OperatorBase::out_list_t& outs) {
+  float gamma;
+  float alpha;
+  SSAttrs(attr).get<float>("gamma", gamma).get<float>("alpha", alpha).done();
+
+  // get inputs and outputs
+  const auto& input = ins[0];
+  const auto& target = ins[1];
+  const auto& weight = ins[2];
+
+  auto& grad_input = outs[0];
+
+  SigmoidFocalLossBackwardMLUKernelLauncher(ctx, input, target, weight,
+                                            grad_input, gamma, alpha);
+}
+
+PARROTS_EXTENSION_REGISTER(sigmoid_focal_loss_backward)
+    .attr("gamma")
+    .attr("alpha")
+    .input(3)
+    .output(1)
+    .apply(sigmoid_focal_loss_backward_camb_parrots)
+    .done();
+
+}  // namespace sigmoid_backeard
+
+#endif  // PARROTS_USE_CAMB

--- a/mmcv/ops/csrc/parrots/mlu/focal_loss_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/focal_loss_mlu.cpp
@@ -1,8 +1,7 @@
 #include <parrots/darray/darraymath.hpp>
+#include <parrots_mlu_helper.hpp>
 
-#include "parrots_mlu_helper.hpp"
-
-#ifdef PARROTS_USE_CAMB
+#include "parrots_focal_loss.h"
 
 using namespace parrots;
 
@@ -155,17 +154,9 @@ void sigmoid_focal_loss_forward_camb_parrots(CambContext& ctx,
                                            gamma, alpha);
 }
 
-PARROTS_EXTENSION_REGISTER(sigmoid_focal_loss_forward)
-    .attr("gamma")
-    .attr("alpha")
-    .input(3)
-    .output(1)
-    .apply(sigmoid_focal_loss_forward_camb_parrots)
-    .done();
-
 }  // namespace sigmoid_forward
 
-namespace sigmoid_backeard {
+namespace sigmoid_backward {
 
 // Policy Function
 static void policyFunc(cnrtDim3_t* k_dim, cnrtFunctionType_t* k_type) {
@@ -348,14 +339,10 @@ void sigmoid_focal_loss_backward_camb_parrots(
                                             grad_input, gamma, alpha);
 }
 
-PARROTS_EXTENSION_REGISTER(sigmoid_focal_loss_backward)
-    .attr("gamma")
-    .attr("alpha")
-    .input(3)
-    .output(1)
-    .apply(sigmoid_focal_loss_backward_camb_parrots)
-    .done();
+}  // namespace sigmoid_backward
 
-}  // namespace sigmoid_backeard
-
-#endif  // PARROTS_USE_CAMB
+REGISTER_DEVICE_IMPL(sigmoid_focal_loss_forward_impl, MLU, Arch::CAMB,
+                     sigmoid_forward::sigmoid_focal_loss_forward_camb_parrots);
+REGISTER_DEVICE_IMPL(
+    sigmoid_focal_loss_backward_impl, MLU, Arch::CAMB,
+    sigmoid_backward::sigmoid_focal_loss_backward_camb_parrots);

--- a/mmcv/ops/csrc/parrots/mlu/focal_loss_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/focal_loss_mlu.cpp
@@ -124,7 +124,6 @@ void sigmoidFocalLossForwardMLUKernelLauncher(
   cnrtDim3_t k_dim;
   cnrtFunctionType_t k_type = CNRT_FUNC_TYPE_UNION1;
   policyFunc(&k_dim, &k_type, input, *target_ptr, weight);
-  auto core_dim = getDeviceAttr(cnrtAttrMcorePerCluster);
 
   // get compute queue
   auto queue = getStreamNative<CambDevice>(ctx.getStream());
@@ -323,7 +322,6 @@ void SigmoidFocalLossBackwardMLUKernelLauncher(
 
   // get dtype of input
   cnrtDataType_t d_type = getCnrtDataType(input.elemType());
-  auto core_dim = getDeviceAttr(cnrtAttrMcorePerCluster);
   auto dim_n = input.dim(0);
 
   // launch kernel

--- a/mmcv/ops/csrc/parrots/mlu/nms_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/nms_mlu.cpp
@@ -4,22 +4,16 @@
 
 using namespace parrots;
 
-template <typename T>
-void nms_parrots(T& ctx, const SSElement& attr,
-                 const OperatorBase::in_list_t& ins,
-                 OperatorBase::out_list_t& outs) {}
-
-// #define USE_CPU_NMS
+#define USE_CPU_NMS
 
 #ifdef USE_CPU_NMS
 
 using at::Tensor;
 Tensor nms_cpu(Tensor boxes, Tensor scores, float iou_threshold, int offset);
 
-template <>
-void nms_parrots<HostContext>(HostContext& ctx, const SSElement& attr,
-                              const OperatorBase::in_list_t& ins,
-                              OperatorBase::out_list_t& outs) {
+void nms_parrots_cpu(HostContext &ctx, const SSElement &attr,
+                     const OperatorBase::in_list_t &ins,
+                     OperatorBase::out_list_t &outs) {
   float iou_threshold;
   int offset;
   SSAttrs(attr)
@@ -40,19 +34,74 @@ void nms_parrots<HostContext>(HostContext& ctx, const SSElement& attr,
 #ifdef PARROTS_USE_CAMB
 
 void KernelNms(cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
-               const cnrtDataType_t data_type_input, const void* boxes_ptr,
-               const void* scores_ptr, const int input_num_boxes,
-               const int max_output_boxes,
-               const float iou_threshold, const float offset,
-               void* workspace_ptr, void* output_size_ptr, void* output_ptr);
+               const cnrtDataType_t data_type_input, const void *boxes_ptr,
+               const void *scores_ptr, const int input_num_boxes,
+               const int max_output_boxes, const float iou_threshold,
+               const float offset, void *workspace_ptr, void *output_size_ptr,
+               void *output_ptr);
 
-void NMSMLUKernelLauncher(CambContext& ctx, const DArrayLite& boxes,
-                          const DArrayLite& scores, DArrayLite& output,
-                          const float iou_threshold, const int offset) {
-  if (boxes.size() == 0) {
-    output = ctx.createDArrayLite(boxes.spec().withElemType(Prim::Int64));
-    return;
+inline int32_t getJobLimitCapability() {
+  CNcontext drv_ctx;
+  TORCH_CHECK(CN_SUCCESS == cnCtxGetCurrent(&drv_ctx), "cnCtxGetCurrent fails");
+  CNctxConfigParam ctx_conf_param;
+  TORCH_CHECK(
+      CN_SUCCESS == cnGetCtxConfigParam(drv_ctx, CN_CTX_CONFIG_UNION_LIMIT,
+                                        &ctx_conf_param),
+      "cnGetCtxConfigParam fails.");
+  return (int32_t)ctx_conf_param.unionLimit;
+}
+
+int selectUnionType(uint32_t use_job, int box_num_per_core) {
+  // the box_num_per_core should be at least 256, otherwise the real IO
+  // bandwidth would be very low
+  while (box_num_per_core < 256 && use_job >= 4) {
+    box_num_per_core *= 2;
+    use_job /= 2;
   }
+  return use_job;
+}
+
+static cnnlStatus_t policyFunc(cnrtDim3_t *k_dim, cnrtFunctionType_t *k_type,
+                               const int input_box_num) {
+  uint32_t core_dim = getDeviceAttr(cnrtAttrMcorePerCluster);
+  uint32_t job_limit = getJobLimitCapability();
+  uint32_t core_number = job_limit;
+
+  int box_num_per_core = (input_box_num + core_number - 1) / core_number;
+  int use_job = selectUnionType(job_limit, box_num_per_core);
+  // initiate k_type as Union1
+  k_dim->x = core_dim;
+  k_dim->y = 1;
+  k_dim->z = 1;
+  *k_type = CNRT_FUNC_TYPE_UNION1;
+  switch (job_limit) {
+    case CN_KERNEL_CLASS_BLOCK:
+    case CN_KERNEL_CLASS_UNION:
+    case CN_KERNEL_CLASS_UNION2:
+    case CN_KERNEL_CLASS_UNION4:
+    case CN_KERNEL_CLASS_UNION8:
+    case CN_KERNEL_CLASS_UNION16: {
+      if (use_job < 4) {
+        k_dim->x = 1;
+        *k_type = CNRT_FUNC_TYPE_BLOCK;
+      } else if (use_job == 4) {
+        k_dim->x = core_dim;
+        *k_type = CNRT_FUNC_TYPE_UNION1;
+      } else {
+        k_dim->x = use_job;
+        *k_type = (cnrtFunctionType_t)use_job;
+      }
+    }; break;
+    default:
+      LOG(WARNING) << "[cnnlNms_v2]: got unsupported job limit number."
+                   << " Use default CN_KERNEL_CLASS_UNION1 with UNION1 task.";
+  }
+  return CNNL_STATUS_SUCCESS;
+}
+
+void NMSMLUKernelLauncher(CambContext &ctx, const DArrayLite &boxes,
+                          const DArrayLite &scores, DArrayLite &output,
+                          const float iou_threshold, const int offset) {
   // dimension parameters check
   PARROTS_CHECKARGS(boxes.ndims() == 2)
       << "boxes should be a 2d tensor, got " << boxes.ndims() << "D";
@@ -61,95 +110,106 @@ void NMSMLUKernelLauncher(CambContext& ctx, const DArrayLite& boxes,
   PARROTS_CHECKARGS(scores.ndims() == 1)
       << "scores should be a 1d tensor, got " << scores.ndims() << "D";
   // data type check
+  PARROTS_CHECKARGS(boxes.elemType() == scores.elemType())
+      << "boxes should have the same type as scores";
   PARROTS_CHECKARGS(boxes.elemType() == Prim::Float32 ||
                     boxes.elemType() == Prim::Float16)
       << "data type of boxes should be Float or Half, got " << boxes.elemType();
-  PARROTS_CHECKARGS(boxes.elemType() == scores.elemType())
-      << "boxes should have the same type as scores";
 
+  if (boxes.size() == 0) {
+    output = ctx.createDArrayLite(boxes.spec().withElemType(Prim::Int64));
+    return;
+  }
   int input_num_boxes = boxes.dim(0);
   int max_output_boxes = boxes.dim(0);
-  cnrtJobType_t k_type = CNRT_FUNC_TYPE_UNION1;
-  int core_dim = getDeviceAttr(cnrtAttrMcorePerCluster);
-  uint32_t dim_x = core_dim;
-  cnrtDim3_t k_dim = {dim_x, 1, 1};
+
   cnrtDataType_t data_type_input = getCnrtDataType(boxes.elemType());
+  cnrtDim3_t k_dim;
+  cnrtJobType_t k_type;
+  policyFunc(&k_dim, &k_type, input_num_boxes);
+
+  // transpose boxes (n, 4) to (4, n) for better performance
+  DArrayLite boxes_tmp = t(ctx, boxes);
+  DArrayLite scores_tmp = scores;
+  if (!boxes_tmp.isContiguous()) {
+    boxes_tmp = ctx.cloneDArrayLite(boxes_tmp);
+  }
+  if (!scores_tmp.isContiguous()) {
+    scores_tmp = ctx.cloneDArrayLite(scores_tmp);
+  }
 
   DArrayLite output_tmp =
-      ctx.createDArrayLite(boxes.spec()
-                               .withElemType(Prim::Int32)
+      ctx.createDArrayLite(boxes_tmp.spec()
+                               .withElemType(Prim::Int64)
                                .withShape(DArrayShape(max_output_boxes)));
   DArrayLite output_size = ctx.createDArrayLite(
-      scores.spec().withElemType(Prim::Int32).withShape(DArrayShape(1)));
+      scores_tmp.spec().withElemType(Prim::Int32).withShape(DArrayShape(1)));
 
   // workspace
   size_t space_size = 0;
-  if (boxes.elemType() == Prim::Float16) {
-    space_size = input_num_boxes * sizeof(int16_t);
+  const int info_num = 5;  // x1, x2, y1, y2 and score
+  if (boxes_tmp.elemType() == Prim::Float16) {
+    space_size = input_num_boxes * sizeof(int16_t) * info_num + sizeof(float);
   } else {
-    space_size = input_num_boxes * sizeof(float);
+    space_size = input_num_boxes * sizeof(float) * info_num + sizeof(float);
   }
   auto workspace = ctx.createDArrayLite(DArraySpec::bytes(space_size));
 
   // get compute queue
   auto queue = getStreamNative<CambDevice>(ctx.getStream());
-
-  switch (k_type) {
-    default: {
-      PARROTS_CHECKARGS(false) << "[nms_mlu]:Failed to choose kernel to launch";
-    }
-    case CNRT_FUNC_TYPE_BLOCK:
-    case CNRT_FUNC_TYPE_UNION1: {
-      KernelNms(k_dim, k_type, queue, data_type_input, boxes.data(),
-                scores.data(), input_num_boxes, max_output_boxes,
-                iou_threshold, offset, workspace.data(), output_size.data(),
-                output_tmp.data());
-    }; break;
-  }
+  KernelNms(k_dim, k_type, queue, data_type_input, boxes_tmp.data(),
+            scores_tmp.data(), input_num_boxes, max_output_boxes, iou_threshold,
+            offset, workspace.data(), output_size.data(), output_tmp.data());
 
   int output_num = 0;
   PARROTS_CALLCNRT(cnrtMemcpyAsync(&output_num, output_size.data(), sizeof(int),
                                    queue, cnrtMemcpyDevToHost));
-
-  PARROTS_CALLCNRT(cnrtSyncQueue(queue));
-  DArrayLite output32 = ctx.createDArrayLite(boxes.spec()
-                                    .withElemType(Prim::Int32)
-                                    .withShape(DArrayShape(output_num)));
-  output = ctx.createDArrayLite(boxes.spec()
+  // since we need to copy then, synchronize here
+  ctx.getStream().synchronize();
+  DArrayLite output32 =
+      ctx.createDArrayLite(boxes_tmp.spec()
+                               .withElemType(Prim::Int32)
+                               .withShape(DArrayShape(output_num)));
+  output = ctx.createDArrayLite(boxes_tmp.spec()
                                     .withElemType(Prim::Int64)
                                     .withShape(DArrayShape(output_num)));
   PARROTS_CALLCNRT(cnrtMemcpyAsync(output32.data(), output_tmp.data(),
-                                   output32.nbytes(), queue, cnrtMemcpyDevToDev));
+                                   output32.nbytes(), queue,
+                                   cnrtMemcpyDevToDev));
   cast(ctx, output32, output);
 }
 
-template <>
-void nms_parrots<CambContext>(CambContext& ctx, const SSElement& attr,
-                              const OperatorBase::in_list_t& ins,
-                              OperatorBase::out_list_t& outs) {
+void nms_parrots_device(CambContext &ctx, const SSElement &attr,
+                        const OperatorBase::in_list_t &ins,
+                        OperatorBase::out_list_t &outs) {
   float iou_threshold;
   int offset;
   SSAttrs(attr)
       .get("iou_threshold", iou_threshold)
       .get("offset", offset)
       .done();
-  const auto& boxes = ins[0];
-  const auto& scores = ins[1];
-  auto& out = outs[0];
+  const auto &boxes = ins[0];
+  const auto &scores = ins[1];
+  auto &out = outs[0];
   NMSMLUKernelLauncher(ctx, boxes, scores, out, iou_threshold, offset);
   return;
 }
 #endif  //  PARROTS_USE_CAMB
+
+void nms_parrots(Context &ctx, const SSElement &attr,
+                 const OperatorBase::in_list_t &ins,
+                 OperatorBase::out_list_t &outs) {
+  if (ctx.getProxy().arch() == parrots::hostArch()) {
+    nms_parrots_cpu(ctx, attr, ins, outs);
+  } else {
+    nms_parrots_device(ctx, attr, ins, outs);
+  }
+}
 
 PARROTS_EXTENSION_REGISTER(nms)
     .attr("iou_threshold")
     .attr("offset")
     .input(2)
     .output(1)
-#ifdef USE_CPU_NMS
-    .apply(nms_parrots<HostContext>)
-#endif
-#ifdef PARROTS_USE_CAMB
-    .apply(nms_parrots<CambContext>)
-#endif
+    .apply(nms_parrots)
     .done();

--- a/mmcv/ops/csrc/parrots/mlu/nms_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/nms_mlu.cpp
@@ -8,7 +8,7 @@ void nms_parrots(T& ctx, const SSElement& attr,
                  const OperatorBase::in_list_t& ins,
                  OperatorBase::out_list_t& outs) {}
 
-#define USE_CPU_NMS
+// #define USE_CPU_NMS
 
 #ifdef USE_CPU_NMS
 

--- a/mmcv/ops/csrc/parrots/mlu/nms_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/nms_mlu.cpp
@@ -1,0 +1,151 @@
+#include <parrots/compute/aten.hpp>
+#include <parrots_mlu_helper.hpp>
+
+using namespace parrots;
+
+template <typename T>
+void nms_parrots(T& ctx, const SSElement& attr,
+                 const OperatorBase::in_list_t& ins,
+                 OperatorBase::out_list_t& outs) {}
+
+#define USE_CPU_NMS
+
+#ifdef USE_CPU_NMS
+
+using at::Tensor;
+Tensor nms_cpu(Tensor boxes, Tensor scores, float iou_threshold, int offset);
+
+template <>
+void nms_parrots<HostContext>(HostContext& ctx, const SSElement& attr,
+                              const OperatorBase::in_list_t& ins,
+                              OperatorBase::out_list_t& outs) {
+  float iou_threshold;
+  int offset;
+  SSAttrs(attr)
+      .get("iou_threshold", iou_threshold)
+      .get("offset", offset)
+      .done();
+
+  at::Tensor boxes, scores;
+  boxes = buildATensor(ctx, ins[0]);
+  scores = buildATensor(ctx, ins[1]);
+  auto out = nms_cpu(boxes, scores, iou_threshold, offset);
+  updateDArray(ctx, out, outs[0]);
+  return;
+}
+
+#endif  // USE_CPU_NMS
+
+#ifdef PARROTS_USE_CAMB
+
+void KernelNms(cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+               const cnrtDataType_t data_type_input, const void* boxes_ptr,
+               const void* scores_ptr, const int input_num_boxes,
+               const int input_stride, const int max_output_boxes,
+               const float iou_threshold, const float offset,
+               void* workspace_ptr, void* output_size_ptr, void* output_ptr);
+
+void NMSMLUKernelLauncher(CambContext& ctx, const DArrayLite& boxes,
+                          const DArrayLite& scores, DArrayLite& output,
+                          const float iou_threshold, const int offset) {
+  if (boxes.size() == 0) {
+    output = ctx.createDArrayLite(boxes.spec().withElemType(Prim::Int32));
+    return;
+  }
+  // dimension parameters check
+  PARROTS_CHECKARGS(boxes.ndims() == 2)
+      << "boxes should be a 2d tensor, got " << boxes.ndims() << "D";
+  PARROTS_CHECKARGS(boxes.dim(1) == 4)
+      << "boxes should have 4 elements in dimension 1, got " << boxes.dim(1);
+  PARROTS_CHECKARGS(scores.ndims() == 1)
+      << "scores should be a 1d tensor, got " << scores.ndims() << "D";
+  // data type check
+  PARROTS_CHECKARGS(boxes.elemType() == Prim::Float32 ||
+                    boxes.elemType() == Prim::Float16)
+      << "data type of boxes should be Float or Half, got " << boxes.elemType();
+  PARROTS_CHECKARGS(boxes.elemType() == scores.elemType())
+      << "boxes should have the same type as scores";
+
+  int input_num_boxes = boxes.dim(0);
+  int input_stride = boxes.dim(1);
+  int max_output_boxes = boxes.dim(0);
+  cnrtJobType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  int core_dim = getDeviceAttr(cnrtAttrMcorePerCluster);
+  uint32_t dim_x = core_dim;
+  cnrtDim3_t k_dim = {dim_x, 1, 1};
+  cnrtDataType_t data_type_input = getCnrtDataType(boxes.elemType());
+
+  DArrayLite output_tmp =
+      ctx.createDArrayLite(boxes.spec()
+                               .withElemType(Prim::Int32)
+                               .withShape(DArrayShape(max_output_boxes)));
+  DArrayLite output_size = ctx.createDArrayLite(
+      scores.spec().withElemType(Prim::Int32).withShape(DArrayShape(1)));
+
+  // workspace
+  size_t space_size = 0;
+  if (boxes.elemType() == Prim::Float16) {
+    space_size = input_num_boxes * sizeof(int16_t);
+  } else {
+    space_size = input_num_boxes * sizeof(float);
+  }
+  auto workspace = ctx.createDArrayLite(DArraySpec::bytes(space_size));
+
+  // get compute queue
+  auto queue = getStreamNative<CambDevice>(ctx.getStream());
+
+  switch (k_type) {
+    default: {
+      PARROTS_CHECKARGS(false) << "[nms_mlu]:Failed to choose kernel to launch";
+    }
+    case CNRT_FUNC_TYPE_BLOCK:
+    case CNRT_FUNC_TYPE_UNION1: {
+      KernelNms(k_dim, k_type, queue, data_type_input, boxes.data(),
+                scores.data(), input_num_boxes, input_stride, max_output_boxes,
+                iou_threshold, offset, workspace.data(), output_size.data(),
+                output_tmp.data());
+    }; break;
+  }
+
+  int output_num = 0;
+  PARROTS_CALLCNRT(cnrtMemcpyAsync(&output_num, output_size.data(), sizeof(int),
+                                   queue, cnrtMemcpyDevToHost));
+
+  PARROTS_CALLCNRT(cnrtSyncQueue(queue));
+  output = ctx.createDArrayLite(boxes.spec()
+                                    .withElemType(Prim::Int32)
+                                    .withShape(DArrayShape(output_num)));
+  PARROTS_CALLCNRT(cnrtMemcpyAsync(output.data(), output_tmp.data(),
+                                   output.nbytes(), queue, cnrtMemcpyDevToDev));
+}
+
+template <>
+void nms_parrots<CambContext>(CambContext& ctx, const SSElement& attr,
+                              const OperatorBase::in_list_t& ins,
+                              OperatorBase::out_list_t& outs) {
+  float iou_threshold;
+  int offset;
+  SSAttrs(attr)
+      .get("iou_threshold", iou_threshold)
+      .get("offset", offset)
+      .done();
+  const auto& boxes = ins[0];
+  const auto& scores = ins[1];
+  auto& out = outs[0];
+  NMSMLUKernelLauncher(ctx, boxes, scores, out, iou_threshold, offset);
+  return;
+}
+#endif  //  PARROTS_USE_CAMB
+
+PARROTS_EXTENSION_REGISTER(nms)
+    .attr("iou_threshold")
+    .attr("offset")
+    .input(2)
+    .output(1)
+#ifdef USE_CPU_NMS
+    .apply(nms_parrots<HostContext>)
+#endif
+#ifdef PARROTS_USE_CAMB
+    .apply(nms_parrots<CambContext>)
+#endif
+    .done();

--- a/mmcv/ops/csrc/parrots/mlu/nms_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/nms_mlu.cpp
@@ -42,7 +42,7 @@ void nms_parrots<HostContext>(HostContext& ctx, const SSElement& attr,
 void KernelNms(cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
                const cnrtDataType_t data_type_input, const void* boxes_ptr,
                const void* scores_ptr, const int input_num_boxes,
-               const int input_stride, const int max_output_boxes,
+               const int max_output_boxes,
                const float iou_threshold, const float offset,
                void* workspace_ptr, void* output_size_ptr, void* output_ptr);
 
@@ -68,7 +68,6 @@ void NMSMLUKernelLauncher(CambContext& ctx, const DArrayLite& boxes,
       << "boxes should have the same type as scores";
 
   int input_num_boxes = boxes.dim(0);
-  int input_stride = boxes.dim(1);
   int max_output_boxes = boxes.dim(0);
   cnrtJobType_t k_type = CNRT_FUNC_TYPE_UNION1;
   int core_dim = getDeviceAttr(cnrtAttrMcorePerCluster);
@@ -102,7 +101,7 @@ void NMSMLUKernelLauncher(CambContext& ctx, const DArrayLite& boxes,
     case CNRT_FUNC_TYPE_BLOCK:
     case CNRT_FUNC_TYPE_UNION1: {
       KernelNms(k_dim, k_type, queue, data_type_input, boxes.data(),
-                scores.data(), input_num_boxes, input_stride, max_output_boxes,
+                scores.data(), input_num_boxes, max_output_boxes,
                 iou_threshold, offset, workspace.data(), output_size.data(),
                 output_tmp.data());
     }; break;

--- a/mmcv/ops/csrc/parrots/mlu/roi_align_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/roi_align_mlu.cpp
@@ -261,8 +261,7 @@ void ROIAlignBackwardMLUKernelLauncher(
         DArrayShape(batch_size, channels, height, width),
         MemoryFormat::ChannelsLast));
     grad_input_ptr = &grad_input_;
-    PARROTS_CALLCNRT(
-        cnrtMemset(grad_input_ptr->data(), 0, grad_input_ptr->nbytes()));
+    fill(ctx, grad_input_, 0);
   }
 
   cnrtJobType_t k_type = CNRT_FUNC_TYPE_UNION1;

--- a/mmcv/ops/csrc/parrots/mlu/roi_align_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/roi_align_mlu.cpp
@@ -1,0 +1,358 @@
+// Copyright (c) OpenMMLab. All rights reserved
+#include <parrots/compute/aten.hpp>
+#include <parrots/darray/darraymath.hpp>
+#include <parrots/foundation/darrayutil.hpp>
+#include <parrots_mlu_helper.hpp>
+using namespace parrots;
+
+#define USE_CPU_ROI_ALIGN
+
+#ifdef USE_CPU_ROI_ALIGN
+using at::Tensor;
+void ROIAlignForwardCPULauncher(Tensor input, Tensor rois, Tensor output,
+                                Tensor argmax_y, Tensor argmax_x,
+                                int aligned_height, int aligned_width,
+                                float spatial_scale, int sampling_ratio,
+                                int pool_mode, bool aligned);
+
+void ROIAlignBackwardCPULauncher(Tensor grad_output, Tensor rois,
+                                 Tensor argmax_y, Tensor argmax_x,
+                                 Tensor grad_input, int aligned_height,
+                                 int aligned_width, float spatial_scale,
+                                 int sampling_ratio, int pool_mode,
+                                 bool aligned);
+
+void roi_align_forward_cpu_parrots(HostContext& ctx, const SSElement& attr,
+                                   const OperatorBase::in_list_t& ins,
+                                   OperatorBase::out_list_t& outs) {
+  int aligned_height;
+  int aligned_width;
+  float spatial_scale;
+  int sampling_ratio;
+  int pool_mode;
+  bool aligned;
+  SSAttrs(attr)
+      .get<int>("aligned_height", aligned_height)
+      .get<int>("aligned_width", aligned_width)
+      .get<float>("spatial_scale", spatial_scale)
+      .get<int>("sampling_ratio", sampling_ratio)
+      .get<int>("pool_mode", pool_mode)
+      .get<bool>("aligned", aligned)
+      .done();
+
+  const auto& input = buildATensor(ctx, ins[0]);
+  const auto& rois = buildATensor(ctx, ins[1]);
+  auto output = buildATensor(ctx, outs[0]);
+  auto argmax_y = buildATensor(ctx, outs[1]);
+  auto argmax_x = buildATensor(ctx, outs[2]);
+
+  ROIAlignForwardCPULauncher(input, rois, output, argmax_y, argmax_x,
+                             aligned_height, aligned_width, spatial_scale,
+                             sampling_ratio, pool_mode, aligned);
+}
+
+void roi_align_backward_cpu_parrots(HostContext& ctx, const SSElement& attr,
+                                    const OperatorBase::in_list_t& ins,
+                                    OperatorBase::out_list_t& outs) {
+  int aligned_height;
+  int aligned_width;
+  float spatial_scale;
+  int sampling_ratio;
+  int pool_mode;
+  bool aligned;
+  SSAttrs(attr)
+      .get<int>("aligned_height", aligned_height)
+      .get<int>("aligned_width", aligned_width)
+      .get<float>("spatial_scale", spatial_scale)
+      .get<int>("sampling_ratio", sampling_ratio)
+      .get<int>("pool_mode", pool_mode)
+      .get<bool>("aligned", aligned)
+      .done();
+
+  const auto& grad_output = buildATensor(ctx, ins[0]);
+  const auto& rois = buildATensor(ctx, ins[1]);
+  const auto& argmax_y = buildATensor(ctx, ins[2]);
+  const auto& argmax_x = buildATensor(ctx, ins[3]);
+  auto grad_input = buildATensor(ctx, outs[0]);
+  ROIAlignBackwardCPULauncher(grad_output, rois, argmax_y, argmax_x, grad_input,
+                              aligned_height, aligned_width, spatial_scale,
+                              sampling_ratio, pool_mode, aligned);
+}
+
+#endif  // USE_CPU_ROI_ALIGN
+
+#ifdef PARROTS_USE_CAMB
+
+void KernelRoiAlign(cnrtDim3_t k_dim, cnrtFunctionType_t k_type,
+                    cnrtQueue_t queue, const cnrtDataType_t d_type,
+                    const void* input, const void* rois, const int channels,
+                    const bool aligned, const int pooled_height,
+                    const int pooled_width, const int input_height,
+                    const int input_width, const int sampling_ratio,
+                    const float spatial_scale, const int num_rois,
+                    void* output);
+
+void KernelRoiAlignBackward(cnrtDim3_t k_dim, cnrtFunctionType_t k_type,
+                            cnrtQueue_t queue, const cnrtDataType_t dtype,
+                            const void* grads, const void* boxes,
+                            void* grads_image, const int boxes_num,
+                            const int hi, const int wi, const int c,
+                            const int no, const int ho, const int wo,
+                            const float spatial_scale, const int sampling_ratio,
+                            const bool aligned);
+
+namespace roi_align_forward {
+
+void ROIAlignForwardMLUKernelLauncher(CambContext& ctx, const DArrayLite& input,
+                                      const DArrayLite& rois,
+                                      DArrayLite& output, DArrayLite& argmax_y,
+                                      DArrayLite& argmax_x, int aligned_height,
+                                      int aligned_width, float spatial_scale,
+                                      int sampling_ratio, int pool_mode,
+                                      bool aligned) {
+  // params check
+  PARROTS_CHECKARGS(input.elemType() == Prim::Float32 ||
+                    input.elemType() == Prim::Float16)
+      << "input type should be Float or Half, bug got " << input.elemType();
+  PARROTS_CHECKARGS(rois.elemType() == input.elemType())
+      << "rois should have the same type as input, bug got" << rois.elemType()
+      << input.elemType();
+  PARROTS_CHECKARGS(input.ndims() == 4)
+      << "input should be a 4d tensor, got " << input.ndims() << "D";
+  PARROTS_CHECKARGS(rois.ndims() == 2)
+      << "rois should be a 2d tensor, got " << rois.ndims() << "D";
+  PARROTS_CHECKARGS(pool_mode == 1)
+      << "pool_mode only suppurts 'avg' currently";
+  PARROTS_CHECKARGS(output.size() > 0) << "output should not be empty";
+
+  const auto num_rois = rois.dim(0);
+  const auto channels = input.dim(1);
+  const int height = input.dim(2);
+  const int width = input.dim(3);
+
+  const DArrayLite* input_ptr = &input;
+  const DArrayLite* output_ptr = &output;
+  DArrayLite input_tmp;
+  DArrayLite output_tmp;
+  const auto input_memformat = input.spec().probableMemoryFormat();
+  if (input_memformat != MemoryFormat::ChannelsLast) {
+    input_tmp = ctx.createDArrayLite(
+        input.spec().duplicate(MemoryFormat::ChannelsLast));
+    copy(ctx, input_tmp, input);
+    input_ptr = &input_tmp;
+  }
+  if (output.spec().probableMemoryFormat() != MemoryFormat::ChannelsLast) {
+    output_tmp = ctx.createDArrayLite(
+        input.spec()
+            .withShape(
+                DArrayShape(num_rois, channels, aligned_height, aligned_width))
+            .duplicate(MemoryFormat::ChannelsLast));
+    output_ptr = &output_tmp;
+  }
+
+  auto queue = getStreamNative<CambDevice>(ctx.getStream());
+
+  cnrtDim3_t k_dim;
+  cnrtJobType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  k_dim.x = getDeviceAttr(cnrtAttrMcorePerCluster);
+  k_dim.y = getDeviceAttr(cnrtAttrClusterCount);
+  k_dim.z = 1;
+  cnrtDataType_t data_type = getCnrtDataType(input.elemType());
+
+  KernelRoiAlign(k_dim, k_type, queue, data_type, (void*)input_ptr->data(),
+                 rois.data(), channels, aligned, aligned_height, aligned_width,
+                 height, width, sampling_ratio, spatial_scale, num_rois,
+                 (void*)output_ptr->data());
+#if 1
+  if (output_tmp.size() > 0) {
+    copy(ctx, output, output_tmp);
+  }
+#endif
+}
+
+void roi_align_forward_camb_parrots(CambContext& ctx, const SSElement& attr,
+                                    const OperatorBase::in_list_t& ins,
+                                    OperatorBase::out_list_t& outs) {
+  int aligned_height;
+  int aligned_width;
+  float spatial_scale;
+  int sampling_ratio;
+  int pool_mode;
+  bool aligned;
+  SSAttrs(attr)
+      .get<int>("aligned_height", aligned_height)
+      .get<int>("aligned_width", aligned_width)
+      .get<float>("spatial_scale", spatial_scale)
+      .get<int>("sampling_ratio", sampling_ratio)
+      .get<int>("pool_mode", pool_mode)
+      .get<bool>("aligned", aligned)
+      .done();
+
+  const auto& input = ins[0];
+  const auto& rois = ins[1];
+  auto& output = outs[0];
+  auto& argmax_y = outs[1];
+  auto& argmax_x = outs[2];
+  ROIAlignForwardMLUKernelLauncher(ctx, input, rois, output, argmax_y, argmax_x,
+                                   aligned_height, aligned_width, spatial_scale,
+                                   sampling_ratio, pool_mode, aligned);
+}
+
+}  //  namespace roi_align_forward
+
+namespace roi_align_backward {
+static int nearestPower2(int x) {
+  x--;
+  x |= x >> 1;
+  x |= x >> 2;
+  x |= x >> 4;
+  x |= x >> 8;
+  x |= x >> 16;
+  x++;
+  return x;
+}
+
+void ROIAlignBackwardMLUKernelLauncher(
+    CambContext& ctx, const DArrayLite& grad, const DArrayLite& rois,
+    const DArrayLite& argmax_y, const DArrayLite& argmax_x,
+    DArrayLite& grad_input, int aligned_height, int aligned_width,
+    float spatial_scale, int sampling_ratio, int pool_mode, bool aligned) {
+  // params check
+  PARROTS_CHECKARGS(grad.elemType() == Prim::Float16 ||
+                    grad.elemType() == Prim::Float32)
+      << "grad type should be Float or Half, got " << grad.elemType();
+  PARROTS_CHECKARGS(rois.elemType() == grad.elemType())
+      << "rois should have the same type as grad";
+  PARROTS_CHECKARGS(grad.ndims() == 4)
+      << "grad should be a 4D tensor, got " << grad.ndims() << "D";
+  PARROTS_CHECKARGS(rois.ndims() == 2)
+      << "rois should be a 2D tensor, got " << rois.ndims() << "D";
+  PARROTS_CHECKARGS(pool_mode == 1)
+      << "pool_mode only suppurts 'avg' currently";
+  PARROTS_CHECKARGS(grad_input.size() > 0) << "grad_input should not be empty";
+
+  const int batch_size = grad_input.dim(0);
+  const int channels = grad_input.dim(1);
+  const int height = grad_input.dim(2);
+  const int width = grad_input.dim(3);
+
+  const int boxes_num = rois.dim(0);
+  const int c = grad.dim(1);
+  const int hi = grad.dim(2);
+  const int wi = grad.dim(3);
+
+  const int no = grad_input.dim(0);
+  const int ho = grad_input.dim(2);
+  const int wo = grad_input.dim(3);
+
+  const DArrayLite* grad_ptr = &grad;
+  DArrayLite grad_tmp;
+  if (grad.spec().probableMemoryFormat() != MemoryFormat::ChannelsLast) {
+    grad_tmp =
+        ctx.createDArrayLite(grad.spec().duplicate(MemoryFormat::ChannelsLast));
+    copy(ctx, grad_tmp, grad);
+    grad_ptr = &grad_tmp;
+  }
+
+  DArrayLite* grad_input_ptr = &grad_input;
+  DArrayLite grad_input_;
+  if (grad.spec().probableMemoryFormat() != MemoryFormat::ChannelsLast) {
+    grad_input_ = ctx.createDArrayLite(grad_input.spec().withShape(
+        DArrayShape(batch_size, channels, height, width),
+        MemoryFormat::ChannelsLast));
+    grad_input_ptr = &grad_input_;
+    PARROTS_CALLCNRT(
+        cnrtMemset(grad_input_ptr->data(), 0, grad_input_ptr->nbytes()));
+  }
+
+  cnrtJobType_t k_type = CNRT_FUNC_TYPE_UNION1;
+  int need_core = nearestPower2(boxes_num);
+  int union_number = getDeviceAttr(cnrtAttrClusterCount);
+  uint32_t dim_x = getDeviceAttr(cnrtAttrMcorePerCluster);
+  uint32_t dim_y = (need_core - 1) / dim_x + 1;
+  dim_y = (dim_y > union_number) ? union_number : dim_y;
+  cnrtDim3_t k_dim = {dim_x, dim_y, 1};
+  cnrtDataType_t k_dtype = getCnrtDataType(grad.elemType());
+  auto queue = getStreamNative<CambDevice>(ctx.getStream());
+
+  KernelRoiAlignBackward(
+      k_dim, k_type, queue, k_dtype, const_cast<void*>(grad_ptr->data()),
+      const_cast<void*>(rois.data()), grad_input_ptr->data(), boxes_num, hi, wi,
+      c, no, ho, wo, spatial_scale, sampling_ratio, aligned);
+  if (grad_input_.size() > 0) {
+    if (grad_input.size() <= 0) {
+      if (grad.spec().probableMemoryFormat() == MemoryFormat::Contiguous) {
+        grad_input = ctx.createDArrayLite(grad_input_);
+      } else {
+        grad_input = grad_input_;
+      }
+    } else {
+      copy(ctx, grad_input, grad_input_);
+    }
+  }
+}
+
+void roi_align_backward_camb_parrots(CambContext& ctx, const SSElement& attr,
+                                     const OperatorBase::in_list_t& ins,
+                                     OperatorBase::out_list_t& outs) {
+  int aligned_height;
+  int aligned_width;
+  float spatial_scale;
+  int sampling_ratio;
+  int pool_mode;
+  bool aligned;
+  SSAttrs(attr)
+      .get<int>("aligned_height", aligned_height)
+      .get<int>("aligned_width", aligned_width)
+      .get<float>("spatial_scale", spatial_scale)
+      .get<int>("sampling_ratio", sampling_ratio)
+      .get<int>("pool_mode", pool_mode)
+      .get<bool>("aligned", aligned)
+      .done();
+  const auto& grad_output = ins[0];
+  const auto& rois = ins[1];
+  const auto& argmax_y = ins[2];
+  const auto& argmax_x = ins[3];
+  auto& grad_input = outs[0];
+  ROIAlignBackwardMLUKernelLauncher(
+      ctx, grad_output, rois, argmax_y, argmax_x, grad_input, aligned_height,
+      aligned_width, spatial_scale, sampling_ratio, pool_mode, aligned);
+}
+
+}  //  namespace roi_align_backward
+
+#endif  //  PARROTS_USE_CAMB
+
+PARROTS_EXTENSION_REGISTER(roi_align_forward)
+    .attr("aligned_height")
+    .attr("aligned_width")
+    .attr("spatial_scale")
+    .attr("sampling_ratio")
+    .attr("pool_mode")
+    .attr("aligned")
+    .input(2)
+    .output(3)
+#ifdef USE_CPU_ROI_ALIGN
+    .apply(roi_align_forward_cpu_parrots)
+#endif
+#ifdef PARROTS_USE_CAMB
+    .apply(roi_align_forward::roi_align_forward_camb_parrots)
+#endif
+    .done();
+
+PARROTS_EXTENSION_REGISTER(roi_align_backward)
+    .attr("aligned_height")
+    .attr("aligned_width")
+    .attr("spatial_scale")
+    .attr("sampling_ratio")
+    .attr("pool_mode")
+    .attr("aligned")
+    .input(4)
+    .output(1)
+#ifdef USE_CPU_ROI_ALIGN
+    .apply(roi_align_backward_cpu_parrots)
+#endif
+#ifdef PARROTS_USE_CAMB
+    .apply(roi_align_backward::roi_align_backward_camb_parrots)
+#endif
+    .done();

--- a/mmcv/ops/csrc/parrots/mlu/roi_align_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/roi_align_mlu.cpp
@@ -83,6 +83,7 @@ void ROIAlignForwardMLUKernelLauncher(CambContext& ctx, const DArrayLite& input,
                  rois.data(), channels, aligned, aligned_height, aligned_width,
                  height, width, sampling_ratio, spatial_scale, num_rois,
                  (void*)output_ptr->data());
+  copy(ctx, output, output_tmp);
 }
 
 void roi_align_forward_camb_parrots(CambContext& ctx, const SSElement& attr,

--- a/mmcv/ops/csrc/parrots/mlu/roi_align_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/roi_align_mlu.cpp
@@ -5,7 +5,7 @@
 #include <parrots_mlu_helper.hpp>
 using namespace parrots;
 
-#define USE_CPU_ROI_ALIGN
+// #define USE_CPU_ROI_ALIGN
 
 #ifdef USE_CPU_ROI_ALIGN
 using at::Tensor;

--- a/mmcv/ops/csrc/parrots/mlu/roi_align_mlu.cpp
+++ b/mmcv/ops/csrc/parrots/mlu/roi_align_mlu.cpp
@@ -83,11 +83,6 @@ void ROIAlignForwardMLUKernelLauncher(CambContext& ctx, const DArrayLite& input,
                  rois.data(), channels, aligned, aligned_height, aligned_width,
                  height, width, sampling_ratio, spatial_scale, num_rois,
                  (void*)output_ptr->data());
-#if 1
-  if (output_tmp.size() > 0) {
-    copy(ctx, output, output_tmp);
-  }
-#endif
 }
 
 void roi_align_forward_camb_parrots(CambContext& ctx, const SSElement& attr,

--- a/mmcv/parallel/distributed.py
+++ b/mmcv/parallel/distributed.py
@@ -41,14 +41,14 @@ class MMDistributedDataParallel(DistributedDataParallel):
 
         # In PyTorch >= 1.7, ``reducer._rebuild_buckets()`` is moved from the
         # end of backward to the beginning of forward.
-        if ('parrots' not in TORCH_VERSION
+        if ('parrots' != TORCH_VERSION
                 and digit_version(TORCH_VERSION) >= digit_version('1.7')
                 and self.reducer._rebuild_buckets()):
             print_log(
                 'Reducer buckets have been rebuilt in this iteration.',
                 logger='mmcv')
 
-        if ('parrots' not in TORCH_VERSION
+        if ('parrots' != TORCH_VERSION
                 and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
             if self._check_sync_bufs_pre_fwd():
                 self._sync_buffers()
@@ -68,7 +68,7 @@ class MMDistributedDataParallel(DistributedDataParallel):
         else:
             output = self.module.train_step(*inputs, **kwargs)
 
-        if ('parrots' not in TORCH_VERSION
+        if ('parrots' != TORCH_VERSION
                 and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
             if self._check_sync_bufs_post_fwd():
                 self._sync_buffers()
@@ -81,7 +81,7 @@ class MMDistributedDataParallel(DistributedDataParallel):
             else:
                 self.reducer.prepare_for_backward([])
         else:
-            if ('parrots' not in TORCH_VERSION
+            if ('parrots' != TORCH_VERSION
                     and digit_version(TORCH_VERSION) > digit_version('1.2')):
                 self.require_forward_param_sync = False
         return output
@@ -96,14 +96,14 @@ class MMDistributedDataParallel(DistributedDataParallel):
         """
         # In PyTorch >= 1.7, ``reducer._rebuild_buckets()`` is moved from the
         # end of backward to the beginning of forward.
-        if ('parrots' not in TORCH_VERSION
+        if ('parrots' != TORCH_VERSION
                 and digit_version(TORCH_VERSION) >= digit_version('1.7')
                 and self.reducer._rebuild_buckets()):
             print_log(
                 'Reducer buckets have been rebuilt in this iteration.',
                 logger='mmcv')
 
-        if ('parrots' not in TORCH_VERSION
+        if ('parrots' != TORCH_VERSION
                 and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
             if self._check_sync_bufs_pre_fwd():
                 self._sync_buffers()
@@ -123,7 +123,7 @@ class MMDistributedDataParallel(DistributedDataParallel):
         else:
             output = self.module.val_step(*inputs, **kwargs)
 
-        if ('parrots' not in TORCH_VERSION
+        if ('parrots' != TORCH_VERSION
                 and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
             if self._check_sync_bufs_post_fwd():
                 self._sync_buffers()
@@ -136,7 +136,7 @@ class MMDistributedDataParallel(DistributedDataParallel):
             else:
                 self.reducer.prepare_for_backward([])
         else:
-            if ('parrots' not in TORCH_VERSION
+            if ('parrots' != TORCH_VERSION
                     and digit_version(TORCH_VERSION) > digit_version('1.2')):
                 self.require_forward_param_sync = False
         return output

--- a/mmcv/utils/__init__.py
+++ b/mmcv/utils/__init__.py
@@ -37,7 +37,7 @@ except ImportError:
     ]
 else:
     from .device_type import (IS_IPU_AVAILABLE, IS_MLU_AVAILABLE,
-                              IS_MPS_AVAILABLE, IS_NPU_AVAILABLE)
+                              IS_MPS_AVAILABLE, IS_NPU_AVAILABLE, DeviceType)
     from .env import collect_env
     from .hub import load_url
     from .logging import get_logger, print_log
@@ -77,5 +77,5 @@ else:
         'is_method_overridden', 'is_jit_tracing', 'is_rocm_pytorch',
         '_get_cuda_home', 'load_url', 'has_method', 'IS_CUDA_AVAILABLE',
         'worker_init_fn', 'IS_MLU_AVAILABLE', 'IS_IPU_AVAILABLE',
-        'IS_MPS_AVAILABLE', 'IS_NPU_AVAILABLE', 'torch_meshgrid'
+        'IS_MPS_AVAILABLE', 'IS_NPU_AVAILABLE', 'DeviceType', 'torch_meshgrid'
     ]

--- a/mmcv/utils/device_type.py
+++ b/mmcv/utils/device_type.py
@@ -15,8 +15,11 @@ IS_IPU_AVAILABLE = is_ipu_available()
 def is_mlu_available() -> bool:
     try:
         import torch
-        return (hasattr(torch, 'is_mlu_available')
-                and torch.is_mlu_available())
+        if torch.__version__ == 'parrots':
+            return torch.cuda.is_available()
+        else:
+            return (hasattr(torch, 'is_mlu_available')
+                    and torch.is_mlu_available())
     except Exception:
         return False
 
@@ -51,3 +54,17 @@ def is_npu_available() -> bool:
 
 
 IS_NPU_AVAILABLE = is_npu_available()
+
+
+class DeviceType:
+    cpu = 'cpu'
+    cuda = 'cuda'
+    hip = 'hip'
+    ascend = 'ascend'
+    npu = 'npu'
+    mlu = 'mlu'
+    try:
+        import torch
+        mlu = 'camb' if torch.__version__ == 'parrots' else 'mlu'
+    except ImportError:
+        pass

--- a/mmcv/utils/torch_ops.py
+++ b/mmcv/utils/torch_ops.py
@@ -5,7 +5,7 @@ from .parrots_wrapper import TORCH_VERSION
 from .version_utils import digit_version
 
 _torch_version_meshgrid_indexing = (
-    'parrots' not in TORCH_VERSION
+    'parrots' != TORCH_VERSION
     and digit_version(TORCH_VERSION) >= digit_version('1.10.0a0'))
 
 

--- a/mmcv/utils/version_utils.py
+++ b/mmcv/utils/version_utils.py
@@ -20,7 +20,8 @@ def digit_version(version_str: str, length: int = 4):
         tuple[int]: The version info in digits (integers).
     """
     if version_str == 'parrots':
-        return digit_version(version_str.version.split('+')[0][:-2])
+        return digit_version(
+            version_str.version.split('+')[0][:-2])  # type: ignore
     version = parse(version_str)
     assert version.release, f'failed to parse version {version_str}'
     release = list(version.release)

--- a/mmcv/utils/version_utils.py
+++ b/mmcv/utils/version_utils.py
@@ -20,8 +20,7 @@ def digit_version(version_str: str, length: int = 4):
         tuple[int]: The version info in digits (integers).
     """
     if version_str == 'parrots':
-        return digit_version(
-            version_str.version.split('+')[0][:-2])  # type: ignore
+        return digit_version(version_str.digit_version)  # type: ignore
     version = parse(version_str)
     assert version.release, f'failed to parse version {version_str}'
     release = list(version.release)

--- a/mmcv/utils/version_utils.py
+++ b/mmcv/utils/version_utils.py
@@ -19,7 +19,8 @@ def digit_version(version_str: str, length: int = 4):
     Returns:
         tuple[int]: The version info in digits (integers).
     """
-    assert 'parrots' not in version_str
+    if version_str == 'parrots':
+        return digit_version(version_str.version.split('+')[0][:-2])
     version = parse(version_str)
     assert version.release, f'failed to parse version {version_str}'
     release = list(version.release)

--- a/setup.py
+++ b/setup.py
@@ -233,11 +233,17 @@ def get_extensions():
             include_dirs.append(os.path.abspath('./mmcv/ops/csrc/common'))
             include_dirs.append(
                 os.path.abspath('./mmcv/ops/csrc/parrots/common'))
-            op_files = glob.glob('./mmcv/ops/csrc/common/mlu/*.mlu') +\
+            mlu_kernel_files = [
+                './mmcv/ops/csrc/common/mlu/roi_align_mlu_kernel.mlu',
+                './mmcv/ops/csrc/common/mlu/nms_mlu_kernel.mlu',
+                './mmcv/ops/csrc/common/mlu/focal_loss_sigmoid_mlu_kernel.mlu'
+            ]
+            op_files = mlu_kernel_files +\
                 glob.glob('./mmcv/ops/csrc/parrots/common/*.cpp') +\
                 glob.glob('./mmcv/ops/csrc/parrots/cpu/*.cpp') +\
                 glob.glob('./mmcv/ops/csrc/parrots/mlu/*.cpp') +\
                 glob.glob('./mmcv/ops/csrc/pytorch/cpu/*.cpp')
+
             mlu_args = os.getenv('MMCV_MLU_ARGS')
             extra_compile_args = {
                 'cncc': [mlu_args] if mlu_args else

--- a/setup.py
+++ b/setup.py
@@ -231,8 +231,11 @@ def get_extensions():
                 ]
         if use_camb:
             include_dirs.append(os.path.abspath('./mmcv/ops/csrc/common'))
+            include_dirs.append(
+                os.path.abspath('./mmcv/ops/csrc/parrots/common'))
             op_files = glob.glob('./mmcv/ops/csrc/common/mlu/*.mlu') +\
-                glob.glob('./mmcv/ops/csrc/parrots/*cpu.cpp') +\
+                glob.glob('./mmcv/ops/csrc/parrots/common/*.cpp') +\
+                glob.glob('./mmcv/ops/csrc/parrots/cpu/*.cpp') +\
                 glob.glob('./mmcv/ops/csrc/parrots/mlu/*.cpp') +\
                 glob.glob('./mmcv/ops/csrc/pytorch/cpu/*.cpp')
             mlu_args = os.getenv('MMCV_MLU_ARGS')

--- a/setup.py
+++ b/setup.py
@@ -203,28 +203,41 @@ def get_extensions():
     if EXT_TYPE == 'parrots':
         ext_name = 'mmcv._ext'
         from parrots.utils.build_extension import Extension
+        from parrots.base import use_cuda, use_camb
 
         # new parrots op impl do not use MMCV_USE_PARROTS
         # define_macros = [('MMCV_USE_PARROTS', None)]
         define_macros = []
         include_dirs = []
-        op_files = glob.glob('./mmcv/ops/csrc/pytorch/cuda/*.cu') +\
-            glob.glob('./mmcv/ops/csrc/pytorch/cpu/*.cpp') +\
-            glob.glob('./mmcv/ops/csrc/parrots/*.cpp')
-        include_dirs.append(os.path.abspath('./mmcv/ops/csrc/common'))
-        include_dirs.append(os.path.abspath('./mmcv/ops/csrc/common/cuda'))
-        cuda_args = os.getenv('MMCV_CUDA_ARGS')
-        extra_compile_args = {
-            'nvcc': [cuda_args, '-std=c++14'] if cuda_args else ['-std=c++14'],
-            'cxx': ['-std=c++14'],
+        if use_cuda:
+            op_files = glob.glob('./mmcv/ops/csrc/pytorch/cuda/*.cu') +\
+                glob.glob('./mmcv/ops/csrc/pytorch/cpu/*.cpp') +\
+                glob.glob('./mmcv/ops/csrc/parrots/*.cpp')
+            include_dirs.append(os.path.abspath('./mmcv/ops/csrc/common'))
+            include_dirs.append(os.path.abspath('./mmcv/ops/csrc/common/cuda'))
+            cuda_args = os.getenv('MMCV_CUDA_ARGS')
+            extra_compile_args = {
+                'nvcc': [cuda_args, '-std=c++14'] if cuda_args else ['-std=c++14'],
+                'cxx': ['-std=c++14'],
+            }
+            if torch.cuda.is_available() or os.getenv('FORCE_CUDA', '0') == '1':
+                define_macros += [('MMCV_WITH_CUDA', None)]
+                extra_compile_args['nvcc'] += [
+                    '-D__CUDA_NO_HALF_OPERATORS__',
+                    '-D__CUDA_NO_HALF_CONVERSIONS__',
+                    '-D__CUDA_NO_HALF2_OPERATORS__',
+                ]
+        if use_camb:
+            include_dirs.append(os.path.abspath('./mmcv/ops/csrc/common'))
+            op_files = glob.glob('./mmcv/ops/csrc/common/mlu/*.mlu') +\
+                glob.glob('./mmcv/ops/csrc/parrots/*cpu.cpp') +\
+                glob.glob('./mmcv/ops/csrc/parrots/mlu/*.cpp')
+            mlu_args = os.getenv('MMCV_MLU_ARGS')
+            extra_compile_args = {
+                'cncc': [mlu_args] if mlu_args else
+                    ['-v', '-fPIC', '--shared', '--bang-mlu-arch=MLU290', '-O3'],
+                'cxx': ['-std=c++14'],
         }
-        if torch.cuda.is_available() or os.getenv('FORCE_CUDA', '0') == '1':
-            define_macros += [('MMCV_WITH_CUDA', None)]
-            extra_compile_args['nvcc'] += [
-                '-D__CUDA_NO_HALF_OPERATORS__',
-                '-D__CUDA_NO_HALF_CONVERSIONS__',
-                '-D__CUDA_NO_HALF2_OPERATORS__',
-            ]
         ext_ops = Extension(
             name=ext_name,
             sources=op_files,

--- a/setup.py
+++ b/setup.py
@@ -202,8 +202,8 @@ def get_extensions():
 
     if EXT_TYPE == 'parrots':
         ext_name = 'mmcv._ext'
+        from parrots.base import use_camb, use_cuda
         from parrots.utils.build_extension import Extension
-        from parrots.base import use_cuda, use_camb
 
         # new parrots op impl do not use MMCV_USE_PARROTS
         # define_macros = [('MMCV_USE_PARROTS', None)]
@@ -217,10 +217,12 @@ def get_extensions():
             include_dirs.append(os.path.abspath('./mmcv/ops/csrc/common/cuda'))
             cuda_args = os.getenv('MMCV_CUDA_ARGS')
             extra_compile_args = {
-                'nvcc': [cuda_args, '-std=c++14'] if cuda_args else ['-std=c++14'],
+                'nvcc':
+                [cuda_args, '-std=c++14'] if cuda_args else ['-std=c++14'],
                 'cxx': ['-std=c++14'],
             }
-            if torch.cuda.is_available() or os.getenv('FORCE_CUDA', '0') == '1':
+            if torch.cuda.is_available() or os.getenv('FORCE_CUDA',
+                                                      '0') == '1':
                 define_macros += [('MMCV_WITH_CUDA', None)]
                 extra_compile_args['nvcc'] += [
                     '-D__CUDA_NO_HALF_OPERATORS__',
@@ -231,13 +233,14 @@ def get_extensions():
             include_dirs.append(os.path.abspath('./mmcv/ops/csrc/common'))
             op_files = glob.glob('./mmcv/ops/csrc/common/mlu/*.mlu') +\
                 glob.glob('./mmcv/ops/csrc/parrots/*cpu.cpp') +\
-                glob.glob('./mmcv/ops/csrc/parrots/mlu/*.cpp')
+                glob.glob('./mmcv/ops/csrc/parrots/mlu/*.cpp') +\
+                glob.glob('./mmcv/ops/csrc/pytorch/cpu/*.cpp')
             mlu_args = os.getenv('MMCV_MLU_ARGS')
             extra_compile_args = {
                 'cncc': [mlu_args] if mlu_args else
-                    ['-v', '-fPIC', '--shared', '--bang-mlu-arch=MLU290', '-O3'],
+                ['-v', '-fPIC', '--shared', '--bang-mlu-arch=MLU290', '-O3'],
                 'cxx': ['-std=c++14'],
-        }
+            }
         ext_ops = Extension(
             name=ext_name,
             sources=op_files,

--- a/tests/test_ops/test_focal_loss.py
+++ b/tests/test_ops/test_focal_loss.py
@@ -3,7 +3,8 @@ import numpy as np
 import pytest
 import torch
 
-from mmcv.utils import IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE, IS_NPU_AVAILABLE
+from mmcv.utils import (IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE, IS_NPU_AVAILABLE,
+                        DeviceType)
 
 _USING_PARROTS = True
 try:
@@ -123,23 +124,27 @@ class Testfocalloss:
             else:
                 gradcheck(floss, (x, y), eps=1e-2, atol=1e-2)
 
+    @pytest.mark.skipif(
+        torch.__version__ == 'parrots', reason='not supported in parrots now')
     def test_softmax_float(self):
         self._test_softmax(dtype=torch.float)
 
+    @pytest.mark.skipif(
+        torch.__version__ == 'parrots', reason='not supported in parrots now')
     def test_softmax_half(self):
         self._test_softmax(dtype=torch.half)
 
     @pytest.mark.parametrize('device', [
         pytest.param(
-            'npu',
+            DeviceType.npu,
             marks=pytest.mark.skipif(
                 not IS_NPU_AVAILABLE, reason='requires NPU support')),
         pytest.param(
-            'cuda',
+            DeviceType.cuda,
             marks=pytest.mark.skipif(
                 not IS_CUDA_AVAILABLE, reason='requires CUDA support')),
         pytest.param(
-            'mlu',
+            DeviceType.mlu,
             marks=pytest.mark.skipif(
                 not IS_MLU_AVAILABLE, reason='requires MLU support'))
     ])
@@ -148,21 +153,23 @@ class Testfocalloss:
 
     @pytest.mark.parametrize('device', [
         pytest.param(
-            'npu',
+            DeviceType.npu,
             marks=pytest.mark.skipif(
                 not IS_NPU_AVAILABLE, reason='requires NPU support')),
         pytest.param(
-            'cuda',
+            DeviceType.cuda,
             marks=pytest.mark.skipif(
                 not IS_CUDA_AVAILABLE, reason='requires CUDA support')),
         pytest.param(
-            'mlu',
+            DeviceType.mlu,
             marks=pytest.mark.skipif(
                 not IS_MLU_AVAILABLE, reason='requires MLU support'))
     ])
     def test_sigmoid_half(self, device):
         self._test_sigmoid(device, dtype=torch.half)
 
+    @pytest.mark.skipif(
+        torch.__version__ == 'parrots', reason='not supported in parrots now')
     def test_grad_softmax_float(self):
         self._test_grad_softmax(dtype=torch.float)
 

--- a/tests/test_ops/test_nms.py
+++ b/tests/test_ops/test_nms.py
@@ -3,18 +3,18 @@ import numpy as np
 import pytest
 import torch
 
-from mmcv.utils import IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE
+from mmcv.utils import IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE, DeviceType
 
 
 class Testnms:
 
     @pytest.mark.parametrize('device', [
         pytest.param(
-            'cuda',
+            DeviceType.cuda,
             marks=pytest.mark.skipif(
                 not IS_CUDA_AVAILABLE, reason='requires CUDA support')),
         pytest.param(
-            'mlu',
+            DeviceType.mlu,
             marks=pytest.mark.skipif(
                 not IS_MLU_AVAILABLE, reason='requires MLU support'))
     ])
@@ -38,6 +38,8 @@ class Testnms:
         assert np.allclose(dets.cpu().numpy(), np_dets)  # test gpu
         assert np.allclose(inds.cpu().numpy(), np_inds)  # test gpu
 
+    @pytest.mark.skipif(
+        torch.__version__ == 'parrots', reason='not supported in parrots now')
     def test_softnms_allclose(self):
         if not torch.cuda.is_available():
             return
@@ -107,6 +109,8 @@ class Testnms:
                 assert np.allclose(dets.cpu().numpy(), np_output[m]['dets'])
                 assert np.allclose(inds.cpu().numpy(), np_output[m]['inds'])
 
+    @pytest.mark.skipif(
+        torch.__version__ == 'parrots', reason='not supported in parrots now')
     def test_nms_match(self):
         if not torch.cuda.is_available():
             return
@@ -143,6 +147,8 @@ class Testnms:
         with pytest.raises(AssertionError):
             nms_match(wrong_dets, iou_thr)
 
+    @pytest.mark.skipif(
+        torch.__version__ == 'parrots', reason='not supported in parrots now')
     def test_batched_nms(self):
         import mmcv
         from mmcv.ops import batched_nms

--- a/tests/test_ops/test_roi_align.py
+++ b/tests/test_ops/test_roi_align.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 import torch
 
-from mmcv.utils import IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE
+from mmcv.utils import IS_CUDA_AVAILABLE, IS_MLU_AVAILABLE, DeviceType
 
 _USING_PARROTS = True
 try:
@@ -94,13 +94,13 @@ def _test_roialign_allclose(device, dtype):
 
 
 @pytest.mark.parametrize('device', [
-    'cpu',
+    DeviceType.cpu,
     pytest.param(
-        'cuda',
+        DeviceType.cuda,
         marks=pytest.mark.skipif(
             not IS_CUDA_AVAILABLE, reason='requires CUDA support')),
     pytest.param(
-        'mlu',
+        DeviceType.mlu,
         marks=pytest.mark.skipif(
             not IS_MLU_AVAILABLE, reason='requires MLU support'))
 ])


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

- Adaptation for ops of mlu device in parrots
- Create a new device registry for dispatching ops

## Modification

- MLU ops
- Part of the unit test

## Use cases (Optional)

```py
import numpy as np
from mmcv.ops import nms
import torch
device = 'camb'
# device = 'cpu'

if __name__ == '__main__':
    np_boxes = np.array([[6.0, 3.0, 8.0, 7.0], [3.0, 6.0, 9.0, 11.0],
                            [3.0, 7.0, 10.0, 12.0], [1.0, 4.0, 13.0, 7.0]],
                        dtype=np.float32)
    np_scores = np.array([0.6, 0.9, 0.7, 0.2], dtype=np.float32)
    np_inds = np.array([1, 0, 3])
    np_dets = np.array([[3.0, 6.0, 9.0, 11.0, 0.9],
                        [6.0, 3.0, 8.0, 7.0, 0.6],
                        [1.0, 4.0, 13.0, 7.0, 0.2]])
    boxes = torch.from_numpy(np_boxes)
    scores = torch.from_numpy(np_scores)
    dets, inds = nms(
       boxes.to(device), scores.to(device), iou_threshold=0.3, offset=0)
    print('final_result:', dets, inds)
    assert np.allclose(dets.cpu().numpy(), np_dets)  # test gpu
    assert np.allclose(inds.cpu().numpy(), np_inds)  # test gpu
```

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials. (No docstrings here)

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
