### PR TITLE
Fix skip_layer for RF-Next

### DIFF
--- a/mmcv/cnn/rfsearch/search.py
+++ b/mmcv/cnn/rfsearch/search.py
@@ -163,6 +163,10 @@ class RFSearchHook(Hook):
                 fullname = 'module.' + name
             else:
                 fullname = prefix + '.' + name
+            if self.config['search']['skip_layer'] is not None:
+                if any(layer in fullname
+                       for layer in self.config['search']['skip_layer']):
+                    continue
             if isinstance(module, eval(op)):
                 if 1 < module.kernel_size[0] and \
                     0 != module.kernel_size[0] % 2 or \
@@ -175,13 +179,7 @@ class RFSearchHook(Hook):
                         logger.info('Wrap model %s to %s.' %
                                     (str(module), str(moduleWrap)))
                     setattr(model, name, moduleWrap)
-            elif isinstance(module, BaseConvRFSearchOp):
-                pass
-            else:
-                if self.config['search']['skip_layer'] is not None:
-                    if any(layer in fullname
-                           for layer in self.config['search']['skip_layer']):
-                        continue
+            elif not isinstance(module, BaseConvRFSearchOp):
                 self.wrap_model(module, search_op, fullname)
 
     def set_model(self,
@@ -206,6 +204,10 @@ class RFSearchHook(Hook):
                 fullname = 'module.' + name
             else:
                 fullname = prefix + '.' + name
+            if self.config['search']['skip_layer'] is not None:
+                if any(layer in fullname
+                       for layer in self.config['search']['skip_layer']):
+                    continue
             if isinstance(module, eval(op)):
                 if 1 < module.kernel_size[0] and \
                     0 != module.kernel_size[0] % 2 or \
@@ -232,11 +234,5 @@ class RFSearchHook(Hook):
                         logger.info(
                             'Set module %s dilation as: [%d %d]' %
                             (fullname, module.dilation[0], module.dilation[1]))
-            elif isinstance(module, BaseConvRFSearchOp):
-                pass
-            else:
-                if self.config['search']['skip_layer'] is not None:
-                    if any(layer in fullname
-                           for layer in self.config['search']['skip_layer']):
-                        continue
+            elif not isinstance(module, BaseConvRFSearchOp):
                 self.set_model(module, search_op, init_rates, fullname)

--- a/mmcv/cnn/rfsearch/search.py
+++ b/mmcv/cnn/rfsearch/search.py
@@ -143,9 +143,9 @@ class RFSearchHook(Hook):
                 module.estimate_rates()
                 module.expand_rates()
 
-    def wrap_model(self, 
-                   model: nn.Module, 
-                   search_op: str = 'Conv2d', 
+    def wrap_model(self,
+                   model: nn.Module,
+                   search_op: str = 'Conv2d',
                    prefix: str = ''):
         """wrap model to support searchable conv op.
 


### PR DESCRIPTION
## Motivation

RF-Next(TPAMI2022) has been merged in [PR](https://github.com/open-mmlab/mmcv/pull/2056).
But when I apply RF-Next to `mmsegmentation`, I found that some codes should be revised. 
Current code will skip a layer when the `config.search.skip_layer` includes one of the subnames of this layer, 
rather than the full name. 

For example,  if I want to skip a layer named `layer.0.conv` during searching, I should add `layer` / `0` / `conv`  to `config.search.skip_layer`. However, this will cause other layers to be incorrectly skipped, e.g., `layer.1.conv`.
So the codes should be revised to to judge whether a layer should be skipped according to its full name.

## Modification

Determine whether a layer should be skipped according to the full_name.

`
if any(layer in fullname for layer in self.config['search']['skip_layer']): continue
`

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
