### PR TITLE
Fix import_module_from_strings() expects list, but is given **dict when called in mmcv.utils.config.fromfile()

### DIFF
--- a/mmcv/utils/config.py
+++ b/mmcv/utils/config.py
@@ -340,7 +340,7 @@ class Config:
         cfg_dict, cfg_text = Config._file2dict(filename,
                                                use_predefined_variables)
         if import_custom_modules and cfg_dict.get('custom_imports', None):
-            import_modules_from_strings(**cfg_dict['custom_imports'])
+            import_modules_from_strings(cfg_dict['custom_imports'])
         return Config(cfg_dict, cfg_text=cfg_text, filename=filename)
 
     @staticmethod


### PR DESCRIPTION
In line 343 of mmcv.utils.config.py, the method `import_modules_from_strings` is called with `**cfg['custom_imports']` as its first positional argument. When the config contains a key `custom_imports` with a list of strings of modules intended to be imported as its value, a `TypeError` stating the following is thrown: `argument after ** must be a mapping, not list`. This is due to the **-operator preceding cfg['custom_imports'] in the method call. Hence, I removed it.