### PR TITLE
[Fix] Fix _flip_keypoint of RandomFlip returns the wrong result

### DIFF
--- a/mmcv/transforms/processing.py
+++ b/mmcv/transforms/processing.py
@@ -1203,7 +1203,8 @@ class RandomFlip(BaseTransform):
             bboxes (numpy.ndarray): Bounding boxes, shape (..., 4*k)
             img_shape (tuple[int]): Image shape (height, width)
             direction (str): Flip direction. Options are 'horizontal',
-                'vertical'.
+                'vertical', and 'diagonal'.
+
         Returns:
             numpy.ndarray: Flipped bounding boxes.
         """
@@ -1239,7 +1240,8 @@ class RandomFlip(BaseTransform):
             keypoints (numpy.ndarray): Keypoints, shape (..., 2)
             img_shape (tuple[int]): Image shape (height, width)
             direction (str): Flip direction. Options are 'horizontal',
-                'vertical'.
+                'vertical', and 'diagonal'.
+
         Returns:
             numpy.ndarray: Flipped keypoints.
         """
@@ -1259,7 +1261,7 @@ class RandomFlip(BaseTransform):
             raise ValueError(
                 f"Flipping direction must be 'horizontal', 'vertical', \
                   or 'diagonal', but got '{direction}'")
-        flipped = np.concatenate([keypoints, meta_info], axis=-1)
+        flipped = np.concatenate([flipped, meta_info], axis=-1)
         return flipped
 
     def _flip_seg_map(self, seg_map: dict, direction: str) -> np.ndarray:
@@ -1357,6 +1359,7 @@ class RandomFlip(BaseTransform):
 
         Args:
             results (dict): Result dict from loading pipeline.
+
         Returns:
             dict: Flipped results, 'img', 'gt_bboxes', 'gt_seg_map',
             'gt_keypoints', 'flip', and 'flip_direction' keys are


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

resolves #2526

`_flip_keypoint` of `RandomFlip` returns the wrong result. `_flip_keypoint` should concatenate the flipped rather than input `keypoints`.

## Modification

`_flip_keypoint` of `RandomFlip`

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
