### PR TITLE
[Fix] Fix CI failed caused by 'Python.h' not found

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,6 +277,10 @@ jobs:
       # pstuil is an optional package to detect the number of CPU for compiling mmcv
       - name: Install psutil
         run: python -m pip install psutil
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          sudo: true
       - name: Build and install
         run: rm -rf .eggs && python -m pip install -e .
       - name: Validate the installation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,25 +235,25 @@ jobs:
       MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
     strategy:
       matrix:
-        # python-version: [3.7]
-        # torch: [1.9.0+cu102, 1.10.0+cu102]
+        python-version: [3.7]
+        torch: [1.9.0+cu102, 1.10.0+cu102]
         include:
-          # - torch: 1.9.0+cu102
-          #   torchvision: 0.10.0+cu102
-          # - torch: 1.10.0+cu102
-          #   torchvision: 0.11.0+cu102
+          - torch: 1.9.0+cu102
+            torchvision: 0.10.0+cu102
+          - torch: 1.10.0+cu102
+            torchvision: 0.11.0+cu102
           - python-version: '3.10'
             torch: 1.11.0+cu102
             torchvision: 0.12.0+cu102
-          # - python-version: '3.10'
-          #   torch: 1.12.0+cu102
-          #   torchvision: 0.13.0+cu102
-          # - python-version: 3.6
-          #   torch: 1.9.0+cu102
-          #   torchvision: 0.10.0+cu102
-          # - python-version: 3.8
-          #   torch: 1.9.0+cu102
-          #   torchvision: 0.10.0+cu102
+          - python-version: '3.10'
+            torch: 1.12.0+cu102
+            torchvision: 0.13.0+cu102
+          - python-version: 3.6
+            torch: 1.9.0+cu102
+            torchvision: 0.10.0+cu102
+          - python-version: 3.8
+            torch: 1.9.0+cu102
+            torchvision: 0.10.0+cu102
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,10 +277,9 @@ jobs:
       # pstuil is an optional package to detect the number of CPU for compiling mmcv
       - name: Install psutil
         run: python -m pip install psutil
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        with:
-          sudo: false
+      # the directory for header files for the Python C-API could be wrong since setuptools>=65.2.0
+      - name: Install specified version for setuptools
+        run: python -m pip install 'setuptools<=65.1.0'
       - name: Build and install
         run: rm -rf .eggs && python -m pip install -e .
       - name: Validate the installation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,204 +27,204 @@ env:
   MMCV_WITH_OPS: 1
 
 jobs:
-  build_without_torch:
-    runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        python-version: [3.7]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
-      - name: Build and install
-        run: rm -rf .eggs && pip install -e .
-      - name: Validate the installation
-        run: python -c "import mmcv"
-      - name: Run unittests and generate coverage report
-        run: |
-          pip install -r requirements/test.txt
-          pytest tests/ \
-              --ignore=tests/test_runner \
-              --ignore=tests/test_device/test_ipu \
-              --ignore=tests/test_optimizer.py \
-              --ignore=tests/test_cnn \
-              --ignore=tests/test_parallel.py \
-              --ignore=tests/test_ops \
-              --ignore=tests/test_load_model_zoo.py \
-              --ignore=tests/test_utils/test_logging.py \
-              --ignore=tests/test_image/test_io.py \
-              --ignore=tests/test_utils/test_registry.py \
-              --ignore=tests/test_utils/test_parrots_jit.py \
-              --ignore=tests/test_utils/test_trace.py \
-              --ignore=tests/test_utils/test_hub.py \
-              --ignore=tests/test_device \
-              --ignore=tests/test_utils/test_torch_ops.py
+  # build_without_torch:
+  #   runs-on: ubuntu-18.04
+  #   strategy:
+  #     matrix:
+  #       python-version: [3.7]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Install system dependencies
+  #       run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
+  #     - name: Build and install
+  #       run: rm -rf .eggs && pip install -e .
+  #     - name: Validate the installation
+  #       run: python -c "import mmcv"
+  #     - name: Run unittests and generate coverage report
+  #       run: |
+  #         pip install -r requirements/test.txt
+  #         pytest tests/ \
+  #             --ignore=tests/test_runner \
+  #             --ignore=tests/test_device/test_ipu \
+  #             --ignore=tests/test_optimizer.py \
+  #             --ignore=tests/test_cnn \
+  #             --ignore=tests/test_parallel.py \
+  #             --ignore=tests/test_ops \
+  #             --ignore=tests/test_load_model_zoo.py \
+  #             --ignore=tests/test_utils/test_logging.py \
+  #             --ignore=tests/test_image/test_io.py \
+  #             --ignore=tests/test_utils/test_registry.py \
+  #             --ignore=tests/test_utils/test_parrots_jit.py \
+  #             --ignore=tests/test_utils/test_trace.py \
+  #             --ignore=tests/test_utils/test_hub.py \
+  #             --ignore=tests/test_device \
+  #             --ignore=tests/test_utils/test_torch_ops.py
 
-  build_without_ops:
-    runs-on: ubuntu-18.04
-    env:
-      MMCV_WITH_OPS: 0
-    strategy:
-      matrix:
-        python-version: [3.7]
-        torch: [1.7.0, 1.8.0, 1.9.0]
-        include:
-          - torch: 1.7.0
-            torchvision: 0.8.1
-          - torch: 1.8.0
-            torchvision: 0.9.0
-          - torch: 1.9.0
-            torchvision: 0.10.0
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
-      - name: Install PyTorch
-        run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
-      - name: Build and install
-        run: rm -rf .eggs && pip install -e .
-      - name: Validate the installation
-        run: python -c "import mmcv"
-      - name: Run unittests
-        run: |
-          pip install -r requirements/test.txt
-          pytest tests/ --ignore=tests/test_ops
+  # build_without_ops:
+  #   runs-on: ubuntu-18.04
+  #   env:
+  #     MMCV_WITH_OPS: 0
+  #   strategy:
+  #     matrix:
+  #       python-version: [3.7]
+  #       torch: [1.7.0, 1.8.0, 1.9.0]
+  #       include:
+  #         - torch: 1.7.0
+  #           torchvision: 0.8.1
+  #         - torch: 1.8.0
+  #           torchvision: 0.9.0
+  #         - torch: 1.9.0
+  #           torchvision: 0.10.0
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Install system dependencies
+  #       run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
+  #     - name: Install PyTorch
+  #       run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
+  #     - name: Build and install
+  #       run: rm -rf .eggs && pip install -e .
+  #     - name: Validate the installation
+  #       run: python -c "import mmcv"
+  #     - name: Run unittests
+  #       run: |
+  #         pip install -r requirements/test.txt
+  #         pytest tests/ --ignore=tests/test_ops
 
-  build_cpu:
-    runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        python-version: [3.7]
-        torch: [1.5.1, 1.6.0, 1.7.0, 1.8.0, 1.9.0]
-        include:
-          - torch: 1.5.1
-            torchvision: 0.6.1
-          - torch: 1.6.0
-            torchvision: 0.7.0
-          - torch: 1.7.0
-            torchvision: 0.8.1
-          - torch: 1.8.0
-            torchvision: 0.9.0
-          - torch: 1.9.0
-            torchvision: 0.10.0
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
-      - name: Install PyTorch
-        run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
-      # pstuil is an optional package to detect the number of CPU for compiling mmcv
-      - name: Install psutil
-        run: pip install psutil
-      - name: Create sdist and untar
-        run: |
-          MMCV_WITH_OPS=1 python setup.py sdist
-          tar zxvf dist/mmcv-full* -C /tmp
-          rm -r mmcv
-      - name: Build and install from sdist
-        run: |
-          pushd /tmp/mmcv-full*
-          pip install -e .
-          popd
-      - name: Validate the installation
-        run: python -c "import mmcv"
-      - name: Run unittests and generate coverage report
-        run: |
-          pip install -r requirements/test.txt
-          coverage run --branch --source=mmcv -m pytest tests/
-          coverage xml
-          coverage report -m
+  # build_cpu:
+  #   runs-on: ubuntu-18.04
+  #   strategy:
+  #     matrix:
+  #       python-version: [3.7]
+  #       torch: [1.5.1, 1.6.0, 1.7.0, 1.8.0, 1.9.0]
+  #       include:
+  #         - torch: 1.5.1
+  #           torchvision: 0.6.1
+  #         - torch: 1.6.0
+  #           torchvision: 0.7.0
+  #         - torch: 1.7.0
+  #           torchvision: 0.8.1
+  #         - torch: 1.8.0
+  #           torchvision: 0.9.0
+  #         - torch: 1.9.0
+  #           torchvision: 0.10.0
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Install system dependencies
+  #       run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
+  #     - name: Install PyTorch
+  #       run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
+  #     # pstuil is an optional package to detect the number of CPU for compiling mmcv
+  #     - name: Install psutil
+  #       run: pip install psutil
+  #     - name: Create sdist and untar
+  #       run: |
+  #         MMCV_WITH_OPS=1 python setup.py sdist
+  #         tar zxvf dist/mmcv-full* -C /tmp
+  #         rm -r mmcv
+  #     - name: Build and install from sdist
+  #       run: |
+  #         pushd /tmp/mmcv-full*
+  #         pip install -e .
+  #         popd
+  #     - name: Validate the installation
+  #       run: python -c "import mmcv"
+  #     - name: Run unittests and generate coverage report
+  #       run: |
+  #         pip install -r requirements/test.txt
+  #         coverage run --branch --source=mmcv -m pytest tests/
+  #         coverage xml
+  #         coverage report -m
 
-  build_cu101:
-    runs-on: ubuntu-18.04
-    container:
-      image: pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel
-    env:
-      FORCE_CUDA: 1
-      MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
-    strategy:
-      matrix:
-        python-version: [3.7]
-        torch: [1.5.1+cu101, 1.6.0+cu101, 1.7.0+cu101, 1.8.0+cu101]
-        include:
-          - torch: 1.5.1+cu101
-            torchvision: 0.6.1+cu101
-          - torch: 1.6.0+cu101
-            torchvision: 0.7.0+cu101
-          - torch: 1.7.0+cu101
-            torchvision: 0.8.1+cu101
-          - torch: 1.8.0+cu101
-            torchvision: 0.9.0+cu101
-          - python-version: 3.6
-            torch: 1.8.0+cu101
-            torchvision: 0.9.0+cu101
-          - python-version: 3.8
-            torch: 1.8.0+cu101
-            torchvision: 0.9.0+cu101
-          - python-version: 3.9
-            torch: 1.8.0+cu101
-            torchvision: 0.9.0+cu101
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Fetch GPG keys
-        run: |
-          apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
-          apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
-      - name: Install python-dev
-        run: apt-get update && apt-get install -y python${{matrix.python-version}}-dev
-        if: ${{matrix.python-version != '3.9'}}
-      - name: Install Pillow
-        run: python -m pip install Pillow==6.2.2
-        if: ${{matrix.torchvision == '0.4.2'}}
-      # When we use a third-party container, we need to add python -m to call
-      # the user-installed pip when we use the pip command, otherwise it will
-      # call the system pip
-      - name: Install PyTorch
-        run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
-      - name: Install system dependencies
-        run: apt-get update && apt-get install -y ffmpeg libturbojpeg ninja-build
-      - name: Install dependencies for compiling onnx when python=3.9
-        run: python -m pip install protobuf && apt-get -y install libprotobuf-dev protobuf-compiler cmake
-        if: ${{matrix.python-version == '3.9'}}
-      # pstuil is an optional package to detect the number of CPU for compiling mmcv
-      - name: Install psutil
-        run: python -m pip install psutil
-      - name: Build and install
-        run: rm -rf .eggs && python -m pip install -e .
-      - name: Validate the installation
-        run: python -c "import mmcv"
-      - name: Run unittests and generate coverage report
-        run: |
-          python -m pip install -r requirements/test.txt
-          coverage run --branch --source=mmcv -m pytest tests/
-          coverage xml
-          coverage report -m
-      # Only upload coverage report for python3.7 && pytorch1.6
-      - name: Upload coverage to Codecov
-        if: ${{matrix.torch == '1.6.0+cu101' && matrix.python-version == '3.7'}}
-        uses: codecov/codecov-action@v1.0.14
-        with:
-          file: ./coverage.xml
-          flags: unittests
-          env_vars: OS,PYTHON
-          name: codecov-umbrella
-          fail_ci_if_error: false
+  # build_cu101:
+  #   runs-on: ubuntu-18.04
+  #   container:
+  #     image: pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel
+  #   env:
+  #     FORCE_CUDA: 1
+  #     MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
+  #   strategy:
+  #     matrix:
+  #       python-version: [3.7]
+  #       torch: [1.5.1+cu101, 1.6.0+cu101, 1.7.0+cu101, 1.8.0+cu101]
+  #       include:
+  #         - torch: 1.5.1+cu101
+  #           torchvision: 0.6.1+cu101
+  #         - torch: 1.6.0+cu101
+  #           torchvision: 0.7.0+cu101
+  #         - torch: 1.7.0+cu101
+  #           torchvision: 0.8.1+cu101
+  #         - torch: 1.8.0+cu101
+  #           torchvision: 0.9.0+cu101
+  #         - python-version: 3.6
+  #           torch: 1.8.0+cu101
+  #           torchvision: 0.9.0+cu101
+  #         - python-version: 3.8
+  #           torch: 1.8.0+cu101
+  #           torchvision: 0.9.0+cu101
+  #         - python-version: 3.9
+  #           torch: 1.8.0+cu101
+  #           torchvision: 0.9.0+cu101
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Fetch GPG keys
+  #       run: |
+  #         apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+  #         apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+  #     - name: Install python-dev
+  #       run: apt-get update && apt-get install -y python${{matrix.python-version}}-dev
+  #       if: ${{matrix.python-version != '3.9'}}
+  #     - name: Install Pillow
+  #       run: python -m pip install Pillow==6.2.2
+  #       if: ${{matrix.torchvision == '0.4.2'}}
+  #     # When we use a third-party container, we need to add python -m to call
+  #     # the user-installed pip when we use the pip command, otherwise it will
+  #     # call the system pip
+  #     - name: Install PyTorch
+  #       run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
+  #     - name: Install system dependencies
+  #       run: apt-get update && apt-get install -y ffmpeg libturbojpeg ninja-build
+  #     - name: Install dependencies for compiling onnx when python=3.9
+  #       run: python -m pip install protobuf && apt-get -y install libprotobuf-dev protobuf-compiler cmake
+  #       if: ${{matrix.python-version == '3.9'}}
+  #     # pstuil is an optional package to detect the number of CPU for compiling mmcv
+  #     - name: Install psutil
+  #       run: python -m pip install psutil
+  #     - name: Build and install
+  #       run: rm -rf .eggs && python -m pip install -e .
+  #     - name: Validate the installation
+  #       run: python -c "import mmcv"
+  #     - name: Run unittests and generate coverage report
+  #       run: |
+  #         python -m pip install -r requirements/test.txt
+  #         coverage run --branch --source=mmcv -m pytest tests/
+  #         coverage xml
+  #         coverage report -m
+  #     # Only upload coverage report for python3.7 && pytorch1.6
+  #     - name: Upload coverage to Codecov
+  #       if: ${{matrix.torch == '1.6.0+cu101' && matrix.python-version == '3.7'}}
+  #       uses: codecov/codecov-action@v1.0.14
+  #       with:
+  #         file: ./coverage.xml
+  #         flags: unittests
+  #         env_vars: OS,PYTHON
+  #         name: codecov-umbrella
+  #         fail_ci_if_error: false
 
   build_cu102:
     runs-on: ubuntu-18.04
@@ -238,22 +238,22 @@ jobs:
         python-version: [3.7]
         torch: [1.9.0+cu102, 1.10.0+cu102]
         include:
-          - torch: 1.9.0+cu102
-            torchvision: 0.10.0+cu102
-          - torch: 1.10.0+cu102
-            torchvision: 0.11.0+cu102
+          # - torch: 1.9.0+cu102
+          #   torchvision: 0.10.0+cu102
+          # - torch: 1.10.0+cu102
+          #   torchvision: 0.11.0+cu102
           - python-version: '3.10'
             torch: 1.11.0+cu102
             torchvision: 0.12.0+cu102
-          - python-version: '3.10'
-            torch: 1.12.0+cu102
-            torchvision: 0.13.0+cu102
-          - python-version: 3.6
-            torch: 1.9.0+cu102
-            torchvision: 0.10.0+cu102
-          - python-version: 3.8
-            torch: 1.9.0+cu102
-            torchvision: 0.10.0+cu102
+          # - python-version: '3.10'
+          #   torch: 1.12.0+cu102
+          #   torchvision: 0.13.0+cu102
+          # - python-version: 3.6
+          #   torch: 1.9.0+cu102
+          #   torchvision: 0.10.0+cu102
+          # - python-version: 3.8
+          #   torch: 1.9.0+cu102
+          #   torchvision: 0.10.0+cu102
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -295,152 +295,152 @@ jobs:
           coverage xml
         if: ${{matrix.python-version == '3.10'}}
 
-  build_cu116:
-    runs-on: ubuntu-18.04
-    container:
-      image: pytorch/pytorch:1.13.0-cuda11.6-cudnn8-devel
-    env:
-      FORCE_CUDA: 1
-      MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
-    strategy:
-      matrix:
-        python-version: ['3.10']
-        torch: [1.13.0+cu116]
-        include:
-          - torch: 1.13.0+cu116
-            torchvision: 0.14.0+cu116
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Fetch GPG keys
-        run: |
-          apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
-          apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
-      - name: Add PPA
-        run: |
-          apt-get update && apt-get install -y software-properties-common
-          add-apt-repository -y ppa:deadsnakes/ppa
-      - name: Install python-dev
-        run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python${{matrix.python-version}}-dev
-      - name: python -m Install PyTorch
-        run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
-      - name: Install system dependencies
-        run: apt-get update && apt-get install -y ffmpeg libturbojpeg ninja-build
-      # pstuil is an optional package to detect the number of CPU for compiling mmcv
-      - name: Install psutil
-        run: python -m pip install psutil
-      - name: Build and install
-        run: rm -rf .eggs && python -m pip install -e .
-      - name: Validate the installation
-        run: python -c "import mmcv"
-      - name: Run unittests and generate coverage report
-        run: |
-          python -m pip install -r requirements/test.txt
-          coverage run --branch --source=mmcv -m pytest tests/ --ignore=tests/test_ops/test_onnx.py --ignore=tests/test_ops/test_tensorrt.py --ignore=tests/test_ops/test_tensorrt_preprocess.py
-          coverage xml
+  # build_cu116:
+  #   runs-on: ubuntu-18.04
+  #   container:
+  #     image: pytorch/pytorch:1.13.0-cuda11.6-cudnn8-devel
+  #   env:
+  #     FORCE_CUDA: 1
+  #     MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
+  #   strategy:
+  #     matrix:
+  #       python-version: ['3.10']
+  #       torch: [1.13.0+cu116]
+  #       include:
+  #         - torch: 1.13.0+cu116
+  #           torchvision: 0.14.0+cu116
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python ${{ matrix.python-version }}
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: ${{ matrix.python-version }}
+  #     - name: Fetch GPG keys
+  #       run: |
+  #         apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+  #         apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+  #     - name: Add PPA
+  #       run: |
+  #         apt-get update && apt-get install -y software-properties-common
+  #         add-apt-repository -y ppa:deadsnakes/ppa
+  #     - name: Install python-dev
+  #       run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python${{matrix.python-version}}-dev
+  #     - name: python -m Install PyTorch
+  #       run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
+  #     - name: Install system dependencies
+  #       run: apt-get update && apt-get install -y ffmpeg libturbojpeg ninja-build
+  #     # pstuil is an optional package to detect the number of CPU for compiling mmcv
+  #     - name: Install psutil
+  #       run: python -m pip install psutil
+  #     - name: Build and install
+  #       run: rm -rf .eggs && python -m pip install -e .
+  #     - name: Validate the installation
+  #       run: python -c "import mmcv"
+  #     - name: Run unittests and generate coverage report
+  #       run: |
+  #         python -m pip install -r requirements/test.txt
+  #         coverage run --branch --source=mmcv -m pytest tests/ --ignore=tests/test_ops/test_onnx.py --ignore=tests/test_ops/test_tensorrt.py --ignore=tests/test_ops/test_tensorrt_preprocess.py
+  #         coverage xml
 
-  build_windows_without_ops:
-    runs-on: windows-latest
-    env:
-      MMCV_WITH_OPS: 0
-    strategy:
-      matrix:
-        torch: [1.7.1, 1.8.0, 1.9.0]
-        include:
-          - torch: 1.7.1
-            torchvision: 0.8.2
-          - torch: 1.8.0
-            torchvision: 0.9.0
-          - torch: 1.9.0
-            torchvision: 0.10.0
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Install PyTorch
-        run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu --no-cache-dir -f https://download.pytorch.org/whl/torch_stable.html
-      - name: Build and install
-        run: pip install -e .
-      - name: Validate the installation
-        run: python -c "import mmcv"
-      - name: Run unittests
-        run: |
-          pip install -r requirements/test.txt
-          pytest tests/ --ignore=tests/test_ops --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py --ignore tests/test_image/test_io.py
+  # build_windows_without_ops:
+  #   runs-on: windows-latest
+  #   env:
+  #     MMCV_WITH_OPS: 0
+  #   strategy:
+  #     matrix:
+  #       torch: [1.7.1, 1.8.0, 1.9.0]
+  #       include:
+  #         - torch: 1.7.1
+  #           torchvision: 0.8.2
+  #         - torch: 1.8.0
+  #           torchvision: 0.9.0
+  #         - torch: 1.9.0
+  #           torchvision: 0.10.0
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python 3.7
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.7
+  #     - name: Install PyTorch
+  #       run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu --no-cache-dir -f https://download.pytorch.org/whl/torch_stable.html
+  #     - name: Build and install
+  #       run: pip install -e .
+  #     - name: Validate the installation
+  #       run: python -c "import mmcv"
+  #     - name: Run unittests
+  #       run: |
+  #         pip install -r requirements/test.txt
+  #         pytest tests/ --ignore=tests/test_ops --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py --ignore tests/test_image/test_io.py
 
-  build_windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        torch: [1.7.1, 1.8.0, 1.9.0]
-        include:
-          - torch: 1.7.1
-            torchvision: 0.8.2
-          - torch: 1.8.0
-            torchvision: 0.9.0
-          - torch: 1.9.0
-            torchvision: 0.10.0
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Install PyTorch
-        run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu --no-cache-dir -f https://download.pytorch.org/whl/torch_stable.html
-      - name: Build and install
-        run: pip install -e .
-      - name: Validate the installation
-        run: python -c "import mmcv"
-      - name: Run unittests
-        run: |
-          pip install -r requirements/test.txt
-          pytest tests/ --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py --ignore tests/test_image/test_io.py
+  # build_windows:
+  #   runs-on: windows-latest
+  #   strategy:
+  #     matrix:
+  #       torch: [1.7.1, 1.8.0, 1.9.0]
+  #       include:
+  #         - torch: 1.7.1
+  #           torchvision: 0.8.2
+  #         - torch: 1.8.0
+  #           torchvision: 0.9.0
+  #         - torch: 1.9.0
+  #           torchvision: 0.10.0
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python 3.7
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.7
+  #     - name: Install PyTorch
+  #       run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu --no-cache-dir -f https://download.pytorch.org/whl/torch_stable.html
+  #     - name: Build and install
+  #       run: pip install -e .
+  #     - name: Validate the installation
+  #       run: python -c "import mmcv"
+  #     - name: Run unittests
+  #       run: |
+  #         pip install -r requirements/test.txt
+  #         pytest tests/ --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py --ignore tests/test_image/test_io.py
 
-  build_macos:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        torch: [1.5.1, 1.6.0, 1.7.0, 1.8.0, 1.9.0]
-        include:
-          - torch: 1.5.1
-            torchvision: 0.6.1
-          - torch: 1.6.0
-            torchvision: 0.7.0
-          - torch: 1.7.0
-            torchvision: 0.8.1
-          - torch: 1.8.0
-            torchvision: 0.9.0
-          - torch: 1.9.0
-            torchvision: 0.10.0
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Install system dependencies
-        run: brew install ffmpeg jpeg-turbo
-      - name: Install utils
-        run: pip install psutil
-      - name: Install Pillow
-        run: pip install Pillow==6.2.2
-        if: ${{matrix.torchvision == '0.4.2'}}
-      - name: Install PyTorch
-        run: pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} --no-cache-dir
-      - name: Build and install
-        run: |
-          rm -rf .eggs
-          CC=clang CXX=clang++ CFLAGS='-stdlib=libc++' pip install -e .
-      - name: Validate the installation
-        run: python -c "import mmcv"
-      - name: Run unittests
-        run: |
-          pip install -r requirements/test.txt
-          # The timing on macos VMs is not precise, so we skip the progressbar tests
-          pytest tests/ --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py
+  # build_macos:
+  #   runs-on: macos-latest
+  #   strategy:
+  #     matrix:
+  #       torch: [1.5.1, 1.6.0, 1.7.0, 1.8.0, 1.9.0]
+  #       include:
+  #         - torch: 1.5.1
+  #           torchvision: 0.6.1
+  #         - torch: 1.6.0
+  #           torchvision: 0.7.0
+  #         - torch: 1.7.0
+  #           torchvision: 0.8.1
+  #         - torch: 1.8.0
+  #           torchvision: 0.9.0
+  #         - torch: 1.9.0
+  #           torchvision: 0.10.0
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Python 3.7
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: 3.7
+  #     - name: Install system dependencies
+  #       run: brew install ffmpeg jpeg-turbo
+  #     - name: Install utils
+  #       run: pip install psutil
+  #     - name: Install Pillow
+  #       run: pip install Pillow==6.2.2
+  #       if: ${{matrix.torchvision == '0.4.2'}}
+  #     - name: Install PyTorch
+  #       run: pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} --no-cache-dir
+  #     - name: Build and install
+  #       run: |
+  #         rm -rf .eggs
+  #         CC=clang CXX=clang++ CFLAGS='-stdlib=libc++' pip install -e .
+  #     - name: Validate the installation
+  #       run: python -c "import mmcv"
+  #     - name: Run unittests
+  #       run: |
+  #         pip install -r requirements/test.txt
+  #         # The timing on macos VMs is not precise, so we skip the progressbar tests
+  #         pytest tests/ --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -235,8 +235,8 @@ jobs:
       MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
     strategy:
       matrix:
-        python-version: [3.7]
-        torch: [1.9.0+cu102, 1.10.0+cu102]
+        # python-version: [3.7]
+        # torch: [1.9.0+cu102, 1.10.0+cu102]
         include:
           # - torch: 1.9.0+cu102
           #   torchvision: 0.10.0+cu102

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,8 +278,9 @@ jobs:
       - name: Install psutil
         run: python -m pip install psutil
       # the directory for header files for the Python C-API could be wrong since setuptools>=65.2.0
-      - name: Install specified version for setuptools
+      - name: Install specified version for setuptools when python==3.10
         run: python -m pip install 'setuptools<=65.1.0'
+        if: ${{matrix.python-version == '3.10'}}
       - name: Build and install
         run: rm -rf .eggs && python -m pip install -e .
       - name: Validate the installation
@@ -335,6 +336,10 @@ jobs:
       # pstuil is an optional package to detect the number of CPU for compiling mmcv
       - name: Install psutil
         run: python -m pip install psutil
+      # the directory for header files for the Python C-API could be wrong since setuptools>=65.2.0
+      - name: Install specified version for setuptools when python==3.10
+        run: python -m pip install 'setuptools<=65.1.0'
+        if: ${{matrix.python-version == '3.10'}}
       - name: Build and install
         run: rm -rf .eggs && python -m pip install -e .
       - name: Validate the installation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,7 +280,7 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         with:
-          sudo: true
+          sudo: false
       - name: Build and install
         run: rm -rf .eggs && python -m pip install -e .
       - name: Validate the installation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,204 +27,204 @@ env:
   MMCV_WITH_OPS: 1
 
 jobs:
-  # build_without_torch:
-  #   runs-on: ubuntu-18.04
-  #   strategy:
-  #     matrix:
-  #       python-version: [3.7]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Install system dependencies
-  #       run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
-  #     - name: Build and install
-  #       run: rm -rf .eggs && pip install -e .
-  #     - name: Validate the installation
-  #       run: python -c "import mmcv"
-  #     - name: Run unittests and generate coverage report
-  #       run: |
-  #         pip install -r requirements/test.txt
-  #         pytest tests/ \
-  #             --ignore=tests/test_runner \
-  #             --ignore=tests/test_device/test_ipu \
-  #             --ignore=tests/test_optimizer.py \
-  #             --ignore=tests/test_cnn \
-  #             --ignore=tests/test_parallel.py \
-  #             --ignore=tests/test_ops \
-  #             --ignore=tests/test_load_model_zoo.py \
-  #             --ignore=tests/test_utils/test_logging.py \
-  #             --ignore=tests/test_image/test_io.py \
-  #             --ignore=tests/test_utils/test_registry.py \
-  #             --ignore=tests/test_utils/test_parrots_jit.py \
-  #             --ignore=tests/test_utils/test_trace.py \
-  #             --ignore=tests/test_utils/test_hub.py \
-  #             --ignore=tests/test_device \
-  #             --ignore=tests/test_utils/test_torch_ops.py
+  build_without_torch:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
+      - name: Build and install
+        run: rm -rf .eggs && pip install -e .
+      - name: Validate the installation
+        run: python -c "import mmcv"
+      - name: Run unittests and generate coverage report
+        run: |
+          pip install -r requirements/test.txt
+          pytest tests/ \
+              --ignore=tests/test_runner \
+              --ignore=tests/test_device/test_ipu \
+              --ignore=tests/test_optimizer.py \
+              --ignore=tests/test_cnn \
+              --ignore=tests/test_parallel.py \
+              --ignore=tests/test_ops \
+              --ignore=tests/test_load_model_zoo.py \
+              --ignore=tests/test_utils/test_logging.py \
+              --ignore=tests/test_image/test_io.py \
+              --ignore=tests/test_utils/test_registry.py \
+              --ignore=tests/test_utils/test_parrots_jit.py \
+              --ignore=tests/test_utils/test_trace.py \
+              --ignore=tests/test_utils/test_hub.py \
+              --ignore=tests/test_device \
+              --ignore=tests/test_utils/test_torch_ops.py
 
-  # build_without_ops:
-  #   runs-on: ubuntu-18.04
-  #   env:
-  #     MMCV_WITH_OPS: 0
-  #   strategy:
-  #     matrix:
-  #       python-version: [3.7]
-  #       torch: [1.7.0, 1.8.0, 1.9.0]
-  #       include:
-  #         - torch: 1.7.0
-  #           torchvision: 0.8.1
-  #         - torch: 1.8.0
-  #           torchvision: 0.9.0
-  #         - torch: 1.9.0
-  #           torchvision: 0.10.0
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Install system dependencies
-  #       run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
-  #     - name: Install PyTorch
-  #       run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
-  #     - name: Build and install
-  #       run: rm -rf .eggs && pip install -e .
-  #     - name: Validate the installation
-  #       run: python -c "import mmcv"
-  #     - name: Run unittests
-  #       run: |
-  #         pip install -r requirements/test.txt
-  #         pytest tests/ --ignore=tests/test_ops
+  build_without_ops:
+    runs-on: ubuntu-18.04
+    env:
+      MMCV_WITH_OPS: 0
+    strategy:
+      matrix:
+        python-version: [3.7]
+        torch: [1.7.0, 1.8.0, 1.9.0]
+        include:
+          - torch: 1.7.0
+            torchvision: 0.8.1
+          - torch: 1.8.0
+            torchvision: 0.9.0
+          - torch: 1.9.0
+            torchvision: 0.10.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
+      - name: Install PyTorch
+        run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      - name: Build and install
+        run: rm -rf .eggs && pip install -e .
+      - name: Validate the installation
+        run: python -c "import mmcv"
+      - name: Run unittests
+        run: |
+          pip install -r requirements/test.txt
+          pytest tests/ --ignore=tests/test_ops
 
-  # build_cpu:
-  #   runs-on: ubuntu-18.04
-  #   strategy:
-  #     matrix:
-  #       python-version: [3.7]
-  #       torch: [1.5.1, 1.6.0, 1.7.0, 1.8.0, 1.9.0]
-  #       include:
-  #         - torch: 1.5.1
-  #           torchvision: 0.6.1
-  #         - torch: 1.6.0
-  #           torchvision: 0.7.0
-  #         - torch: 1.7.0
-  #           torchvision: 0.8.1
-  #         - torch: 1.8.0
-  #           torchvision: 0.9.0
-  #         - torch: 1.9.0
-  #           torchvision: 0.10.0
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Install system dependencies
-  #       run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
-  #     - name: Install PyTorch
-  #       run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
-  #     # pstuil is an optional package to detect the number of CPU for compiling mmcv
-  #     - name: Install psutil
-  #       run: pip install psutil
-  #     - name: Create sdist and untar
-  #       run: |
-  #         MMCV_WITH_OPS=1 python setup.py sdist
-  #         tar zxvf dist/mmcv-full* -C /tmp
-  #         rm -r mmcv
-  #     - name: Build and install from sdist
-  #       run: |
-  #         pushd /tmp/mmcv-full*
-  #         pip install -e .
-  #         popd
-  #     - name: Validate the installation
-  #       run: python -c "import mmcv"
-  #     - name: Run unittests and generate coverage report
-  #       run: |
-  #         pip install -r requirements/test.txt
-  #         coverage run --branch --source=mmcv -m pytest tests/
-  #         coverage xml
-  #         coverage report -m
+  build_cpu:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: [3.7]
+        torch: [1.5.1, 1.6.0, 1.7.0, 1.8.0, 1.9.0]
+        include:
+          - torch: 1.5.1
+            torchvision: 0.6.1
+          - torch: 1.6.0
+            torchvision: 0.7.0
+          - torch: 1.7.0
+            torchvision: 0.8.1
+          - torch: 1.8.0
+            torchvision: 0.9.0
+          - torch: 1.9.0
+            torchvision: 0.10.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg libturbojpeg
+      - name: Install PyTorch
+        run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      # pstuil is an optional package to detect the number of CPU for compiling mmcv
+      - name: Install psutil
+        run: pip install psutil
+      - name: Create sdist and untar
+        run: |
+          MMCV_WITH_OPS=1 python setup.py sdist
+          tar zxvf dist/mmcv-full* -C /tmp
+          rm -r mmcv
+      - name: Build and install from sdist
+        run: |
+          pushd /tmp/mmcv-full*
+          pip install -e .
+          popd
+      - name: Validate the installation
+        run: python -c "import mmcv"
+      - name: Run unittests and generate coverage report
+        run: |
+          pip install -r requirements/test.txt
+          coverage run --branch --source=mmcv -m pytest tests/
+          coverage xml
+          coverage report -m
 
-  # build_cu101:
-  #   runs-on: ubuntu-18.04
-  #   container:
-  #     image: pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel
-  #   env:
-  #     FORCE_CUDA: 1
-  #     MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
-  #   strategy:
-  #     matrix:
-  #       python-version: [3.7]
-  #       torch: [1.5.1+cu101, 1.6.0+cu101, 1.7.0+cu101, 1.8.0+cu101]
-  #       include:
-  #         - torch: 1.5.1+cu101
-  #           torchvision: 0.6.1+cu101
-  #         - torch: 1.6.0+cu101
-  #           torchvision: 0.7.0+cu101
-  #         - torch: 1.7.0+cu101
-  #           torchvision: 0.8.1+cu101
-  #         - torch: 1.8.0+cu101
-  #           torchvision: 0.9.0+cu101
-  #         - python-version: 3.6
-  #           torch: 1.8.0+cu101
-  #           torchvision: 0.9.0+cu101
-  #         - python-version: 3.8
-  #           torch: 1.8.0+cu101
-  #           torchvision: 0.9.0+cu101
-  #         - python-version: 3.9
-  #           torch: 1.8.0+cu101
-  #           torchvision: 0.9.0+cu101
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Fetch GPG keys
-  #       run: |
-  #         apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
-  #         apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
-  #     - name: Install python-dev
-  #       run: apt-get update && apt-get install -y python${{matrix.python-version}}-dev
-  #       if: ${{matrix.python-version != '3.9'}}
-  #     - name: Install Pillow
-  #       run: python -m pip install Pillow==6.2.2
-  #       if: ${{matrix.torchvision == '0.4.2'}}
-  #     # When we use a third-party container, we need to add python -m to call
-  #     # the user-installed pip when we use the pip command, otherwise it will
-  #     # call the system pip
-  #     - name: Install PyTorch
-  #       run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
-  #     - name: Install system dependencies
-  #       run: apt-get update && apt-get install -y ffmpeg libturbojpeg ninja-build
-  #     - name: Install dependencies for compiling onnx when python=3.9
-  #       run: python -m pip install protobuf && apt-get -y install libprotobuf-dev protobuf-compiler cmake
-  #       if: ${{matrix.python-version == '3.9'}}
-  #     # pstuil is an optional package to detect the number of CPU for compiling mmcv
-  #     - name: Install psutil
-  #       run: python -m pip install psutil
-  #     - name: Build and install
-  #       run: rm -rf .eggs && python -m pip install -e .
-  #     - name: Validate the installation
-  #       run: python -c "import mmcv"
-  #     - name: Run unittests and generate coverage report
-  #       run: |
-  #         python -m pip install -r requirements/test.txt
-  #         coverage run --branch --source=mmcv -m pytest tests/
-  #         coverage xml
-  #         coverage report -m
-  #     # Only upload coverage report for python3.7 && pytorch1.6
-  #     - name: Upload coverage to Codecov
-  #       if: ${{matrix.torch == '1.6.0+cu101' && matrix.python-version == '3.7'}}
-  #       uses: codecov/codecov-action@v1.0.14
-  #       with:
-  #         file: ./coverage.xml
-  #         flags: unittests
-  #         env_vars: OS,PYTHON
-  #         name: codecov-umbrella
-  #         fail_ci_if_error: false
+  build_cu101:
+    runs-on: ubuntu-18.04
+    container:
+      image: pytorch/pytorch:1.6.0-cuda10.1-cudnn7-devel
+    env:
+      FORCE_CUDA: 1
+      MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
+    strategy:
+      matrix:
+        python-version: [3.7]
+        torch: [1.5.1+cu101, 1.6.0+cu101, 1.7.0+cu101, 1.8.0+cu101]
+        include:
+          - torch: 1.5.1+cu101
+            torchvision: 0.6.1+cu101
+          - torch: 1.6.0+cu101
+            torchvision: 0.7.0+cu101
+          - torch: 1.7.0+cu101
+            torchvision: 0.8.1+cu101
+          - torch: 1.8.0+cu101
+            torchvision: 0.9.0+cu101
+          - python-version: 3.6
+            torch: 1.8.0+cu101
+            torchvision: 0.9.0+cu101
+          - python-version: 3.8
+            torch: 1.8.0+cu101
+            torchvision: 0.9.0+cu101
+          - python-version: 3.9
+            torch: 1.8.0+cu101
+            torchvision: 0.9.0+cu101
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Fetch GPG keys
+        run: |
+          apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+          apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+      - name: Install python-dev
+        run: apt-get update && apt-get install -y python${{matrix.python-version}}-dev
+        if: ${{matrix.python-version != '3.9'}}
+      - name: Install Pillow
+        run: python -m pip install Pillow==6.2.2
+        if: ${{matrix.torchvision == '0.4.2'}}
+      # When we use a third-party container, we need to add python -m to call
+      # the user-installed pip when we use the pip command, otherwise it will
+      # call the system pip
+      - name: Install PyTorch
+        run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
+      - name: Install system dependencies
+        run: apt-get update && apt-get install -y ffmpeg libturbojpeg ninja-build
+      - name: Install dependencies for compiling onnx when python=3.9
+        run: python -m pip install protobuf && apt-get -y install libprotobuf-dev protobuf-compiler cmake
+        if: ${{matrix.python-version == '3.9'}}
+      # pstuil is an optional package to detect the number of CPU for compiling mmcv
+      - name: Install psutil
+        run: python -m pip install psutil
+      - name: Build and install
+        run: rm -rf .eggs && python -m pip install -e .
+      - name: Validate the installation
+        run: python -c "import mmcv"
+      - name: Run unittests and generate coverage report
+        run: |
+          python -m pip install -r requirements/test.txt
+          coverage run --branch --source=mmcv -m pytest tests/
+          coverage xml
+          coverage report -m
+      # Only upload coverage report for python3.7 && pytorch1.6
+      - name: Upload coverage to Codecov
+        if: ${{matrix.torch == '1.6.0+cu101' && matrix.python-version == '3.7'}}
+        uses: codecov/codecov-action@v1.0.14
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          env_vars: OS,PYTHON
+          name: codecov-umbrella
+          fail_ci_if_error: false
 
   build_cu102:
     runs-on: ubuntu-18.04
@@ -298,152 +298,152 @@ jobs:
           coverage xml
         if: ${{matrix.python-version == '3.10'}}
 
-  # build_cu116:
-  #   runs-on: ubuntu-18.04
-  #   container:
-  #     image: pytorch/pytorch:1.13.0-cuda11.6-cudnn8-devel
-  #   env:
-  #     FORCE_CUDA: 1
-  #     MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
-  #   strategy:
-  #     matrix:
-  #       python-version: ['3.10']
-  #       torch: [1.13.0+cu116]
-  #       include:
-  #         - torch: 1.13.0+cu116
-  #           torchvision: 0.14.0+cu116
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #     - name: Fetch GPG keys
-  #       run: |
-  #         apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
-  #         apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
-  #     - name: Add PPA
-  #       run: |
-  #         apt-get update && apt-get install -y software-properties-common
-  #         add-apt-repository -y ppa:deadsnakes/ppa
-  #     - name: Install python-dev
-  #       run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python${{matrix.python-version}}-dev
-  #     - name: python -m Install PyTorch
-  #       run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
-  #     - name: Install system dependencies
-  #       run: apt-get update && apt-get install -y ffmpeg libturbojpeg ninja-build
-  #     # pstuil is an optional package to detect the number of CPU for compiling mmcv
-  #     - name: Install psutil
-  #       run: python -m pip install psutil
-  #     - name: Build and install
-  #       run: rm -rf .eggs && python -m pip install -e .
-  #     - name: Validate the installation
-  #       run: python -c "import mmcv"
-  #     - name: Run unittests and generate coverage report
-  #       run: |
-  #         python -m pip install -r requirements/test.txt
-  #         coverage run --branch --source=mmcv -m pytest tests/ --ignore=tests/test_ops/test_onnx.py --ignore=tests/test_ops/test_tensorrt.py --ignore=tests/test_ops/test_tensorrt_preprocess.py
-  #         coverage xml
+  build_cu116:
+    runs-on: ubuntu-18.04
+    container:
+      image: pytorch/pytorch:1.13.0-cuda11.6-cudnn8-devel
+    env:
+      FORCE_CUDA: 1
+      MMCV_CUDA_ARGS: -gencode=arch=compute_61,code=sm_61
+    strategy:
+      matrix:
+        python-version: ['3.10']
+        torch: [1.13.0+cu116]
+        include:
+          - torch: 1.13.0+cu116
+            torchvision: 0.14.0+cu116
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Fetch GPG keys
+        run: |
+          apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+          apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+      - name: Add PPA
+        run: |
+          apt-get update && apt-get install -y software-properties-common
+          add-apt-repository -y ppa:deadsnakes/ppa
+      - name: Install python-dev
+        run: apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y python${{matrix.python-version}}-dev
+      - name: python -m Install PyTorch
+        run: python -m pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} -f https://download.pytorch.org/whl/torch_stable.html
+      - name: Install system dependencies
+        run: apt-get update && apt-get install -y ffmpeg libturbojpeg ninja-build
+      # pstuil is an optional package to detect the number of CPU for compiling mmcv
+      - name: Install psutil
+        run: python -m pip install psutil
+      - name: Build and install
+        run: rm -rf .eggs && python -m pip install -e .
+      - name: Validate the installation
+        run: python -c "import mmcv"
+      - name: Run unittests and generate coverage report
+        run: |
+          python -m pip install -r requirements/test.txt
+          coverage run --branch --source=mmcv -m pytest tests/ --ignore=tests/test_ops/test_onnx.py --ignore=tests/test_ops/test_tensorrt.py --ignore=tests/test_ops/test_tensorrt_preprocess.py
+          coverage xml
 
-  # build_windows_without_ops:
-  #   runs-on: windows-latest
-  #   env:
-  #     MMCV_WITH_OPS: 0
-  #   strategy:
-  #     matrix:
-  #       torch: [1.7.1, 1.8.0, 1.9.0]
-  #       include:
-  #         - torch: 1.7.1
-  #           torchvision: 0.8.2
-  #         - torch: 1.8.0
-  #           torchvision: 0.9.0
-  #         - torch: 1.9.0
-  #           torchvision: 0.10.0
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python 3.7
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.7
-  #     - name: Install PyTorch
-  #       run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu --no-cache-dir -f https://download.pytorch.org/whl/torch_stable.html
-  #     - name: Build and install
-  #       run: pip install -e .
-  #     - name: Validate the installation
-  #       run: python -c "import mmcv"
-  #     - name: Run unittests
-  #       run: |
-  #         pip install -r requirements/test.txt
-  #         pytest tests/ --ignore=tests/test_ops --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py --ignore tests/test_image/test_io.py
+  build_windows_without_ops:
+    runs-on: windows-latest
+    env:
+      MMCV_WITH_OPS: 0
+    strategy:
+      matrix:
+        torch: [1.7.1, 1.8.0, 1.9.0]
+        include:
+          - torch: 1.7.1
+            torchvision: 0.8.2
+          - torch: 1.8.0
+            torchvision: 0.9.0
+          - torch: 1.9.0
+            torchvision: 0.10.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install PyTorch
+        run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu --no-cache-dir -f https://download.pytorch.org/whl/torch_stable.html
+      - name: Build and install
+        run: pip install -e .
+      - name: Validate the installation
+        run: python -c "import mmcv"
+      - name: Run unittests
+        run: |
+          pip install -r requirements/test.txt
+          pytest tests/ --ignore=tests/test_ops --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py --ignore tests/test_image/test_io.py
 
-  # build_windows:
-  #   runs-on: windows-latest
-  #   strategy:
-  #     matrix:
-  #       torch: [1.7.1, 1.8.0, 1.9.0]
-  #       include:
-  #         - torch: 1.7.1
-  #           torchvision: 0.8.2
-  #         - torch: 1.8.0
-  #           torchvision: 0.9.0
-  #         - torch: 1.9.0
-  #           torchvision: 0.10.0
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python 3.7
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.7
-  #     - name: Install PyTorch
-  #       run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu --no-cache-dir -f https://download.pytorch.org/whl/torch_stable.html
-  #     - name: Build and install
-  #       run: pip install -e .
-  #     - name: Validate the installation
-  #       run: python -c "import mmcv"
-  #     - name: Run unittests
-  #       run: |
-  #         pip install -r requirements/test.txt
-  #         pytest tests/ --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py --ignore tests/test_image/test_io.py
+  build_windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        torch: [1.7.1, 1.8.0, 1.9.0]
+        include:
+          - torch: 1.7.1
+            torchvision: 0.8.2
+          - torch: 1.8.0
+            torchvision: 0.9.0
+          - torch: 1.9.0
+            torchvision: 0.10.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install PyTorch
+        run: pip install torch==${{matrix.torch}}+cpu torchvision==${{matrix.torchvision}}+cpu --no-cache-dir -f https://download.pytorch.org/whl/torch_stable.html
+      - name: Build and install
+        run: pip install -e .
+      - name: Validate the installation
+        run: python -c "import mmcv"
+      - name: Run unittests
+        run: |
+          pip install -r requirements/test.txt
+          pytest tests/ --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py --ignore tests/test_image/test_io.py
 
-  # build_macos:
-  #   runs-on: macos-latest
-  #   strategy:
-  #     matrix:
-  #       torch: [1.5.1, 1.6.0, 1.7.0, 1.8.0, 1.9.0]
-  #       include:
-  #         - torch: 1.5.1
-  #           torchvision: 0.6.1
-  #         - torch: 1.6.0
-  #           torchvision: 0.7.0
-  #         - torch: 1.7.0
-  #           torchvision: 0.8.1
-  #         - torch: 1.8.0
-  #           torchvision: 0.9.0
-  #         - torch: 1.9.0
-  #           torchvision: 0.10.0
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Set up Python 3.7
-  #       uses: actions/setup-python@v2
-  #       with:
-  #         python-version: 3.7
-  #     - name: Install system dependencies
-  #       run: brew install ffmpeg jpeg-turbo
-  #     - name: Install utils
-  #       run: pip install psutil
-  #     - name: Install Pillow
-  #       run: pip install Pillow==6.2.2
-  #       if: ${{matrix.torchvision == '0.4.2'}}
-  #     - name: Install PyTorch
-  #       run: pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} --no-cache-dir
-  #     - name: Build and install
-  #       run: |
-  #         rm -rf .eggs
-  #         CC=clang CXX=clang++ CFLAGS='-stdlib=libc++' pip install -e .
-  #     - name: Validate the installation
-  #       run: python -c "import mmcv"
-  #     - name: Run unittests
-  #       run: |
-  #         pip install -r requirements/test.txt
-  #         # The timing on macos VMs is not precise, so we skip the progressbar tests
-  #         pytest tests/ --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py
+  build_macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        torch: [1.5.1, 1.6.0, 1.7.0, 1.8.0, 1.9.0]
+        include:
+          - torch: 1.5.1
+            torchvision: 0.6.1
+          - torch: 1.6.0
+            torchvision: 0.7.0
+          - torch: 1.7.0
+            torchvision: 0.8.1
+          - torch: 1.8.0
+            torchvision: 0.9.0
+          - torch: 1.9.0
+            torchvision: 0.10.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install system dependencies
+        run: brew install ffmpeg jpeg-turbo
+      - name: Install utils
+        run: pip install psutil
+      - name: Install Pillow
+        run: pip install Pillow==6.2.2
+        if: ${{matrix.torchvision == '0.4.2'}}
+      - name: Install PyTorch
+        run: pip install torch==${{matrix.torch}} torchvision==${{matrix.torchvision}} --no-cache-dir
+      - name: Build and install
+        run: |
+          rm -rf .eggs
+          CC=clang CXX=clang++ CFLAGS='-stdlib=libc++' pip install -e .
+      - name: Validate the installation
+        run: python -c "import mmcv"
+      - name: Run unittests
+        run: |
+          pip install -r requirements/test.txt
+          # The timing on macos VMs is not precise, so we skip the progressbar tests
+          pytest tests/ --ignore tests/test_utils/test_progressbar.py --ignore tests/test_utils/test_timer.py


### PR DESCRIPTION
## Motivation
The CI job failed: https://github.com/open-mmlab/mmcv/actions/runs/3826436209/jobs/6566398257

The mmcv-full compile failed because the Python C-API header include directory is wrong:
![image](https://user-images.githubusercontent.com/32220263/211142309-612b9500-4331-4ecd-8f11-2013ef25d9f5.png)
In the CI container:
![image](https://user-images.githubusercontent.com/32220263/211142457-0910775f-621a-4bcd-8a11-058090ba96a8.png)

This is a bug introduce by setuptools [v65.2.0](https://github.com/pypa/setuptools/pull/3258), and the verison of setuptools for python 3.10.9 in setup-python action is 65.5.0 (while 63.2.0 for python3.10.8).

Related links:
- https://github.com/pypa/setuptools/issues/3589
- https://github.com/pypa/distutils/issues/178

## Modification
A workaround is use `setuptools<=65.1.0` when python==3.10