### PR TITLE
Fix issue #2524, do scatter before train_step() when use MMDDP with CPU

### DIFF
--- a/mmcv/parallel/distributed.py
+++ b/mmcv/parallel/distributed.py
@@ -66,7 +66,8 @@ class MMDistributedDataParallel(DistributedDataParallel):
                     self._module_copies[:len(inputs)], inputs, kwargs)
                 output = self.gather(outputs, self.output_device)
         else:
-            output = self.module.train_step(*inputs, **kwargs)
+            inputs, kwargs = self.scatter(inputs, kwargs, [-1])
+            output = self.module.train_step(*inputs[0], **kwargs[0])
 
         if ('parrots' not in TORCH_VERSION
                 and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

related issue: https://github.com/open-mmlab/mmcv/issues/2524
this pr is to fix this problem

## Modification

Update MMDDP, when use MMDDP with CPU, scatter the input before train_step().

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
