### PR TITLE
Add missing contiguous calls for nms_rotated

### DIFF
--- a/mmcv/ops/csrc/pytorch/nms_rotated.cpp
+++ b/mmcv/ops/csrc/pytorch/nms_rotated.cpp
@@ -21,12 +21,12 @@ Tensor nms_rotated(const Tensor dets, const Tensor scores, const Tensor order,
   assert(dets.device().is_cuda() == scores.device().is_cuda());
   if (dets.device().is_cuda()) {
 #ifdef MMCV_WITH_CUDA
-    return nms_rotated_cuda(dets, scores, order, dets_sorted, iou_threshold,
-                            multi_label);
+    return nms_rotated_cuda(dets, scores, order, dets_sorted.contiguous(),
+                            iou_threshold, multi_label);
 #else
     AT_ERROR("Not compiled with GPU support");
 #endif
   }
 
-  return nms_rotated_cpu(dets, scores, iou_threshold);
+  return nms_rotated_cpu(dets.contiguous(), scores.contiguous(), iou_threshold);
 }


### PR DESCRIPTION
## Motivation

Addresses issue https://github.com/open-mmlab/mmcv/issues/2542

## Modification

For nms_rotated_cuda only adds contiguous call to dets_sorted which is accessed directly. For nms_rotated_cpu the implementation now matches what's in the detectron2 repo.

## BC-breaking (Optional)

No, bug fix only.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
