### PR TITLE
get proper cpu_use in docker container

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import glob
 import os
 import platform
 import re
+import subprocess
 import warnings
 from pkg_resources import DistributionNotFound, get_distribution
 from setuptools import find_packages, setup
@@ -244,7 +245,12 @@ def get_extensions():
             import psutil
             num_cpu = len(psutil.Process().cpu_affinity())
             cpu_use = max(4, num_cpu - 1)
-        except (ModuleNotFoundError, AttributeError):
+            # docker container resource limited case
+            if os.path.exists('/.dockerenv'):
+                exit_code, cpu_use_ns = subprocess.getstatusoutput('cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us')
+                if exit_code == 0 and cpu_use_ns != '-1':
+                    cpu_use = int(int(cpu_use_ns) / 100000 - 1)
+        except (ModuleNotFoundError, AttributeError, ValueError):
             cpu_use = 4
 
         os.environ.setdefault('MAX_JOBS', str(cpu_use))


### PR DESCRIPTION
## Motivation

When run in docker container, if the container are cpu limited, and the cpu resource quota is far smaller than the host cpu number, the install process will stuck and killed by cgroup later. So when run in docker container, try to get the right cpu quota.

## Modification

Check whether the process is running in container, and then set the `cpu_use` value to the resource limited in cgroup.
