### PR TITLE
[Fix] Check the version of torchvision in __init__ of DCN

### DIFF
--- a/mmcv/ops/deform_conv.py
+++ b/mmcv/ops/deform_conv.py
@@ -438,12 +438,9 @@ class DeformConv2dPack(DeformConv2d):
 
 if IS_MLU_AVAILABLE:
     import torchvision
+    from torchvision.ops import deform_conv2d as tv_deform_conv2d
 
     from mmcv.utils import digit_version
-    assert digit_version(torchvision.__version__) >= digit_version(
-        '0.10.0a0'), 'the version of torchvision should be >= 0.10.0'
-
-    from torchvision.ops import deform_conv2d as tv_deform_conv2d
 
     @CONV_LAYERS.register_module('DCN', force=True)
     class DeformConv2dPack_MLU(DeformConv2d):
@@ -471,6 +468,8 @@ if IS_MLU_AVAILABLE:
         """
 
         def __init__(self, *args, **kwargs):
+            assert digit_version(torchvision.__version__) >= digit_version(
+                '0.10.0a0'), 'the version of torchvision should be >= 0.10.0'
             super().__init__(*args, **kwargs)
 
             self.conv_offset = nn.Conv2d(
@@ -494,7 +493,6 @@ if IS_MLU_AVAILABLE:
                     ) == 0, 'batch size must be divisible by im2col_step'
             offset = self.conv_offset(x)
             x = x.type_as(offset)
-            weight = self.weight
-            weight = weight.type_as(x)
+            weight = self.weight.type_as(x)
             return tv_deform_conv2d(x, offset, weight, None, self.stride,
                                     self.padding, self.dilation)

--- a/mmcv/ops/modulated_deform_conv.py
+++ b/mmcv/ops/modulated_deform_conv.py
@@ -356,11 +356,9 @@ class ModulatedDeformConv2dPack(ModulatedDeformConv2d):
 
 if IS_MLU_AVAILABLE:
     import torchvision
+    from torchvision.ops import deform_conv2d as tv_deform_conv2d
 
     from mmcv.utils import digit_version
-    assert digit_version(torchvision.__version__) >= digit_version(
-        '0.10.0a0'), 'the version of torchvision should be >= 0.10.0'
-    from torchvision.ops import deform_conv2d as tv_deform_conv2d
 
     @CONV_LAYERS.register_module('DCNv2', force=True)
     class ModulatedDeformConv2dPack_MLU(ModulatedDeformConv2d):
@@ -383,6 +381,8 @@ if IS_MLU_AVAILABLE:
         """
 
         def __init__(self, *args, **kwargs):
+            assert digit_version(torchvision.__version__) >= digit_version(
+                '0.10.0a0'), 'the version of torchvision should be >= 0.10.0'
             super().__init__(*args, **kwargs)
             self.conv_offset = nn.Conv2d(
                 self.in_channels,


### PR DESCRIPTION

## Motivation

When performing the MLU-based PyTorch1.6 test, because PyTorch1.6-mlu does not support DCN,
 the local test case will report an error.

## Modification

mmcv/ops/deform_conv.py： 
-Put the assert of torchvision version in the function
-Simplified weight syntax
mmcv/ops/modulated_deform_conv.py：
-Put the assert of torchvision version in the function


**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
