### PR TITLE
[Docs] Refine the docstring of EvalHook

### DIFF
--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -24,8 +24,8 @@ class EvalHook(Hook):
         dataloader (DataLoader): A PyTorch dataloader, whose dataset has
             implemented ``evaluate`` function.
         start (int | None, optional): Evaluation starting epoch or iteration.
-            It enables evaluation before the training starts if ``start`` <= the
-            resuming epoch or iteration. If None, whether to evaluate is
+            It enables evaluation before the training starts if ``start`` <=
+            the resuming epoch or iteration. If None, whether to evaluate is
             merely decided by ``interval``. Default: None.
         interval (int): Evaluation interval. Default: 1.
         by_epoch (bool): Determine perform evaluation by epoch or by iteration.

--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -23,10 +23,10 @@ class EvalHook(Hook):
     Args:
         dataloader (DataLoader): A PyTorch dataloader, whose dataset has
             implemented ``evaluate`` function.
-        start (int | None, optional): Evaluation starting epoch. It enables
-            evaluation before the training starts if ``start`` <= the resuming
-            epoch. If None, whether to evaluate is merely decided by
-            ``interval``. Default: None.
+        start (int | None, optional): Evaluation starting epoch or iteration.
+            It enablesevaluation before the training starts if ``start`` <= the
+            resuming epoch or the resuming iteration. If None, whether to
+            evaluate is merely decided by ``interval``. Default: None.
         interval (int): Evaluation interval. Default: 1.
         by_epoch (bool): Determine perform evaluation by epoch or by iteration.
             If set to True, it will perform by epoch. Otherwise, by iteration.

--- a/mmcv/runner/hooks/evaluation.py
+++ b/mmcv/runner/hooks/evaluation.py
@@ -24,9 +24,9 @@ class EvalHook(Hook):
         dataloader (DataLoader): A PyTorch dataloader, whose dataset has
             implemented ``evaluate`` function.
         start (int | None, optional): Evaluation starting epoch or iteration.
-            It enablesevaluation before the training starts if ``start`` <= the
-            resuming epoch or the resuming iteration. If None, whether to
-            evaluate is merely decided by ``interval``. Default: None.
+            It enables evaluation before the training starts if ``start`` <= the
+            resuming epoch or iteration. If None, whether to evaluate is
+            merely decided by ``interval``. Default: None.
         interval (int): Evaluation interval. Default: 1.
         by_epoch (bool): Determine perform evaluation by epoch or by iteration.
             If set to True, it will perform by epoch. Otherwise, by iteration.


### PR DESCRIPTION
Refine the EvalHook comments

## Motivation
I noticed that according to the implementation of EvalHook, its parameter [start](https://github.com/open-mmlab/mmcv/blob/7e063e3e615153409e7c8b1f67f146905ea392b2/mmcv/runner/hooks/evaluation.py#L88) can also work in iteration mode. However, only the [epoch](https://github.com/open-mmlab/mmcv/blob/7e063e3e615153409e7c8b1f67f146905ea392b2/mmcv/runner/hooks/evaluation.py#L26-L29) mode was stated in the original comment, so I improved the comment.

## Modification
Improve the comments for [EvalHook](https://github.com/open-mmlab/mmcv/blob/7e063e3e61/mmcv/runner/hooks/evaluation.py).

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
