### PR TITLE
[Fix] Fix tensor descriptor setting in MLU ball_query.

### DIFF
--- a/mmcv/ops/csrc/pytorch/mlu/ball_query_mlu.cpp
+++ b/mmcv/ops/csrc/pytorch/mlu/ball_query_mlu.cpp
@@ -14,17 +14,17 @@
 void ball_query_forward_mlu(int b, int n, int m, float min_radius,
                             float max_radius, int nsample, const Tensor new_xyz,
                             const Tensor xyz, Tensor idx) {
-  MluOpTensorDescriptor new_xyz_desc, xyz_desc, idx_desc;
-  new_xyz_desc.set(new_xyz);
-  xyz_desc.set(xyz);
-  idx_desc.set(idx);
-
   auto new_xyz_contiguous = torch_mlu::cnnl::ops::cnnl_contiguous(
       new_xyz, new_xyz.suggest_memory_format());
   auto xyz_contiguous = torch_mlu::cnnl::ops::cnnl_contiguous(
       xyz, new_xyz.suggest_memory_format());
   auto idx_contiguous = torch_mlu::cnnl::ops::cnnl_contiguous(
       idx, new_xyz.suggest_memory_format());
+
+  MluOpTensorDescriptor new_xyz_desc, xyz_desc, idx_desc;
+  new_xyz_desc.set(new_xyz_contiguous);
+  xyz_desc.set(xyz_contiguous);
+  idx_desc.set(idx_contiguous);
 
   auto new_xyz_impl = torch_mlu::getMluTensorImpl(new_xyz_contiguous);
   auto xyz_impl = torch_mlu::getMluTensorImpl(xyz_contiguous);


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.
 
## Motivation
 
The motivation of the PR is to fix the tensor descriptor setting in ball_query with MLU backend.
 
It includes one part:
 
    1. Revise mmcv/ops/csrc/pytorch/mlu/ball_query_mlu.cpp to fix the the setting of tensor descriptor for MLU.
 
## Modification
 
- MLU src code
  revise MLU src code of ball_query in directory mmcv/ops/csrc/pytorch/mlu/ball_query_mlu.cpp

 
## BC-breaking (Optional)
 
Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
 
## Use cases (Optional)
 
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.
 
## Checklist
 
**Before PR**:
 
- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.
 
**After PR**:
 
- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.