### PR TITLE
check if input is contiguous, as required

### DIFF
--- a/mmcv/ops/roi_align.py
+++ b/mmcv/ops/roi_align.py
@@ -80,6 +80,8 @@ class RoIAlignFunction(Function):
         ctx.aligned = aligned
         ctx.input_shape = input.size()
 
+        assert input.is_contiguous(), "Memory of input must be contiguous"
+
         assert rois.size(1) == 5, 'RoI must be (idx, x1, y1, x2, y2)!'
 
         output_shape = (rois.size(0), input.size(1), ctx.output_size[0],

--- a/mmcv/ops/roi_align.py
+++ b/mmcv/ops/roi_align.py
@@ -80,8 +80,6 @@ class RoIAlignFunction(Function):
         ctx.aligned = aligned
         ctx.input_shape = input.size()
 
-        assert input.is_contiguous(), "Memory of input must be contiguous"
-
         assert rois.size(1) == 5, 'RoI must be (idx, x1, y1, x2, y2)!'
 
         output_shape = (rois.size(0), input.size(1), ctx.output_size[0],
@@ -197,10 +195,11 @@ class RoIAlign(nn.Module):
     def forward(self, input: torch.Tensor, rois: torch.Tensor) -> torch.Tensor:
         """
         Args:
-            input: NCHW images
+            input: NCHW images. The tensor's memory needs to be contiguous.
             rois: Bx5 boxes. First column is the index into N.\
                 The other 4 columns are xyxy.
         """
+        assert input.is_contiguous(), 'Memory of input must be contiguous'
         if self.use_torchvision:
             from torchvision.ops import roi_align as tv_roi_align
             if 'aligned' in tv_roi_align.__code__.co_varnames:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

As mentioned in #2203  the memory of the input tensor must be contiguous. I passed an non-contiguous tensor which leads to spurious results. As there was no check on the input, the code seemingly produced good results though. 

I would prefer an exception over internally converting the tensor to contiguous memory and have added the assert statement.  

## Modification

See above

## BC-breaking (Optional)

N/A/

## Use cases (Optional)

N/A

## Checklist

**Before PR**:

Note: I did run the pre-commit hooks, but I am seeing several mypy errors in files I did not touch. 

Maybe somebody can kindly instruct me running the pre-commit hooks correctly? 

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
