### PR TITLE
[FIX] Abnormal image size when resizing tall image to wide image

### DIFF
--- a/mmcv/image/geometric.py
+++ b/mmcv/image/geometric.py
@@ -237,10 +237,8 @@ def rescale_size(old_size: tuple,
             raise ValueError(f'Invalid scale {scale}, must be positive.')
         scale_factor = scale
     elif isinstance(scale, tuple):
-        max_long_edge = max(scale)
-        max_short_edge = min(scale)
-        scale_factor = min(max_long_edge / max(h, w),
-                           max_short_edge / min(h, w))
+        scale_factor = min(scale[0] / w,
+                           scale[1] / h)
     else:
         raise TypeError(
             f'Scale must be a number or tuple of int, but got {type(scale)}')

--- a/mmcv/image/geometric.py
+++ b/mmcv/image/geometric.py
@@ -237,7 +237,13 @@ def rescale_size(old_size: tuple,
             raise ValueError(f'Invalid scale {scale}, must be positive.')
         scale_factor = scale
     elif isinstance(scale, tuple):
-        scale_factor = min(scale[0] / w, scale[1] / h)
+        original_scale = w / h
+        target_scale = scale[0] / scale[1]
+
+        if target_scale > original_scale:
+            scale_factor = scale[1] / h
+        else:
+            scale_factor = scale[0] / w
     else:
         raise TypeError(
             f'Scale must be a number or tuple of int, but got {type(scale)}')

--- a/mmcv/image/geometric.py
+++ b/mmcv/image/geometric.py
@@ -237,8 +237,7 @@ def rescale_size(old_size: tuple,
             raise ValueError(f'Invalid scale {scale}, must be positive.')
         scale_factor = scale
     elif isinstance(scale, tuple):
-        scale_factor = min(scale[0] / w,
-                           scale[1] / h)
+        scale_factor = min(scale[0] / w, scale[1] / h)
     else:
         raise TypeError(
             f'Scale must be a number or tuple of int, but got {type(scale)}')


### PR DESCRIPTION
## Motivation

比如，用w:640, h:864竖屏图片训练的模型，可以输入w:1200, h:1600的竖屏图片。但是此时混入了一张w:1600, h:1200横屏图片。
本应依然resize成w:640，h:864，结果却resize成w:864，h:640。

就是因为原来的实现中，默认了长边就是预设输入尺寸中较大值所在的边（在此案例中，长边为高），而一旦有特殊输入时（比如在此案例中，长边为宽的图片），就会出错。


## Modification

scale的第一个和第二个值就是w，h，目标宽高比比原始宽高比更大，就用高的scale，反之用宽的scale
