### PR TITLE
[Fix] Fix a typo in the docstring of MSDeformAttn

### DIFF
--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -167,7 +167,7 @@ class MultiScaleDeformableAttention(BaseModule):
     Args:
         embed_dims (int): The embedding dimension of Attention.
             Default: 256.
-        num_heads (int): Parallel attention heads. Default: 64.
+        num_heads (int): Parallel attention heads. Default: 8.
         num_levels (int): The number of feature map used in
             Attention. Default: 4.
         num_points (int): The number of sampling points for


### PR DESCRIPTION


## Motivation

The default value for `num_heads` is 8, not 64.

## Modification

Please briefly describe what modification is made in this PR.
