### PR TITLE
Fix the paper link error in the docstring

### DIFF
--- a/mmcv/cnn/bricks/generalized_attention.py
+++ b/mmcv/cnn/bricks/generalized_attention.py
@@ -15,7 +15,7 @@ class GeneralizedAttention(nn.Module):
     """GeneralizedAttention module.
 
     See 'An Empirical Study of Spatial Attention Mechanisms in Deep Networks'
-    (https://arxiv.org/abs/1711.07971) for details.
+    (https://arxiv.org/abs/1904.05873) for details.
 
     Args:
         in_channels (int): Channels of the input feature map.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Revise the link of the paper cited by the code.

## Modification

https://github.com/open-mmlab/mmcv/blob/master/mmcv/cnn/bricks/generalized_attention.py#L18
(https://arxiv.org/abs/1711.07971) -> (https://arxiv.org/abs/1904.05873)

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?

No.


