### PR TITLE
Bug/deprecated neptune

### DIFF
--- a/mmcv/runner/hooks/logger/neptune.py
+++ b/mmcv/runner/hooks/logger/neptune.py
@@ -61,7 +61,7 @@ class NeptuneLoggerHook(LoggerHook):
             import neptune
         except ImportError:
             raise ImportError(
-                'Please run "pip install neptune-client" to install neptune')
+                'Please run "pip install neptune" to install neptune')
         self.neptune = neptune
         self.run = None
 

--- a/mmcv/runner/hooks/logger/neptune.py
+++ b/mmcv/runner/hooks/logger/neptune.py
@@ -58,7 +58,7 @@ class NeptuneLoggerHook(LoggerHook):
 
     def import_neptune(self) -> None:
         try:
-            import neptune.new as neptune
+            import neptune
         except ImportError:
             raise ImportError(
                 'Please run "pip install neptune-client" to install neptune')
@@ -68,9 +68,9 @@ class NeptuneLoggerHook(LoggerHook):
     @master_only
     def before_run(self, runner) -> None:
         if self.init_kwargs:
-            self.run = self.neptune.init(**self.init_kwargs)
+            self.run = self.neptune.init_run(**self.init_kwargs)
         else:
-            self.run = self.neptune.init()
+            self.run = self.neptune.init_run()
 
     @master_only
     def log(self, runner) -> None:

--- a/tests/test_runner/test_hooks.py
+++ b/tests/test_runner/test_hooks.py
@@ -1639,7 +1639,7 @@ def test_neptune_hook():
     runner.run([loader, loader], [('train', 1), ('val', 1)])
     shutil.rmtree(runner.work_dir)
 
-    hook.neptune.init.assert_called_with()
+    hook.neptune.init_run.assert_called_with()
     hook.run['momentum'].log.assert_called_with(0.95, step=6)
     hook.run.stop.assert_called_with()
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Update the deprecated ```neptune-client``` logger hook.
Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.
```neptune-client``` module is updated to ```neptune``` and initialization is updated from ```init()``` to ```init_run()```.
```test_neptune_hook()``` is also updated to assert ```init_run``` instead of ```init```.

```neptune 1.0``` upgrade guide can be found here: https://docs.neptune.ai/setup/neptune-client_1-0_release_changes/

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
