### PR TITLE
add ReduceLROnPlateauHook

### DIFF
--- a/mmcv/runner/base_runner.py
+++ b/mmcv/runner/base_runner.py
@@ -424,6 +424,10 @@ class BaseRunner(metaclass=ABCMeta):
             if policy_type == policy_type.lower():
                 policy_type = policy_type.title()
             hook_type = policy_type + 'LrUpdaterHook'
+
+            if policy_type == 'ReduceLROnPlateau':
+                hook_type = "ReduceLROnPlateauHook"
+
             lr_config['type'] = hook_type
             hook = mmcv.build_from_cfg(lr_config, HOOKS)
         else:

--- a/mmcv/runner/hooks/__init__.py
+++ b/mmcv/runner/hooks/__init__.py
@@ -15,7 +15,7 @@ from .lr_updater import (CosineAnnealingLrUpdaterHook,
                          FlatCosineAnnealingLrUpdaterHook, InvLrUpdaterHook,
                          LinearAnnealingLrUpdaterHook, LrUpdaterHook,
                          OneCycleLrUpdaterHook, PolyLrUpdaterHook,
-                         StepLrUpdaterHook)
+                         StepLrUpdaterHook, ReduceLROnPlateauHook)
 from .memory import EmptyCacheHook
 from .momentum_updater import (CosineAnnealingMomentumUpdaterHook,
                                CyclicMomentumUpdaterHook,
@@ -44,5 +44,6 @@ __all__ = [
     'SyncBuffersHook', 'EMAHook', 'EvalHook', 'DistEvalHook', 'ProfilerHook',
     'GradientCumulativeOptimizerHook', 'GradientCumulativeFp16OptimizerHook',
     'SegmindLoggerHook', 'LinearAnnealingLrUpdaterHook',
-    'LinearAnnealingMomentumUpdaterHook', 'ClearMLLoggerHook'
+    'LinearAnnealingMomentumUpdaterHook', 'ClearMLLoggerHook',
+    'ReduceLROnPlateauHook'
 ]

--- a/mmcv/runner/hooks/average_loss.py
+++ b/mmcv/runner/hooks/average_loss.py
@@ -1,0 +1,19 @@
+class AverageLoss:
+    def __init__(self, name=None, n=500):
+        assert n > 0
+        self.name = name
+        self.window_len = n
+        self.reset()
+
+    def reset(self):
+        self.loss_history = list()
+        self.count = 0
+
+    def update(self, val):
+        assert isinstance(val, (float, int))
+        self.loss_history.append(val)
+        self.count += 1
+
+    def average(self):
+        history = self.loss_history[-self.window_len:]
+        return sum(history) / len(history)


### PR DESCRIPTION
## Motivation

To add [REDUCELRONPLATEAU](https://pytorch.org/docs/stable/generated/torch.optim.lr_scheduler.ReduceLROnPlateau.html#reducelronplateau) like learning rate scheduler that monitors "average" training loss.

## Modification

Simple package imports together with a simple class to have moving average of loss values and the LR updater hook itself.

## BC-breaking (Optional)

No, it does not introduce changes that break the backward-compatibility of the downstream repositories.
