### PR TITLE
[Feature] ms_deform_attn performance optimization V3

### DIFF
--- a/mmcv/ops/csrc/common/mlu/ms_deform_attn_mlu_kernel.mlu
+++ b/mmcv/ops/csrc/common/mlu/ms_deform_attn_mlu_kernel.mlu
@@ -1,5 +1,5 @@
-/*************************************************************************
- * Copyright (C) 2022 by Cambricon.
+/************************************************************************* 
+ *copyright (C) 2022 by Cambricon.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
@@ -32,7 +32,6 @@
 /****************************************************************************************
  *
  * NRAM partition backward:
- * default kernel
  * | grad_output_nram   | grad_output_nram_temp | grad_weight       |
  * | grad_h_weight      | grad_w_weight         | top_grad          |
  * | top_grad_temp      | spatial_shapes_nram   | sampling_loc_nram |
@@ -40,26 +39,11 @@
  * | deal_size          | deal_size             | deal_size         |
  * | deal_size          | deal_size             | 64bytes           |
  *
- * small channel kernel
- * |  nram_grad_output_tl   |   nram_grad_output_tr   |   nram_grad_output_bl  |
- * |  nram_grad_output_br   |         grad_temp1      |        grad_temp2      |
- * |      grad_temp3        |         grad_temp4      |        nram_loc_w      |
- * |     nram_loc_h         |         nram_h_low      |        nram_w_low      |
- * |     nram_h_high        |        nram_w_high      |       nram_h_low_temp  |
- * |   nram_h_high_temp     |         nram_hw         |         nram_hh        |
- * |        nram_lw         |         nram_lh         | nram_h_low_ptr_offset  |
- * | nram_h_high_ptr_offset |  nram_w_low_ptr_offset  | nram_w_high_ptr_offset |
- * |        nram_w1         |         nram_w2         |         nram_w3        |
- * |        nram_w4         |     nram_grad_weight    |        nram_base_ptr   |
- * |    nram_offset_temp    |        nram_offset1     |        nram_offset2    |
- * |     nram_offset3       |        nram_offset4     |     nram_w_low_temp    |
- * |  nram_spatial_shapes   | nram_level_start_index  |     nram_h_stride      |
  ****************************************************************************************/
 
 #define TWELVE_SPLIT 12
 #define ALIGN_NUM 32
 #define ALIGN_NUM_FOR_REDUCE 32
-#define ELE_COUNT 32
 #define LEN_FLOAT sizeof(float)
 
 __nram__ char nram_buffer[MAX_NRAM_SIZE];
@@ -556,17 +540,6 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardDefault(
   return;
 }
 
-__mlu_func__ void genMask0101(float *mask_ram, int32_t size) {
-  int32_t align_num = NFU_ALIGN_SIZE / sizeof(float);
-  for (int32_t i = 0; i < align_num; ++i) {
-    mask_ram[i] = i % 2;
-  }
-  __asm__ volatile("sync;");
-  __memcpy(mask_ram + align_num, mask_ram, NFU_ALIGN_SIZE, NRAM2NRAM,
-           NFU_ALIGN_SIZE, 0, size / align_num - 2);
-  __asm__ volatile("sync;");
-}
-
 template <typename T>
 __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
     const char *data_value_gdram, const char *data_spatial_shapes_gdram,
@@ -575,471 +548,467 @@ __mlu_global__ void MLUKernelMsDeformAttnForwardSmallChannel(
     const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
     const int32_t channels, const int32_t num_levels, const int32_t num_queries,
     const int32_t num_points, char *data_col_gdram) {
-#if __BANG_ARCH__ >= 300
   if (coreId == 0x80) {
     return;
   }
-
-  size_t block_num_per_core, batch_start, deal_g, offset_g;
-  size_t block_num_rem = 0;
-  const size_t grid_total = num_queries * num_heads * num_levels * num_points;
-  if (batch_size >= taskDim) {
-    block_num_rem = batch_size % taskDim;
-    block_num_per_core = taskId < block_num_rem ? batch_size / taskDim + 1
-                                                : batch_size / taskDim;
-    batch_start = taskId < block_num_rem
-                      ? taskId * block_num_per_core
-                      : taskId * block_num_per_core + block_num_rem;
-    deal_g = grid_total;
-    offset_g = 0;
-  } else {
-    size_t skip_n = taskDim / batch_size;
-    batch_start = taskId / skip_n;
-    block_num_per_core = batch_start >= batch_size ? 0 : 1;
-    deal_g = PAD_UP(grid_total / skip_n, num_levels * num_points);
-    size_t id = taskId % skip_n;
-    offset_g = id * deal_g;
-    deal_g = id < (skip_n - 1) ? deal_g : grid_total - deal_g * (skip_n - 1);
-  }
-
-  const int32_t float_align = NFU_ALIGN_SIZE / sizeof(float);
-  int32_t deal_num;
-  int32_t cut_channel_iter = 2;
 
   const size_t spatial_size =
       PAD_UP(num_levels * 2 * sizeof(int32_t), NFU_ALIGN_SIZE);
   const size_t level_start_index_size =
       PAD_UP(num_levels * sizeof(int32_t), NFU_ALIGN_SIZE);
-
-  int32_t channel = channels;
-  int32_t mult;
-  while (true) {
-    deal_num = (MAX_NRAM_SIZE - spatial_size - level_start_index_size) /
-               (8 * channel + 7) / sizeof(T);
-    deal_num = PAD_DOWN(deal_num, float_align);
-    deal_num = PAD_DOWN(deal_num, num_levels * num_points);
-    if (deal_num > 0) {
-      break;
-    } else {
-      channel = channels / cut_channel_iter;
-      cut_channel_iter += 2;
-    }
+  size_t sampling_loc_size =
+      PAD_UP(num_levels * num_points * 2 * sizeof(T), NFU_ALIGN_SIZE);
+  size_t attn_weight_size =
+      PAD_UP(num_levels * num_points * sizeof(T), NFU_ALIGN_SIZE);
+  size_t span_num_deal =
+      PAD_DOWN((MAX_NRAM_SIZE - spatial_size - level_start_index_size -
+                sampling_loc_size - attn_weight_size) /
+                   TWELVE_SPLIT / sizeof(T),
+               NFU_ALIGN_SIZE);
+  const int32_t channels_seg_num = channels / span_num_deal;
+  const size_t channels_rem = channels % span_num_deal;
+  int32_t load_loc_weight_idx = 0;
+  int32_t load_loc_weight_seg = 1;
+  if (channels_seg_num == 0) {
+    span_num_deal = PAD_UP(channels, NFU_ALIGN_SIZE);
+    attn_weight_size =
+        PAD_DOWN((MAX_NRAM_SIZE - spatial_size - level_start_index_size -
+                  TWELVE_SPLIT * span_num_deal * sizeof(T)) /
+                     3,
+                 num_levels * num_points * sizeof(T));
+    attn_weight_size = PAD_DOWN(attn_weight_size, NFU_ALIGN_SIZE);
+    sampling_loc_size = attn_weight_size * 2;
+    load_loc_weight_seg =
+        attn_weight_size / (num_levels * num_points * sizeof(T));
   }
-  mult = channel;
 
-  const int32_t c_rep = channels / channel;
-  const int32_t c_rem = channels % channel;
-
-  const int32_t g_rep = deal_g / deal_num;
-  const int32_t g_rem = deal_g % deal_num;
-
-  // nram buffer alloc
+#if __BANG_ARCH__ < 322
+  const size_t align_num = NFU_ALIGN_SIZE;
+  const size_t channels_align_rem = CEIL_ALIGN(channels_rem, align_num);
+#endif
   char *data_spatial_shapes_nram = nram_buffer;
   char *data_level_start_index_nram = data_spatial_shapes_nram + spatial_size;
-  char *input_tl = data_level_start_index_nram + level_start_index_size;
-  char *input_tr = input_tl + deal_num * mult * sizeof(T);
-  char *input_bl = input_tr + deal_num * mult * sizeof(T);
-  char *input_br = input_bl + deal_num * mult * sizeof(T);
-  char *weight_tl = input_tl + 4 * deal_num * mult * sizeof(T);
-  char *weight_tr = weight_tl + deal_num * mult * sizeof(T);
-  char *weight_bl = weight_tr + deal_num * mult * sizeof(T);
-  char *weight_br = weight_bl + deal_num * mult * sizeof(T);
-  char *mask_tl = weight_br + deal_num * mult * sizeof(T);
-  char *mask_tr = mask_tl + deal_num * sizeof(T);
-  char *mask_bl = mask_tr + deal_num * sizeof(T);
-  char *mask_br = mask_bl + deal_num * sizeof(T);
-  char *point_ram = mask_br + deal_num * sizeof(T);
-  char *index_tl = point_ram + deal_num * sizeof(T);
-  char *index_bl = index_tl + deal_num * sizeof(T);
+  char *data_sampling_loc_nram =
+      data_level_start_index_nram + level_start_index_size;
+  char *data_attn_weight_nram = data_sampling_loc_nram + sampling_loc_size;
+  char *ping_data_value_p1_nram = data_attn_weight_nram + attn_weight_size;
+  char *ping_data_value_p2_nram =
+      ping_data_value_p1_nram + span_num_deal * sizeof(T);
+  char *ping_data_value_p3_nram =
+      ping_data_value_p2_nram + span_num_deal * sizeof(T);
+  char *ping_data_value_p4_nram =
+      ping_data_value_p3_nram + span_num_deal * sizeof(T);
+  char *ping_data_col_nram =
+      ping_data_value_p4_nram + span_num_deal * sizeof(T);
+  char *pong_data_value_p1_nram =
+      ping_data_col_nram + span_num_deal * sizeof(T);
+  char *pong_data_value_p2_nram =
+      pong_data_value_p1_nram + span_num_deal * sizeof(T);
+  char *pong_data_value_p3_nram =
+      pong_data_value_p2_nram + span_num_deal * sizeof(T);
+  char *pong_data_value_p4_nram =
+      pong_data_value_p3_nram + span_num_deal * sizeof(T);
+  char *pong_data_col_nram =
+      pong_data_value_p4_nram + span_num_deal * sizeof(T);
+  char *auxiliary_a = pong_data_col_nram + span_num_deal * sizeof(T);
+  char *auxiliary_b = auxiliary_a + span_num_deal * sizeof(T);
+  const size_t ping_pong_gap = 5 * span_num_deal * sizeof(T);
+  size_t data_col_ping_pong_idx = 0;
 
-  // nram space reuse
-  char *grid_ram = weight_tl;
-  char *mask_ram = weight_bl;
-  char *coord_x = input_bl;
-  char *coord_y = coord_x + deal_num * sizeof(T);
-  char *coord_x_low = input_tl;
-  char *coord_y_low = coord_x_low + deal_num * sizeof(T);
-  char *coord_x_low_int = weight_tl;
-  char *coord_y_low_int = weight_tr;
-  char *spatial_x = mask_tl;
-  char *spatial_y = mask_tr;
-  char *spatial_x_float = weight_bl;
-  char *spatial_y_float = weight_br;
-  char *spatial_x_temp = mask_bl;
-  char *spatial_y_temp = mask_br;
-  char *base_ptr_offset = weight_tl;
-  char *auxiliary_a = point_ram;
-  char *auxiliary_b = weight_bl;
+  const int32_t block_num_rem =
+      (batch_size * num_queries * num_heads) % taskDim;
+  const int32_t block_num_per_core =
+      taskId < block_num_rem
+          ? (batch_size * num_queries * num_heads) / taskDim + 1
+          : (batch_size * num_queries * num_heads) / taskDim;
+  const int32_t idx_start = taskId < block_num_rem
+                                ? taskId * block_num_per_core
+                                : taskId * block_num_per_core + block_num_rem;
 
   __memcpy_async(data_spatial_shapes_nram, data_spatial_shapes_gdram,
                  num_levels * 2 * sizeof(int32_t), GDRAM2NRAM);
   __memcpy_async(data_level_start_index_nram, data_level_start_index_gdram,
                  num_levels * sizeof(int32_t), GDRAM2NRAM);
-  __asm__ volatile("sync;");
 
-  for (int32_t batch_idx = batch_start;
-       batch_idx < batch_start + block_num_per_core; ++batch_idx) {
-    for (int32_t grid_iter = 0; grid_iter <= g_rep; ++grid_iter) {
-      int32_t io_data_num = deal_num;
-      const int32_t grid_off_base =
-          batch_idx * grid_total + offset_g + grid_iter * deal_num;
-      if (grid_iter == g_rep) {
-        if (g_rem == 0) {
-          continue;
-        } else {
-          io_data_num = g_rem;
-        }
-      }
+  for (int32_t cur_idx = idx_start; cur_idx < idx_start + block_num_per_core;
+       ++cur_idx) {
+    // cur_idx = batch_idx * num_queries * num_heads + query_idx * num_heads +
+    // head_idx
+    const int32_t head_idx = cur_idx % num_heads;
+    const int32_t batch_idx = (cur_idx / num_heads) / num_queries;
 
-      char *data_col_gdram_start =
-          data_col_gdram + (batch_idx * num_queries * num_heads * channels +
-                            (offset_g + grid_iter * deal_num) /
-                                (num_levels * num_points) * channels) *
-                               sizeof(float);
+    const char *data_value_gdram_start =
+        data_value_gdram +
+        batch_idx * num_keys * num_heads * channels * sizeof(T);
+    char *data_col_gdram_start =
+        data_col_gdram + cur_idx * channels * sizeof(T);
 
-      // load data_sampling_loc
+    if (load_loc_weight_seg == 1 ||
+        (load_loc_weight_idx % load_loc_weight_seg) == 0) {
+      const char *data_sampling_loc_gdram_start =
+          data_sampling_loc_gdram +
+          cur_idx * num_levels * num_points * 2 * sizeof(T);
+      const char *data_attn_weight_gdram_start =
+          data_attn_weight_gdram +
+          cur_idx * num_levels * num_points * sizeof(T);
+      const int32_t load_loc_weight_size =
+          (block_num_per_core - load_loc_weight_idx) < load_loc_weight_seg
+              ? block_num_per_core - load_loc_weight_idx
+              : load_loc_weight_seg;
       __memcpy_async(
-          grid_ram, data_sampling_loc_gdram + grid_off_base * 2 * sizeof(float),
-          io_data_num * 2 * sizeof(float), GDRAM2NRAM);
-      genMask0101((float *)mask_ram, deal_num * 2);
+          data_sampling_loc_nram, data_sampling_loc_gdram_start,
+          load_loc_weight_size * num_levels * num_points * 2 * sizeof(T),
+          GDRAM2NRAM);
+      __memcpy_async(data_attn_weight_nram, data_attn_weight_gdram_start,
+                     load_loc_weight_size * num_levels * num_points * sizeof(T),
+                     GDRAM2NRAM);
       __asm__ volatile("sync;");
-
-      // generate x and y coordinate vector
-      // generate spatial_x and spatial_y spatial vector
-      __bang_collect((float *)coord_y, (float *)grid_ram, (float *)mask_ram,
-                     deal_num * 2);  // y
-      __bang_collect((float *)spatial_x_temp, (float *)data_spatial_shapes_nram,
-                     (float *)mask_ram,
-                     num_levels * 2);  // spatial_x
-      __bang_not((float *)mask_ram, (float *)mask_ram, deal_num * 2);
-      __bang_collect((float *)coord_x, (float *)grid_ram, (float *)mask_ram,
-                     deal_num * 2);  // x
-      __bang_collect((float *)spatial_y_temp, (float *)data_spatial_shapes_nram,
-                     (float *)mask_ram,
-                     num_levels * 2);  // spatial_y
-
-      for (int32_t i = 0; i < num_levels; i++) {
-        __bang_write_value((int32_t *)spatial_x + i * num_points, num_points,
-                           ((int32_t *)spatial_x_temp)[i]);
-        __bang_write_value((int32_t *)spatial_y + i * num_points, num_points,
-                           ((int32_t *)spatial_y_temp)[i]);
-      }
-
-      __bang_int322float_rd((float *)spatial_x_float, (int32_t *)spatial_x,
-                            num_levels * num_points, 0);
-      __bang_int322float_rd((float *)spatial_y_float, (int32_t *)spatial_y,
-                            num_levels * num_points, 0);
-
-      // map x from [0, 1] to [0, spatial_x]; map y from [0, 1] to [0,
-      // spatial_y]
-      __bang_cycle_mul((float *)coord_x, (float *)coord_x,
-                       (float *)spatial_x_float, deal_num,
-                       num_levels * num_points);
-      __bang_sub_scalar((float *)coord_x, (float *)coord_x, (float)0.5,
-                        deal_num);
-      __bang_cycle_mul((float *)coord_y, (float *)coord_y,
-                       (float *)spatial_y_float, deal_num,
-                       num_levels * num_points);
-      __bang_sub_scalar((float *)coord_y, (float *)coord_y, (float)0.5,
-                        deal_num);
-
-      __bang_floor((float *)coord_x_low, (float *)coord_x, deal_num);
-      __bang_floor((float *)coord_y_low, (float *)coord_y, deal_num);
-
-      // calc index_tl
-      const int32_t w_stride = num_heads * channels;
-      __bang_float2int32_rd((int32_t *)coord_x_low_int, (float *)coord_x_low,
-                            deal_num, 0);
-      __bang_float2int32_rd((int32_t *)coord_y_low_int, (float *)coord_y_low,
-                            deal_num, 0);
-      __bang_cycle_mul((int32_t *)index_tl, (int32_t *)coord_y_low_int,
-                       (int32_t *)spatial_x, deal_num, num_levels * num_points);
-      __bang_add((int32_t *)index_tl, (int32_t *)index_tl,
-                 (int32_t *)coord_x_low_int, deal_num);
-      __bang_mul_scalar((int32_t *)index_tl, (int32_t *)index_tl, w_stride,
-                        deal_num);
-
-      const int32_t deal_lp_num = deal_num / (num_levels * num_points);
-      const int32_t h_rep = deal_lp_num / num_heads;
-      const int32_t h_rem = deal_lp_num % num_heads;
-      const int32_t head_start =
-          ((offset_g + grid_iter * deal_num) / (num_levels * num_points)) %
-          num_heads;
-      for (int32_t iter = 0; iter < num_heads; ++iter) {
-        ((int32_t *)base_ptr_offset)[iter] =
-            ((head_start + iter) % num_heads) * channels;
-      }
-      if (h_rep > 0) {
-        __memcpy((int32_t *)base_ptr_offset + num_heads,
-                 (int32_t *)base_ptr_offset, num_heads * sizeof(int32_t),
-                 NRAM2NRAM, num_heads * sizeof(int32_t), 0, h_rep - 1);
-      }
-      if (h_rep > 0 && h_rem > 0) {
-        __memcpy((int32_t *)base_ptr_offset + h_rep * num_heads,
-                 (int32_t *)base_ptr_offset, h_rem * sizeof(int32_t),
-                 NRAM2NRAM);
-      }
-      __bang_transpose((int32_t *)auxiliary_a, (int32_t *)index_tl, deal_lp_num,
-                       num_levels * num_points);
-      __bang_cycle_add((int32_t *)auxiliary_a, (int32_t *)auxiliary_a,
-                       (int32_t *)base_ptr_offset, deal_num, deal_lp_num);
-      __bang_transpose((int32_t *)index_tl, (int32_t *)auxiliary_a,
-                       num_levels * num_points, deal_lp_num);
-
-      // calc index_bl
-      __bang_mul_scalar((int32_t *)auxiliary_a, (int32_t *)spatial_x, w_stride,
-                        deal_num);
-      __bang_cycle_add((int32_t *)index_bl, (int32_t *)index_tl,
-                       (int32_t *)auxiliary_a, deal_num,
-                       num_levels * num_points);
-
-      // calc mask_tl, mask_tr, mask_bl, mask_br
-      __bang_sub_scalar((float *)spatial_x_float, (float *)spatial_x_float,
-                        (float)1.0, deal_num);
-      __bang_sub_scalar((float *)spatial_y_float, (float *)spatial_y_float,
-                        (float)1.0, deal_num);
-      // mask_tl : 0 <= coord_x_low < spatial_x && 0 <= coord_y_low < spatial_y
-      __bang_ge_scalar((float *)mask_bl, (float *)coord_x_low, (float)0,
-                       deal_num);
-      __bang_cycle_le((float *)mask_br, (float *)coord_x_low,
-                      (float *)spatial_x_float, deal_num,
-                      num_levels * num_points);
-      __bang_and((float *)mask_bl, (float *)mask_bl, (float *)mask_br,
-                 deal_num);
-
-      __bang_ge_scalar((float *)mask_tr, (float *)coord_y_low, (float)0,
-                       deal_num);
-      __bang_cycle_le((float *)mask_br, (float *)coord_y_low,
-                      (float *)spatial_y_float, deal_num,
-                      num_levels * num_points);
-      __bang_and((float *)mask_tr, (float *)mask_tr, (float *)mask_br,
-                 deal_num);
-      __bang_and((float *)mask_tl, (float *)mask_tr, (float *)mask_bl,
-                 deal_num);
-
-      // mask_tr : 0 <= coord_x_high < spatial_x && 0 <= coord_y_low < spatial_y
-      __bang_ge_scalar((float *)mask_br, (float *)coord_x_low, (float)(-1.0),
-                       deal_num);
-      __bang_cycle_lt((float *)auxiliary_a, (float *)coord_x_low,
-                      (float *)spatial_x_float, deal_num,
-                      num_levels * num_points);
-      __bang_and((float *)mask_br, (float *)mask_br, (float *)auxiliary_a,
-                 deal_num);
-      __bang_and((float *)mask_tr, (float *)mask_tr, (float *)mask_br,
-                 deal_num);
-
-      // mask_bl : 0 <= coord_x_low < spatial_x && 0 <= coord_y_high < spatial_y
-      __bang_ge_scalar((float *)auxiliary_a, (float *)coord_y_low,
-                       (float)(-1.0), deal_num);
-      __bang_cycle_lt((float *)auxiliary_b, (float *)coord_y_low,
-                      (float *)spatial_y_float, deal_num,
-                      num_levels * num_points);
-      __bang_and((float *)auxiliary_a, (float *)auxiliary_a,
-                 (float *)auxiliary_b, deal_num);
-      __bang_and((float *)mask_bl, (float *)mask_bl, (float *)auxiliary_a,
-                 deal_num);
-
-      // mask_br : 0 <= coord_x_high < spatial_x && 0 <= coord_y_high <
-      // spatial_y
-      __bang_and((float *)mask_br, (float *)mask_br, (float *)auxiliary_a,
-                 deal_num);
-
-      // calc inner point num
-      __bang_mul_scalar((float *)weight_tl, (float *)mask_tl, (float)7.0,
-                        deal_num);
-      __bang_mul_scalar((float *)weight_tr, (float *)mask_tr, (float)5.0,
-                        deal_num);
-      __bang_add((float *)weight_tl, (float *)weight_tl, (float *)weight_tr,
-                 deal_num);
-      __bang_mul_scalar((float *)weight_tr, (float *)mask_bl, (float)3.0,
-                        deal_num);
-      __bang_add((float *)point_ram, (float *)weight_tr, (float *)mask_br,
-                 deal_num);
-      __bang_add((float *)point_ram, (float *)point_ram, (float *)weight_tl,
-                 deal_num);
-
-      // calc interpolation weight
-      __bang_sub((float *)weight_bl, (float *)coord_x_low, (float *)coord_x,
-                 deal_num);
-      __bang_sub((float *)weight_br, (float *)coord_y_low, (float *)coord_y,
-                 deal_num);
-      __bang_add_scalar((float *)weight_bl, (float *)weight_bl, (float)1.0,
-                        deal_num);
-      __bang_add_scalar((float *)weight_br, (float *)weight_br, (float)1.0,
-                        deal_num);
-
-      __bang_sub((float *)weight_tl, (float *)coord_x, (float *)coord_x_low,
-                 deal_num);
-      __bang_sub((float *)weight_tr, (float *)coord_y, (float *)coord_y_low,
-                 deal_num);
-      __bang_mul((float *)input_tl, (float *)weight_bl, (float *)weight_br,
-                 deal_num);
-      __bang_mul((float *)input_tl + deal_num, (float *)weight_br,
-                 (float *)weight_tl, deal_num);
-      __bang_mul((float *)input_tl + 2 * deal_num, (float *)weight_bl,
-                 (float *)weight_tr, deal_num);
-      __bang_mul((float *)input_tl + 3 * deal_num, (float *)weight_tl,
-                 (float *)weight_tr, deal_num);
-
-      __asm__ volatile("sync;");
-
-      // extend weight
-      const int32_t w_rep = channel / ELE_COUNT * ELE_COUNT;
-      const int32_t w_rem = channel % ELE_COUNT;
-      if (w_rem != 0) {
-        const int32_t data_sz = 1 * sizeof(float);
-        const int32_t dst_str = channel * sizeof(float);
-        for (int32_t iter = w_rep; iter < channel; ++iter) {
-          __memcpy_async((float *)weight_tl + iter, (float *)input_tl, data_sz,
-                         NRAM2NRAM, dst_str, data_sz, 4 * deal_num - 1);
-        }
-      }
-      if (w_rep != 0) {
-        for (int32_t i = 0; i < 4 * deal_num; i++) {
-          __bang_write_value((float *)weight_tl + i * channel, w_rep,
-                             ((float *)input_tl)[i]);
-        }
-      }
-
-      __asm__ volatile("sync;");
-
-      const char *data_value_gdram_start =
-          data_value_gdram +
-          batch_idx * num_keys * num_heads * channels * sizeof(float);
-      const int32_t c_str = deal_num * channel * sizeof(float);
-      const int32_t cs_str = num_heads * channels * sizeof(float);
-
-      for (int32_t c_iter = 0; c_iter <= c_rep; ++c_iter) {
-        int32_t c_real_num = channel;
-        if (c_iter == c_rep) {
-          if (c_rem == 0) {
-            continue;
-          } else {
-            c_real_num = c_rem;
-          }
-        }
-
-        __bang_write_zero((float *)input_tl, 4 * deal_num * channel);
-        __asm__ volatile("sync;");
-
-        // load data_value
-        for (int32_t p_idx = 0; p_idx < io_data_num; ++p_idx) {
-          const int32_t inner_point_num = (int32_t)((float *)point_ram)[p_idx];
-          const int32_t tl_offset = ((int32_t *)index_tl)[p_idx];
-          const int32_t bl_offset = ((int32_t *)index_bl)[p_idx];
-          const int32_t level_start_id =
-              ((int32_t *)data_level_start_index_nram)[(p_idx / num_points) %
-                                                       num_levels];
-          const char *data_value_ptr =
-              data_value_gdram_start +
-              (level_start_id * num_heads * channels + c_iter * channel) *
-                  sizeof(float);
-
-          switch (inner_point_num) {
-            case 16:  // 4 points are cached.
-              __memcpy_async((float *)input_tl + p_idx * channel,
-                             (float *)data_value_ptr + tl_offset,
-                             c_real_num * sizeof(float), GDRAM2NRAM, c_str,
-                             cs_str, 1);
-              __memcpy_async((float *)input_bl + p_idx * channel,
-                             (float *)data_value_ptr + bl_offset,
-                             c_real_num * sizeof(float), GDRAM2NRAM, c_str,
-                             cs_str, 1);
-              break;
-            case 12:  // 2 points are cached. (top_left, top_right)
-              __memcpy_async((float *)input_tl + p_idx * channel,
-                             (float *)data_value_ptr + tl_offset,
-                             c_real_num * sizeof(float), GDRAM2NRAM, c_str,
-                             cs_str, 1);
-              break;
-            case 4:  // 2 points are cached. (bottom_left, bottom_right)
-              __memcpy_async((float *)input_bl + p_idx * channel,
-                             (float *)data_value_ptr + bl_offset,
-                             c_real_num * sizeof(float), GDRAM2NRAM, c_str,
-                             cs_str, 1);
-              break;
-            case 10:  // 2 points are cached. (top_left, bottom_left)
-              __memcpy_async((float *)input_tl + p_idx * channel,
-                             (float *)data_value_ptr + tl_offset,
-                             c_real_num * sizeof(float), GDRAM2NRAM);
-              __memcpy_async((float *)input_bl + p_idx * channel,
-                             (float *)data_value_ptr + bl_offset,
-                             c_real_num * sizeof(float), GDRAM2NRAM);
-              break;
-            case 6:  // 2 points are cached. (top_right, bottom_right)
-              __memcpy_async(
-                  (float *)input_tr + p_idx * channel,
-                  (float *)data_value_ptr + tl_offset + num_heads * channels,
-                  c_real_num * sizeof(float), GDRAM2NRAM);
-              __memcpy_async(
-                  (float *)input_br + p_idx * channel,
-                  (float *)data_value_ptr + bl_offset + num_heads * channels,
-                  c_real_num * sizeof(float), GDRAM2NRAM);
-              break;
-            case 7:  // 1 point is cached. (top_left)
-              __memcpy_async((float *)input_tl + p_idx * channel,
-                             (float *)data_value_ptr + tl_offset,
-                             c_real_num * sizeof(float), GDRAM2NRAM);
-              break;
-            case 5:  // 1 point is cached. (top_right)
-              __memcpy_async(
-                  (float *)input_tr + p_idx * channel,
-                  (float *)data_value_ptr + tl_offset + num_heads * channels,
-                  c_real_num * sizeof(float), GDRAM2NRAM);
-              break;
-            case 3:  // 1 point is cached. (bottom_left)
-              __memcpy_async((float *)input_bl + p_idx * channel,
-                             (float *)data_value_ptr + bl_offset,
-                             c_real_num * sizeof(float), GDRAM2NRAM);
-              break;
-            case 1:  // 1 point is cached. (bottom_right)
-              __memcpy_async(
-                  (float *)input_br + p_idx * channel,
-                  (float *)data_value_ptr + bl_offset + num_heads * channels,
-                  c_real_num * sizeof(float), GDRAM2NRAM);
-              break;
-            default:
-              continue;
-          }
-        }
-
-        __asm__ volatile("sync;");
-
-        // interpolation
-        __bang_mul((float *)input_tl, (float *)input_tl, (float *)weight_tl,
-                   4 * deal_num * channel);
-        __bang_add((float *)input_tl, (float *)input_tl, (float *)input_bl,
-                   2 * deal_num * channel);
-        __bang_add((float *)input_tl, (float *)input_tl, (float *)input_tr,
-                   deal_num * channel);
-
-        // load attention weight
-        void *attn_weight = mask_tl;
-        __memcpy((float *)attn_weight,
-                 (float *)data_attn_weight_gdram + grid_off_base,
-                 io_data_num * sizeof(float), GDRAM2NRAM);
-
-        // calc data_col, muladd attention weight
-        __bang_transpose((float *)input_tr, (float *)input_tl, deal_num,
-                         channel);
-        __bang_cycle_mul((float *)input_tr, (float *)input_tr,
-                         (float *)attn_weight, deal_num * channel, deal_num);
-        __bang_transpose((float *)input_tl, (float *)input_tr, channel,
-                         deal_num);
-        __bang_sumpool((float *)input_bl, (float *)input_tl, channel, 1,
-                       io_data_num, 1, num_levels * num_points,
-                       num_levels * num_points, 1);
-
-        // store
-        __memcpy((float *)data_col_gdram_start + c_iter * channel,
-                 (float *)input_bl, c_real_num * sizeof(float), NRAM2GDRAM,
-                 channels * sizeof(float), channel * sizeof(float),
-                 (io_data_num / (num_levels * num_points)) - 1);
-      }
     }
+    const int32_t load_loc_weight_offset =
+        (load_loc_weight_idx % load_loc_weight_seg) * num_levels * num_points;
+
+    for (int32_t c_seg_idx = 0; c_seg_idx < channels_seg_num; ++c_seg_idx) {
+      __bang_write_value(
+          (T *)(ping_data_col_nram + data_col_ping_pong_idx * ping_pong_gap),
+          span_num_deal, (T)0);
+      // load data
+      // level_idx = 0, point_idx = 0
+      int32_t spatial_h = ((int32_t *)data_spatial_shapes_nram)[0];
+      int32_t spatial_w = ((int32_t *)data_spatial_shapes_nram)[1];
+      const char *data_value_ptr =
+          data_value_gdram_start + c_seg_idx * span_num_deal * sizeof(T);
+      T loc_w = ((T *)data_sampling_loc_nram)[load_loc_weight_offset * 2];
+      T loc_h = ((T *)data_sampling_loc_nram)[load_loc_weight_offset * 2 + 1];
+      T weight = ((T *)data_attn_weight_nram)[load_loc_weight_offset];
+      T x = loc_w * spatial_w - 0.5;
+      T y = loc_h * spatial_h - 0.5;
+      if (y > -1 && x > -1 && y < spatial_h && x < spatial_w) {
+        loadNeighborPointsData(
+            (T *)data_value_ptr, (T *)ping_data_value_p1_nram,
+            (T *)ping_data_value_p2_nram, (T *)ping_data_value_p3_nram,
+            (T *)ping_data_value_p4_nram, span_num_deal, spatial_w, spatial_h,
+            num_heads, channels, x, y, head_idx);
+      }
+      T spatial_h_next_point = 0;
+      T spatial_w_next_point = 0;
+      T weight_next_point = 0;
+      T x_next_point = 0;
+      T y_next_point = 0;
+      __asm__ volatile("sync;");
+
+      for (int32_t level_idx = 0; level_idx < num_levels; ++level_idx) {
+        for (int32_t point_idx = 0; point_idx < num_points; ++point_idx) {
+          // load data
+          if (point_idx == num_points - 1 && level_idx == num_levels - 1) {
+            // last point no need to load data, continue to compute
+          } else if (point_idx == num_points - 1) {
+            const int32_t level_start_id =
+                ((int32_t *)data_level_start_index_nram)[level_idx + 1];
+            const int32_t spatial_h_ptr = (level_idx + 1) << 1;
+            spatial_h_next_point =
+                ((int32_t *)data_spatial_shapes_nram)[spatial_h_ptr];
+            spatial_w_next_point =
+                ((int32_t *)data_spatial_shapes_nram)[spatial_h_ptr + 1];
+            data_value_ptr = data_value_gdram_start +
+                             (level_start_id * num_heads * channels +
+                              c_seg_idx * span_num_deal) *
+                                 sizeof(T);
+            loc_w = ((T *)data_sampling_loc_nram)[(load_loc_weight_offset +
+                                                   level_idx * num_points +
+                                                   point_idx + 1) *
+                                                  2];
+            loc_h = ((T *)data_sampling_loc_nram)[(load_loc_weight_offset +
+                                                   level_idx * num_points +
+                                                   point_idx + 1) *
+                                                      2 +
+                                                  1];
+            weight_next_point =
+                ((T *)data_attn_weight_nram)[load_loc_weight_offset +
+                                             level_idx * num_points +
+                                             point_idx + 1];
+            x_next_point = loc_w * spatial_w_next_point - 0.5;
+            y_next_point = loc_h * spatial_h_next_point - 0.5;
+            if (y_next_point > -1 && x_next_point > -1 &&
+                y_next_point < spatial_h_next_point &&
+                x_next_point < spatial_w_next_point) {
+              loadNeighborPointsData(
+                  (T *)data_value_ptr,
+                  (T *)(ping_data_value_p1_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p2_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p3_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p4_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  span_num_deal, spatial_w_next_point, spatial_h_next_point,
+                  num_heads, channels, x_next_point, y_next_point, head_idx);
+            }
+          } else {
+            spatial_h_next_point = spatial_h;
+            spatial_w_next_point = spatial_w;
+            loc_w = ((T *)data_sampling_loc_nram)[(load_loc_weight_offset +
+                                                   level_idx * num_points +
+                                                   point_idx + 1) *
+                                                  2];
+            loc_h = ((T *)data_sampling_loc_nram)[(load_loc_weight_offset +
+                                                   level_idx * num_points +
+                                                   point_idx + 1) *
+                                                      2 +
+                                                  1];
+            weight_next_point =
+                ((T *)data_attn_weight_nram)[load_loc_weight_offset +
+                                             level_idx * num_points +
+                                             point_idx + 1];
+            x_next_point = loc_w * spatial_w - 0.5;
+            y_next_point = loc_h * spatial_h - 0.5;
+            if (y_next_point > -1 && x_next_point > -1 &&
+                y_next_point < spatial_h && x_next_point < spatial_w) {
+              loadNeighborPointsData(
+                  (T *)data_value_ptr,
+                  (T *)(ping_data_value_p1_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p2_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p3_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p4_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  span_num_deal, spatial_w, spatial_h, num_heads, channels,
+                  x_next_point, y_next_point, head_idx);
+            }
+          }
+
+          // compute
+          if (y > -1 && x > -1 && y < spatial_h && x < spatial_w) {
+            computeMsDeformAttn(
+                (T *)(ping_data_value_p1_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)(ping_data_value_p2_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)(ping_data_value_p3_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)(ping_data_value_p4_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)auxiliary_a, (T *)auxiliary_b,
+                (T *)(ping_data_col_nram +
+                      data_col_ping_pong_idx * ping_pong_gap),
+                weight, span_num_deal, spatial_w, spatial_h, x, y);
+          }
+
+          spatial_w = spatial_w_next_point;
+          spatial_h = spatial_h_next_point;
+          weight = weight_next_point;
+          x = x_next_point;
+          y = y_next_point;
+          __asm__ volatile("sync;");
+        }
+      }
+      // store
+      __memcpy_async(
+          data_col_gdram_start + c_seg_idx * span_num_deal * sizeof(T),
+          ping_data_col_nram + data_col_ping_pong_idx * ping_pong_gap,
+          span_num_deal * sizeof(T), NRAM2GDRAM);
+      data_col_ping_pong_idx = (data_col_ping_pong_idx + 1) % 2;
+    }
+
+    if (channels_rem > 0) {
+#if __BANG_ARCH__ >= 322
+      __bang_write_value(
+          (T *)(ping_data_col_nram + data_col_ping_pong_idx * ping_pong_gap),
+          channels_rem, (T)0);
+#else
+      __bang_write_value(
+          (T *)(ping_data_col_nram + data_col_ping_pong_idx * ping_pong_gap),
+          channels_align_rem, (T)0);
+#endif
+      // load data
+      // level_idx = 0, point_idx = 0
+      int32_t spatial_h = ((int32_t *)data_spatial_shapes_nram)[0];
+      int32_t spatial_w = ((int32_t *)data_spatial_shapes_nram)[1];
+      const char *data_value_ptr =
+          data_value_gdram_start + channels_seg_num * span_num_deal * sizeof(T);
+      T loc_w = ((T *)data_sampling_loc_nram)[load_loc_weight_offset * 2];
+      T loc_h = ((T *)data_sampling_loc_nram)[load_loc_weight_offset * 2 + 1];
+      T weight = ((T *)data_attn_weight_nram)[load_loc_weight_offset];
+      T x = loc_w * spatial_w - 0.5;
+      T y = loc_h * spatial_h - 0.5;
+      if (y > -1 && x > -1 && y < spatial_h && x < spatial_w) {
+        loadNeighborPointsData(
+            (T *)data_value_ptr, (T *)ping_data_value_p1_nram,
+            (T *)ping_data_value_p2_nram, (T *)ping_data_value_p3_nram,
+            (T *)ping_data_value_p4_nram, channels_rem, spatial_w, spatial_h,
+            num_heads, channels, x, y, head_idx);
+      }
+      T spatial_h_next_point = 0;
+      T spatial_w_next_point = 0;
+      T weight_next_point = 0;
+      T x_next_point = 0;
+      T y_next_point = 0;
+      __asm__ volatile("sync;");
+
+      for (int32_t level_idx = 0; level_idx < num_levels; ++level_idx) {
+        for (int32_t point_idx = 0; point_idx < num_points; ++point_idx) {
+          // load data
+          if (point_idx == num_points - 1 && level_idx == num_levels - 1) {
+            // last point no need to load data, continue to compute
+          } else if (point_idx == num_points - 1) {
+            const int32_t level_start_id =
+                ((int32_t *)data_level_start_index_nram)[level_idx + 1];
+            const int32_t spatial_h_ptr = (level_idx + 1) << 1;
+            spatial_h_next_point =
+                ((int32_t *)data_spatial_shapes_nram)[spatial_h_ptr];
+            spatial_w_next_point =
+                ((int32_t *)data_spatial_shapes_nram)[spatial_h_ptr + 1];
+            data_value_ptr = data_value_gdram_start +
+                             (level_start_id * num_heads * channels +
+                              channels_seg_num * span_num_deal) *
+                                 sizeof(T);
+            loc_w = ((T *)data_sampling_loc_nram)[(load_loc_weight_offset +
+                                                   level_idx * num_points +
+                                                   point_idx + 1) *
+                                                  2];
+            loc_h = ((T *)data_sampling_loc_nram)[(load_loc_weight_offset +
+                                                   level_idx * num_points +
+                                                   point_idx + 1) *
+                                                      2 +
+                                                  1];
+            weight_next_point =
+                ((T *)data_attn_weight_nram)[load_loc_weight_offset +
+                                             level_idx * num_points +
+                                             point_idx + 1];
+            x_next_point = loc_w * spatial_w_next_point - 0.5;
+            y_next_point = loc_h * spatial_h_next_point - 0.5;
+            if (y_next_point > -1 && x_next_point > -1 &&
+                y_next_point < spatial_h_next_point &&
+                x_next_point < spatial_w_next_point) {
+              loadNeighborPointsData(
+                  (T *)data_value_ptr,
+                  (T *)(ping_data_value_p1_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p2_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p3_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p4_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  channels_rem, spatial_w_next_point, spatial_h_next_point,
+                  num_heads, channels, x_next_point, y_next_point, head_idx);
+            }
+          } else {
+            spatial_w_next_point = spatial_w;
+            spatial_h_next_point = spatial_h;
+            loc_w = ((T *)data_sampling_loc_nram)[(load_loc_weight_offset +
+                                                   level_idx * num_points +
+                                                   point_idx + 1) *
+                                                  2];
+            loc_h = ((T *)data_sampling_loc_nram)[(load_loc_weight_offset +
+                                                   level_idx * num_points +
+                                                   point_idx + 1) *
+                                                      2 +
+                                                  1];
+            weight_next_point =
+                ((T *)data_attn_weight_nram)[load_loc_weight_offset +
+                                             level_idx * num_points +
+                                             point_idx + 1];
+            x_next_point = loc_w * spatial_w - 0.5;
+            y_next_point = loc_h * spatial_h - 0.5;
+            if (y_next_point > -1 && x_next_point > -1 &&
+                y_next_point < spatial_h && x_next_point < spatial_w) {
+              loadNeighborPointsData(
+                  (T *)data_value_ptr,
+                  (T *)(ping_data_value_p1_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p2_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p3_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  (T *)(ping_data_value_p4_nram +
+                        ((level_idx * num_points + point_idx + 1) % 2) *
+                            ping_pong_gap),
+                  channels_rem, spatial_w, spatial_h, num_heads, channels,
+                  x_next_point, y_next_point, head_idx);
+            }
+          }
+
+          // compute
+          if (y > -1 && x > -1 && y < spatial_h && x < spatial_w) {
+#if __BANG_ARCH__ >= 322
+            computeMsDeformAttn(
+                (T *)(ping_data_value_p1_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)(ping_data_value_p2_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)(ping_data_value_p3_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)(ping_data_value_p4_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)auxiliary_a, (T *)auxiliary_b,
+                (T *)(ping_data_col_nram +
+                      data_col_ping_pong_idx * ping_pong_gap),
+                weight, channels_rem, spatial_w, spatial_h, x, y);
+#else
+            computeMsDeformAttn(
+                (T *)(ping_data_value_p1_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)(ping_data_value_p2_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)(ping_data_value_p3_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)(ping_data_value_p4_nram +
+                      ((level_idx * num_points + point_idx) % 2) *
+                          ping_pong_gap),
+                (T *)auxiliary_a, (T *)auxiliary_b,
+                (T *)(ping_data_col_nram +
+                      data_col_ping_pong_idx * ping_pong_gap),
+                weight, channels_align_rem, spatial_w, spatial_h, x, y);
+#endif
+          }
+
+          spatial_w = spatial_w_next_point;
+          spatial_h = spatial_h_next_point;
+          weight = weight_next_point;
+          x = x_next_point;
+          y = y_next_point;
+          __asm__ volatile("sync;");
+        }
+      }
+      // store
+      __memcpy_async(
+          data_col_gdram_start + channels_seg_num * span_num_deal * sizeof(T),
+          ping_data_col_nram + data_col_ping_pong_idx * ping_pong_gap,
+          channels_rem * sizeof(T), NRAM2GDRAM);
+      data_col_ping_pong_idx = (data_col_ping_pong_idx + 1) % 2;
+    }
+    load_loc_weight_idx += 1;
   }
   __asm__ volatile("sync;");
-#endif
   return;
 }
 
@@ -1102,6 +1071,7 @@ void __mlu_func__ msDeformAttnCol2imBilinear(
     T *grad_sampling_loc, T *grad_attn_weight, T *grad_output_nram_temp,
     const int32_t &deal_num, const int32_t &deal_num_real,
     const T *data_value_ptr) {
+#if __BANG_ARCH__ >= 322
   if (h_low >= 0 && w_low >= 0) {
     int32_t offset1 = h_low_ptr_offset + w_low_ptr_offset + base_ptr;
     __memcpy(grad_output_nram, data_value_ptr + offset1,
@@ -1115,8 +1085,8 @@ void __mlu_func__ msDeformAttnCol2imBilinear(
     __bang_mul_scalar(top_grad_temp, top_grad_temp, w1, deal_num_real);
     // for calc grad_attn_weight
     __bang_mul_scalar(grad_output_nram, grad_output_nram, w1, deal_num_real);
-    __bang_atomic_add((T *)top_grad_temp, (T *)(grad_value + offset1),
-                      (T *)top_grad_temp, deal_num_real);
+    __bang_atomic_reduce_add((T *)(grad_value + offset1), (T *)top_grad_temp,
+                             deal_num_real);
   }
   if (h_low >= 0 && w_high <= width - 1) {
     int32_t offset2 = h_low_ptr_offset + w_high_ptr_offset + base_ptr;
@@ -1134,8 +1104,8 @@ void __mlu_func__ msDeformAttnCol2imBilinear(
                       deal_num_real);
     __bang_add(grad_output_nram, grad_output_nram, grad_output_nram_temp,
                deal_num_real);
-    __bang_atomic_add((T *)top_grad_temp, (T *)(grad_value + offset2),
-                      (T *)top_grad_temp, deal_num_real);
+    __bang_atomic_reduce_add((T *)(grad_value + offset2), (T *)top_grad_temp,
+                             deal_num_real);
   }
   if (h_high <= height - 1 && w_low >= 0) {
     int32_t offset3 = h_high_ptr_offset + w_low_ptr_offset + base_ptr;
@@ -1153,8 +1123,8 @@ void __mlu_func__ msDeformAttnCol2imBilinear(
                       deal_num_real);
     __bang_add(grad_output_nram, grad_output_nram, grad_output_nram_temp,
                deal_num_real);
-    __bang_atomic_add((T *)top_grad_temp, (T *)(grad_value + offset3),
-                      (T *)top_grad_temp, deal_num_real);
+    __bang_atomic_reduce_add((T *)(grad_value + offset3), (T *)top_grad_temp,
+                             deal_num_real);
   }
   if (h_high <= height - 1 && w_high <= width - 1) {
     int32_t offset4 = h_high_ptr_offset + w_high_ptr_offset + base_ptr;
@@ -1173,8 +1143,8 @@ void __mlu_func__ msDeformAttnCol2imBilinear(
     __bang_add(grad_output_nram, grad_output_nram, grad_output_nram_temp,
                deal_num_real);
 
-    __bang_atomic_add((T *)top_grad_temp, (T *)(grad_value + offset4),
-                      (T *)top_grad_temp, deal_num_real);
+    __bang_atomic_reduce_add((T *)(grad_value + offset4), (T *)top_grad_temp,
+                             deal_num_real);
   }
   __bang_mul(grad_output_nram, grad_output_nram, top_grad, deal_num_real);
 #if __BANG_ARCH__ >= 322
@@ -1186,8 +1156,7 @@ void __mlu_func__ msDeformAttnCol2imBilinear(
   __bang_reduce_sum(grad_output_nram, grad_output_nram,
                     NFU_ALIGN_SIZE / LEN_FLOAT);
 #endif
-  __bang_atomic_add((T *)grad_output_nram, (T *)grad_attn_weight,
-                    (T *)grad_output_nram, 1);
+  __bang_atomic_reduce_add((T *)grad_attn_weight, (T *)grad_output_nram, 1);
   __bang_mul_scalar(grad_w_weight, grad_w_weight, width, deal_num_real);
   __bang_mul_scalar(top_grad_temp, top_grad, data_attn_weight, deal_num_real);
   __bang_mul(grad_w_weight, grad_w_weight, top_grad_temp, deal_num_real);
@@ -1198,8 +1167,7 @@ void __mlu_func__ msDeformAttnCol2imBilinear(
                    ALIGN_NUM_FOR_REDUCE);
   __bang_reduce_sum(grad_w_weight, grad_w_weight, NFU_ALIGN_SIZE / LEN_FLOAT);
 #endif
-  __bang_atomic_add((T *)grad_w_weight, (T *)(grad_sampling_loc),
-                    (T *)grad_w_weight, 1);
+  __bang_atomic_reduce_add((T *)(grad_sampling_loc), (T *)grad_w_weight, 1);
 
   __bang_mul_scalar(grad_h_weight, grad_h_weight, height, deal_num_real);
   __bang_mul(grad_h_weight, grad_h_weight, top_grad_temp, deal_num_real);
@@ -1210,8 +1178,8 @@ void __mlu_func__ msDeformAttnCol2imBilinear(
                    ALIGN_NUM_FOR_REDUCE);
   __bang_reduce_sum(grad_h_weight, grad_h_weight, NFU_ALIGN_SIZE / LEN_FLOAT);
 #endif
-  __bang_atomic_add((T *)grad_h_weight, (T *)(grad_sampling_loc + 1),
-                    (T *)grad_h_weight, 1);
+  __bang_atomic_reduce_add((T *)(grad_sampling_loc + 1), (T *)grad_h_weight, 1);
+#endif
 }
 
 __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwarDefaultKernel(
@@ -1251,6 +1219,7 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwarDefaultKernel(
   const int32_t C_tail = channels % deal_num;
   const int32_t qid_stride = num_heads * channels;
   int32_t base_ptr = 0;
+
   for (int32_t num_loop = start_per_core; num_loop < end_per_core; ++num_loop) {
     const int32_t l_col = num_loop % num_levels;
     const int32_t m_col = num_loop / num_levels % num_heads;
@@ -1306,9 +1275,9 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwarDefaultKernel(
 
         for (int32_t C_loop = 0; C_loop < C_repeat; ++C_loop) {
           base_ptr = m_col * channels + C_loop * deal_num;
-          __bang_write_zero(grad_h_weight, PAD_UP(channels, ALIGN_NUM));
-          __bang_write_zero(grad_w_weight, PAD_UP(channels, ALIGN_NUM));
-          __bang_write_zero(grad_output_nram, PAD_UP(channels, ALIGN_NUM));
+          __bang_write_zero(grad_h_weight, PAD_UP(channels, ALIGN_NUM));
+          __bang_write_zero(grad_w_weight, PAD_UP(channels, ALIGN_NUM));
+          __bang_write_zero(grad_output_nram, PAD_UP(channels, ALIGN_NUM));
           __memcpy(top_grad,
                    grad_output + grad_output_offset + C_loop * deal_num,
                    deal_num * LEN_FLOAT, GDRAM2NRAM);
@@ -1324,9 +1293,9 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwarDefaultKernel(
         }
         if (C_tail != 0) {
           base_ptr = m_col * channels + C_repeat * deal_num;
-          __bang_write_zero(grad_h_weight, PAD_UP(channels, ALIGN_NUM));
-          __bang_write_zero(grad_w_weight, PAD_UP(channels, ALIGN_NUM));
-          __bang_write_zero(grad_output_nram, PAD_UP(channels, ALIGN_NUM));
+          __bang_write_zero(grad_h_weight, PAD_UP(channels, ALIGN_NUM));
+          __bang_write_zero(grad_w_weight, PAD_UP(channels, ALIGN_NUM));
+          __bang_write_zero(grad_output_nram, PAD_UP(channels, ALIGN_NUM));
           __memcpy(top_grad,
                    grad_output + grad_output_offset + C_repeat * deal_num,
                    C_tail * LEN_FLOAT, GDRAM2NRAM);
@@ -1346,7 +1315,6 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwarDefaultKernel(
     }
   }
 }
-
 void __mlu_func__ computeGridMaskAndOffset(
     float *nram_grad_output_tl, float *nram_grad_output_tr, float *nram_loc_w,
     float *nram_loc_h, float *nram_h_stride, int32_t *nram_spatial_shapes,
@@ -1358,24 +1326,28 @@ void __mlu_func__ computeGridMaskAndOffset(
     float *nram_w2, float *nram_w3, float *nram_w4, float *nram_offset_temp,
     float *nram_offset1, float *nram_offset2, float *nram_offset3,
     float *nram_offset4, float *nram_base_ptr, float *nram_h_low_temp,
-    int32_t num_deal_grid, int32_t num_per_time_real, const int32_t num_heads,
-    const int32_t num_levels, const int32_t num_points, const int32_t w_stride,
-    const int32_t qid_stride) {
-#if __BANG_ARCH__ >= 322
+    const int32_t &num_deal_grid, const int32_t &num_per_time_real,
+    const int32_t &num_heads, const int32_t &num_levels,
+    const int32_t &num_points, const int32_t &w_stride,
+    const int32_t &qid_stride, float *grad_temp1) {
+#if __BANG_ARCH__ > 322
   // [num_levels, 2] --> [2, num_levels]
-  __bang_transpose(nram_grad_output_tl, nram_loc_w, num_deal_grid, 2);
+  __bang_transpose(nram_grad_output_tl, nram_loc_w, num_deal_grid,
+                   2);  // 2 * xhlp
   __bang_transpose(nram_loc_w, nram_grad_output_tl,
                    num_per_time_real * num_heads * num_levels, num_points);
   __bang_transpose(nram_loc_h, nram_grad_output_tl + num_deal_grid,
                    num_per_time_real * num_heads * num_levels, num_points);
   __bang_int322float((float *)nram_spatial_shapes,
                      (int32_t *)nram_spatial_shapes, num_levels * 2, 0);
+
   __bang_transpose(nram_grad_output_tr, (float *)nram_spatial_shapes,
                    num_levels, 2);
   __bang_mul_scalar(nram_h_stride, nram_grad_output_tr + num_levels, w_stride,
                     num_levels);
   __memcpy_async(nram_spatial_shapes, nram_grad_output_tr,
                  num_levels * 2 * sizeof(float), NRAM2NRAM);
+
   __bang_cycle_mul(nram_loc_w, nram_loc_w,
                    (float *)nram_spatial_shapes + num_levels, num_deal_grid,
                    num_levels);
@@ -1383,13 +1355,13 @@ void __mlu_func__ computeGridMaskAndOffset(
                    num_deal_grid, num_levels);
   __bang_sub_scalar(nram_loc_w, nram_loc_w, 0.5, num_deal_grid);
   __bang_sub_scalar(nram_loc_h, nram_loc_h, 0.5, num_deal_grid);
-  // get mask. (h_im > -1 && w_im > -1 &&
-  // h_im < spatial_h && w_im < spatial_w)
+  // get mask. (h_im > -1 && w_im > -1 && h_im < spatial_h && w_im < spatial_w)
   __bang_cycle_lt(nram_w_low_temp, nram_loc_w,
                   (float *)(nram_spatial_shapes + num_levels), num_deal_grid,
                   num_levels);
   __bang_cycle_lt(nram_h_high_temp, nram_loc_h, (float *)(nram_spatial_shapes),
                   num_deal_grid, num_levels);
+
   __bang_and(nram_w_low_temp, nram_w_low_temp, nram_h_high_temp, num_deal_grid);
   __bang_gt_scalar(nram_h_high_temp, nram_loc_h, -1, num_deal_grid);
   __bang_and(nram_h_high_temp, nram_h_high_temp, nram_w_low_temp,
@@ -1397,10 +1369,12 @@ void __mlu_func__ computeGridMaskAndOffset(
   __bang_gt_scalar(nram_w_low_temp, nram_loc_w, -1, num_deal_grid);
   __bang_and(nram_h_high_temp, nram_h_high_temp, nram_w_low_temp,
              num_deal_grid);
+
   __bang_transpose(nram_w_low_temp, nram_h_high_temp, num_points,
                    num_per_time_real * num_heads * num_levels);
   __memcpy_async(nram_h_high_temp, nram_w_low_temp,
                  num_deal_grid * sizeof(float), NRAM2NRAM);
+
   __bang_transpose(nram_grad_output_tl, nram_loc_w, num_points,
                    num_per_time_real * num_heads * num_levels);
   __memcpy_async(nram_loc_w, nram_grad_output_tl, num_deal_grid * sizeof(float),
@@ -1409,22 +1383,24 @@ void __mlu_func__ computeGridMaskAndOffset(
                    num_per_time_real * num_heads * num_levels);
   __memcpy_async(nram_loc_h, nram_grad_output_tl, num_deal_grid * sizeof(float),
                  NRAM2NRAM);
+
   __bang_floor(nram_w_low, nram_loc_w, num_deal_grid);
   __bang_floor(nram_h_low, nram_loc_h, num_deal_grid);
+
   __bang_add_scalar(nram_h_high, nram_h_low, 1, num_deal_grid);
   __bang_add_scalar(nram_w_high, nram_w_low, 1, num_deal_grid);
-  __bang_sub(nram_lh, nram_loc_h, nram_h_low, num_deal_grid);
-  __bang_sub(nram_lw, nram_loc_w, nram_w_low, num_deal_grid);
-  __bang_fusion(FUSION_FMA, nram_hh, nram_lh, (float)(-1), 1, num_deal_grid);
-  __bang_fusion(FUSION_FMA, nram_hw, nram_lw, (float)(-1), 1, num_deal_grid);
+
   __bang_transpose(nram_h_low_ptr_offset, nram_h_low,
                    num_per_time_real * num_heads * num_levels, num_points);
   __bang_cycle_mul(nram_h_low_ptr_offset, nram_h_low_ptr_offset, nram_h_stride,
                    num_deal_grid, num_levels);
+
   __bang_cycle_add(nram_h_high_ptr_offset, nram_h_low_ptr_offset, nram_h_stride,
                    num_deal_grid, num_levels);
+
   __bang_transpose(nram_w_low_ptr_offset, nram_h_low_ptr_offset, num_points,
                    num_per_time_real * num_heads * num_levels);
+
   __memcpy_async(nram_h_low_ptr_offset, nram_w_low_ptr_offset,
                  num_deal_grid * sizeof(float), NRAM2NRAM);
   __bang_transpose(nram_w_low_ptr_offset, nram_h_high_ptr_offset, num_points,
@@ -1435,18 +1411,18 @@ void __mlu_func__ computeGridMaskAndOffset(
                     num_deal_grid);
   __bang_add_scalar(nram_w_high_ptr_offset, nram_w_low_ptr_offset, qid_stride,
                     num_deal_grid);
-  __bang_mul(nram_w1, nram_hh, nram_hw, num_deal_grid);
-  __bang_mul(nram_w2, nram_hh, nram_lw, num_deal_grid);
-  __bang_mul(nram_w3, nram_lh, nram_hw, num_deal_grid);
-  __bang_mul(nram_w4, nram_lh, nram_lw, num_deal_grid);
+
   __bang_add(nram_offset1, nram_h_low_ptr_offset, nram_w_low_ptr_offset,
              num_deal_grid);
+
   __bang_transpose(nram_offset_temp, nram_offset1,
                    num_per_time_real * num_heads, num_levels * num_points);
   __bang_cycle_add(nram_offset_temp, nram_offset_temp, nram_base_ptr,
                    num_deal_grid, num_heads);
+
   __bang_transpose(nram_offset1, nram_offset_temp, num_levels * num_points,
                    num_per_time_real * num_heads);
+
   __bang_add(nram_offset2, nram_h_low_ptr_offset, nram_w_high_ptr_offset,
              num_deal_grid);
   __bang_transpose(nram_offset_temp, nram_offset2,
@@ -1455,6 +1431,7 @@ void __mlu_func__ computeGridMaskAndOffset(
                    num_deal_grid, num_heads);
   __bang_transpose(nram_offset2, nram_offset_temp, num_levels * num_points,
                    num_per_time_real * num_heads);
+
   __bang_add(nram_offset3, nram_h_high_ptr_offset, nram_w_low_ptr_offset,
              num_deal_grid);
   __bang_transpose(nram_offset_temp, nram_offset3,
@@ -1471,7 +1448,8 @@ void __mlu_func__ computeGridMaskAndOffset(
                    num_deal_grid, num_heads);
   __bang_transpose(nram_offset4, nram_offset_temp, num_levels * num_points,
                    num_per_time_real * num_heads);
-  // h_low >= 0 && w_low >= 0 mask2
+
+  // h_low >= 0 && w_low >= 0  mask2
   float *mask1 = nram_h_low_ptr_offset;
   float *mask2 = nram_h_high_ptr_offset;
   float *mask3 = nram_w_low_ptr_offset;
@@ -1480,6 +1458,7 @@ void __mlu_func__ computeGridMaskAndOffset(
   __bang_ge_scalar(mask2, nram_w_low, 0, num_deal_grid);
   __bang_and(mask2, mask1, mask2, num_deal_grid);
   __bang_and(mask2, nram_h_high_temp, mask2, num_deal_grid);
+
   // h_low >= 0 && w_high <= width - 1 mask1
   __bang_transpose(mask3, nram_w_high,
                    num_per_time_real * num_heads * num_levels, num_points);
@@ -1491,98 +1470,212 @@ void __mlu_func__ computeGridMaskAndOffset(
                    num_per_time_real * num_heads * num_levels);
   __bang_and(mask1, mask1, mask4, num_deal_grid);
   __bang_and(mask1, nram_h_high_temp, mask1, num_deal_grid);
+
   // h_high <= height - 1 && w_high <= width - 1 mask3
   __bang_transpose(mask3, nram_h_high,
                    num_per_time_real * num_heads * num_levels, num_points);
   __bang_cycle_le(mask3, mask3, (float *)(nram_spatial_shapes), num_deal_grid,
                   num_levels);
-
   __bang_transpose(nram_h_low_temp, mask3, num_points,
                    num_per_time_real * num_heads * num_levels);
   __bang_and(mask4, mask4, nram_h_low_temp, num_deal_grid);
   __bang_and(mask3, mask4, nram_h_high_temp, num_deal_grid);
+
   // h_high <= height - 1 && w_low >= 0 mask4
   __bang_ge_scalar(nram_w_low_temp, nram_w_low, 0, num_deal_grid);
   __bang_and(mask4, nram_h_low_temp, nram_w_low_temp, num_deal_grid);
   __bang_and(mask4, mask4, nram_h_high_temp, num_deal_grid);
+  __bang_gt_scalar(grad_temp1, nram_offset1, 0, num_deal_grid);
+  __bang_mul(nram_offset1, nram_offset1, grad_temp1, num_deal_grid);
+  __bang_mul(nram_offset1, nram_offset1, mask2, num_deal_grid);
+
+  __bang_gt_scalar(grad_temp1, nram_offset2, 0, num_deal_grid);
+  __bang_mul(nram_offset2, nram_offset2, grad_temp1, num_deal_grid);
+  __bang_mul(nram_offset2, nram_offset2, mask1, num_deal_grid);
+
+  __bang_gt_scalar(grad_temp1, nram_offset3, 0, num_deal_grid);
+  __bang_mul(nram_offset3, nram_offset3, grad_temp1, num_deal_grid);
+  __bang_mul(nram_offset3, nram_offset3, mask4, num_deal_grid);
+
+  __bang_gt_scalar(grad_temp1, nram_offset4, 0, num_deal_grid);
+  __bang_mul(nram_offset4, nram_offset4, grad_temp1, num_deal_grid);
+  __bang_mul(nram_offset4, nram_offset4, mask3, num_deal_grid);
+  __sync_io_move_compute();
+  __bang_sub(nram_lh, nram_loc_h, nram_h_low, num_deal_grid);
+  __bang_sub(nram_lw, nram_loc_w, nram_w_low, num_deal_grid);
+
+  __bang_fusion(FUSION_FMA, nram_hh, nram_lh, (float)(-1), 1, num_deal_grid);
+  __bang_fusion(FUSION_FMA, nram_hw, nram_lw, (float)(-1), 1, num_deal_grid);
+
+  __bang_mul(nram_w1, nram_hh, nram_hw, num_deal_grid);
+  __bang_mul(nram_w2, nram_hh, nram_lw, num_deal_grid);
+  __bang_mul(nram_w3, nram_lh, nram_hw, num_deal_grid);
+  __bang_mul(nram_w4, nram_lh, nram_lw, num_deal_grid);
 #endif
 }
 
 void __mlu_func__ loadValue(
     float *nram_grad_output_tl, float *nram_grad_output_tr,
     float *nram_grad_output_bl, float *nram_grad_output_br,
-    const float *data_value, const float *grad_output, float *grad_temp1,
-    float *grad_temp2, float *mask1, float *mask2, float *mask3, float *mask4,
-    float *nram_offset1, float *nram_offset2, float *nram_offset3,
-    float *nram_offset4, float *nram_grad_weight,
-    int32_t *nram_level_start_index, int32_t offset_nram,
-    int32_t start_per_core, int32_t grid_loop, int32_t num_per_time_theory,
-    int32_t num_heads, int32_t deal_num_real, int32_t num_per_time_real,
-    int32_t num_deal_grid, const int32_t num_query, const int32_t num_levels,
-    const int32_t num_points, int32_t grid_offset, const int32_t spatial_size,
-    const int32_t qid_stride) {
-#if __BANG_ARCH__ >= 322
+    const float *data_value, float *grad_temp1, float *grad_temp3, float *mask1,
+    float *mask2, float *mask3, float *mask4, float *nram_offset1,
+    float *nram_offset2, float *nram_offset3, float *nram_offset4,
+    float *nram_grad_weight, int32_t *nram_level_start_index,
+    const int32_t &offset_nram, const int32_t &num_heads,
+    const int32_t &deal_num_real, const int32_t &num_deal_grid,
+    const int32_t &num_query, const int32_t &num_levels,
+    const int32_t &num_points, const int32_t &grid_offset,
+    const int32_t &spatial_size, const int32_t &qid_stride) {
+#if __BANG_ARCH__ > 322
   int32_t value_offset_temp = 0;
-  __bang_write_zero(nram_grad_output_tl, 4 * offset_nram);
-  __sync_io_move_compute();
-  __memcpy_async(
-      grad_temp2,
-      grad_output + (start_per_core + grid_loop * num_per_time_theory) *
-                        num_heads * deal_num_real,
-      num_per_time_real * num_heads * deal_num_real * sizeof(float),
-      GDRAM2NRAM);
-  for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
-    const int32_t b_col =
-        (grid_offset + loop) / num_query / num_heads / num_levels / num_points;
-    const int32_t l_col = (grid_offset + loop) / num_points % num_levels;
-    const int32_t level_start_id = nram_level_start_index[l_col];
+
+#if __BANG_ARCH__ > 590
+  for (int i = 0; i < num_deal_grid; ++i) {
+    int32_t b_col =
+        (grid_offset + i) / num_query / num_heads / num_levels / num_points;
+    int32_t l_col = (grid_offset + i) / num_points % num_levels;
+    int32_t level_start_id = nram_level_start_index[l_col];
     value_offset_temp =
         b_col * spatial_size * qid_stride + level_start_id * qid_stride;
-    if (mask2[loop]) {
-      __memcpy_async(
-          nram_grad_output_tl + loop * deal_num_real,
-          data_value + value_offset_temp + int32_t(nram_offset1[loop]),
-          deal_num_real * sizeof(float), GDRAM2NRAM);
-    }
-    if (mask1[loop]) {
-      __memcpy_async(
-          nram_grad_output_tr + loop * deal_num_real,
-          data_value + value_offset_temp + int32_t(nram_offset2[loop]),
-          deal_num_real * sizeof(float), GDRAM2NRAM);
-    }
-    if (mask4[loop]) {
-      __memcpy_async(
-          nram_grad_output_bl + loop * deal_num_real,
-          data_value + value_offset_temp + int32_t(nram_offset3[loop]),
-          deal_num_real * sizeof(float), GDRAM2NRAM);
-    }
-    if (mask3[loop]) {
-      __memcpy_async(
-          nram_grad_output_br + loop * deal_num_real,
-          data_value + value_offset_temp + int32_t(nram_offset4[loop]),
-          deal_num_real * sizeof(float), GDRAM2NRAM);
-    }
+    ((float *)grad_temp1)[i] = value_offset_temp;
   }
-  for (int32_t m = 0; m < deal_num_real; ++m) {
-    __memcpy_async(grad_temp1 + m * num_deal_grid, nram_grad_weight,
-                   num_deal_grid * sizeof(float), NRAM2NRAM);
-  }
+
+  __bang_add(grad_temp3, grad_temp1, nram_offset1, num_deal_grid);
+  __bang_add(grad_temp3 + num_deal_grid, grad_temp1, nram_offset2,
+             num_deal_grid);
+  __bang_add(grad_temp3 + 2 * num_deal_grid, grad_temp1, nram_offset3,
+             num_deal_grid);
+  __bang_add(grad_temp3 + 3 * num_deal_grid, grad_temp1, nram_offset4,
+             num_deal_grid);
+  __bang_mul_scalar(grad_temp3, grad_temp3, sizeof(float), 4 * num_deal_grid);
+  __bang_float2int32((int32_t *)(grad_temp3), (grad_temp3), 4 * num_deal_grid,
+                     0);
   __sync_io_move_compute();
+
+  __gather_async((void *)nram_grad_output_tl, (void *)data_value,
+                 (unsigned int *)grad_temp3, deal_num_real * sizeof(float),
+                 GDRAM2NRAM, deal_num_real * sizeof(float), num_deal_grid);
+
+  __gather_async((void *)nram_grad_output_tr, (void *)data_value,
+                 (unsigned int *)(grad_temp3 + num_deal_grid),
+                 deal_num_real * sizeof(float), GDRAM2NRAM,
+                 deal_num_real * sizeof(float), num_deal_grid);
+
+  __gather_async((void *)nram_grad_output_bl, (void *)data_value,
+                 (unsigned int *)(grad_temp3 + 2 * num_deal_grid),
+                 deal_num_real * sizeof(float), GDRAM2NRAM,
+                 deal_num_real * sizeof(float), num_deal_grid);
+
+  __gather_async((void *)nram_grad_output_br, (void *)data_value,
+                 (unsigned int *)(grad_temp3 + 3 * num_deal_grid),
+                 deal_num_real * sizeof(float), GDRAM2NRAM,
+                 deal_num_real * sizeof(float), num_deal_grid);
+  __sync_io_move_compute();
+
+#else
+  int32_t b_col =
+      (grid_offset) / num_query / num_heads / num_levels / num_points;
+  int32_t l_col = (grid_offset) / num_points % num_levels;
+  int32_t level_start_id = nram_level_start_index[l_col];
+  value_offset_temp =
+      b_col * spatial_size * qid_stride + level_start_id * qid_stride;
+  for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
+    __memcpy_async(
+        (void *)(nram_grad_output_tl + loop * deal_num_real),
+        (void *)(data_value + value_offset_temp + int32_t(nram_offset1[loop])),
+        deal_num_real * sizeof(float), GDRAM2NRAM, offset_nram * sizeof(float),
+        (int32_t(nram_offset2[loop]) - int32_t(nram_offset1[loop])) *
+            sizeof(float),
+        mask1[loop]);
+    b_col = (grid_offset + loop + 1) / num_query / num_heads / num_levels /
+            num_points;
+    l_col = (grid_offset + loop + 1) / num_points % num_levels;
+    level_start_id = nram_level_start_index[l_col];
+
+    __memcpy_async(
+        (void *)(nram_grad_output_bl + loop * deal_num_real),
+        (void *)(data_value + value_offset_temp + int32_t(nram_offset3[loop])),
+        deal_num_real * sizeof(float), GDRAM2NRAM, offset_nram * sizeof(float),
+        (int32_t(nram_offset4[loop]) - int32_t(nram_offset3[loop])) *
+            sizeof(float),
+        mask3[loop]);
+    value_offset_temp =
+        b_col * spatial_size * qid_stride + level_start_id * qid_stride;
+  }
+
+#endif
+  __bang_write_zero(grad_temp1, deal_num_real * num_deal_grid);
+  __bang_cycle_add(grad_temp1, grad_temp1, mask2, deal_num_real * num_deal_grid,
+                   num_deal_grid);
+  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
+  __nram__ int32_t table[2] = {0, (int32_t)0xffffffff};
+  __bang_float2int32((int32_t *)grad_temp3, grad_temp3,
+                     num_deal_grid * deal_num_real, 0);
+  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
+                 num_deal_grid * deal_num_real, 64);
+  __bang_write_zero(grad_temp1, deal_num_real * num_deal_grid);
+  __bang_cycle_add(grad_temp1, grad_temp1, mask1, deal_num_real * num_deal_grid,
+                   num_deal_grid);
+  __sync_io_move_compute();
+
+  __bang_band((char *)nram_grad_output_tl, (char *)nram_grad_output_tl,
+              (char *)grad_temp3,
+              num_deal_grid * deal_num_real * sizeof(float));
+  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
+
+  __bang_float2int32((int32_t *)grad_temp3, grad_temp3,
+                     num_deal_grid * deal_num_real, 0);
+  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
+                 num_deal_grid * deal_num_real, 64);
+  __bang_band((char *)nram_grad_output_tr, (char *)nram_grad_output_tr,
+              (char *)grad_temp3,
+              num_deal_grid * deal_num_real * sizeof(float));
+
+  __bang_write_zero(grad_temp1, deal_num_real * num_deal_grid);
+  __bang_cycle_add(grad_temp1, grad_temp1, mask4, deal_num_real * num_deal_grid,
+                   num_deal_grid);
+  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
+
+  __bang_float2int32((int32_t *)grad_temp3, grad_temp3,
+                     num_deal_grid * deal_num_real, 0);
+  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
+                 num_deal_grid * deal_num_real, 64);
+  __bang_band((char *)nram_grad_output_bl, (char *)nram_grad_output_bl,
+              (char *)grad_temp3,
+              num_deal_grid * deal_num_real * sizeof(float));
+
+  __bang_write_zero(grad_temp1, deal_num_real * num_deal_grid);
+  __bang_cycle_add(grad_temp1, grad_temp1, mask3, deal_num_real * num_deal_grid,
+                   num_deal_grid);
+  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
+
+  __bang_float2int32((int32_t *)grad_temp3, grad_temp3,
+                     num_deal_grid * deal_num_real, 0);
+  __bang_lut_s32((int32_t *)grad_temp3, (int32_t *)grad_temp3, (int32_t *)table,
+                 num_deal_grid * deal_num_real, 64);
+  __bang_band((char *)nram_grad_output_br, (char *)nram_grad_output_br,
+              (char *)grad_temp3,
+              num_deal_grid * deal_num_real * sizeof(float));
 #endif
 }
-
 void __mlu_func__ computeGradValue(
     float *grad_temp1, float *grad_temp2, float *grad_temp3, float *grad_temp4,
     float *mask1, float *mask2, float *mask3, float *mask4, float *nram_offset1,
     float *nram_offset2, float *nram_offset3, float *nram_offset4,
     int32_t *nram_level_start_index, int32_t deal_num_real,
     const float *grad_value, float *nram_w1, float *nram_w2, float *nram_w3,
-    float *nram_w4, int32_t num_per_time_real, const int32_t num_heads,
-    const int32_t num_levels, const int32_t num_points, const int32_t num_query,
-    int32_t num_deal_grid, int32_t grid_offset, const int32_t spatial_size,
-    const int32_t qid_stride, float *nram_grid_offset1,
-    float *nram_grid_offset2) {
-#if __BANG_ARCH__ >= 322
+    float *nram_w4, const int32_t &num_per_time_real, const int32_t &num_heads,
+    const int32_t &num_levels, const int32_t &num_points,
+    const int32_t &num_query, const int32_t &num_deal_grid,
+    const int32_t &grid_offset, const int32_t &spatial_size,
+    const int32_t &qid_stride, float *nram_grid_offset1,
+    float *nram_grid_offset2, const int32_t &batch, float *nram_grad_output_tl,
+    float *nram_grad_output_tr, float *nram_grad_output_bl,
+    float *nram_grad_output_br, float *nram_grad_weight) {
+#if __BANG_ARCH__ > 322
+  __bang_write_zero(grad_temp1, deal_num_real * num_deal_grid);
+  __bang_cycle_add(grad_temp1, grad_temp1, nram_grad_weight,
+                   deal_num_real * num_deal_grid, num_deal_grid);
   __bang_transpose(grad_temp3, grad_temp1,
                    deal_num_real * num_per_time_real * num_heads,
                    num_levels * num_points);
@@ -1593,14 +1686,13 @@ void __mlu_func__ computeGradValue(
                    deal_num_real * num_per_time_real * num_heads);
   __bang_transpose(grad_temp4, grad_temp3, num_levels * num_points,
                    deal_num_real * num_per_time_real * num_heads);
-  __bang_cycle_mul(grad_temp1, grad_temp4, nram_w1,
-                   num_deal_grid * deal_num_real, num_deal_grid);
-  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
+
+  int32_t temp_res = num_query * num_heads * num_levels * num_points;
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
-    nram_grid_offset1[loop] = ((loop + grid_offset) / num_query / num_heads /
-                               num_levels / num_points) *
-                              spatial_size * qid_stride;
+    nram_grid_offset1[loop] = ((loop + grid_offset) / temp_res);
   }
+  __bang_mul_scalar((float *)nram_grid_offset1, (float *)nram_grid_offset1,
+                    spatial_size * qid_stride, num_deal_grid);
   __bang_transpose(nram_grid_offset2, nram_grid_offset1,
                    num_per_time_real * num_heads * num_levels, num_points);
   __bang_int322float((float *)nram_level_start_index, nram_level_start_index,
@@ -1615,65 +1707,130 @@ void __mlu_func__ computeGradValue(
   __bang_add(nram_offset2, nram_offset2, nram_grid_offset1, num_deal_grid);
   __bang_add(nram_offset3, nram_offset3, nram_grid_offset1, num_deal_grid);
   __bang_add(nram_offset4, nram_offset4, nram_grid_offset1, num_deal_grid);
+
+#if __BANG_ARCH__ >= 590
+  // make sure offset not great than (batch * spatial_size * num_heads *
+  // channels)
+  __bang_lt_scalar(grad_temp1, nram_offset1,
+                   batch * spatial_size * num_heads * deal_num_real,
+                   num_deal_grid);
+  __bang_mul(nram_offset1, nram_offset1, grad_temp1, num_deal_grid);
+  __bang_lt_scalar(grad_temp1, nram_offset2,
+                   batch * spatial_size * num_heads * deal_num_real,
+                   num_deal_grid);
+  __bang_mul(nram_offset2, nram_offset2, grad_temp1, num_deal_grid);
+  __bang_lt_scalar(grad_temp1, nram_offset3,
+                   batch * spatial_size * num_heads * deal_num_real,
+                   num_deal_grid);
+  __bang_mul(nram_offset3, nram_offset3, grad_temp1, num_deal_grid);
+  __bang_lt_scalar(grad_temp1, nram_offset4,
+                   batch * spatial_size * num_heads * deal_num_real,
+                   num_deal_grid);
+  __bang_mul(nram_offset4, nram_offset4, grad_temp1, num_deal_grid);
+  __bang_mul(grad_temp3, nram_w1, mask2, num_deal_grid);
+  __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
+                   num_deal_grid * deal_num_real, num_deal_grid);
+  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
+
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
-    if (mask2[loop]) {
-      __bang_atomic_add((float *)(grad_temp3 + loop * deal_num_real),
-                        (float *)(grad_value + int32_t(nram_offset1[loop])),
-                        (float *)(grad_temp3 + loop * deal_num_real),
-                        deal_num_real);
-    }
+    __bang_atomic_reduce_add(
+        (float *)(grad_value + int32_t(nram_offset1[loop])),
+        (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
   }
+
+  __bang_mul(grad_temp3, nram_w2, mask1, num_deal_grid);
+  __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
+                   num_deal_grid * deal_num_real, num_deal_grid);
+  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
+
+  for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
+    __bang_atomic_reduce_add(
+        (float *)(grad_value + int32_t(nram_offset2[loop])),
+        (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
+  }
+  __bang_mul(grad_temp3, nram_w3, mask4, num_deal_grid);
+  __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
+                   num_deal_grid * deal_num_real, num_deal_grid);
+
+  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
+
+  for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
+    __bang_atomic_reduce_add(
+        (float *)(grad_value + int32_t(nram_offset3[loop])),
+        (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
+  }
+  __bang_mul(grad_temp3, nram_w4, mask3, num_deal_grid);
+  __bang_cycle_mul(grad_temp1, grad_temp4, grad_temp3,
+                   num_deal_grid * deal_num_real, num_deal_grid);
+  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
+
+  for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
+    __bang_atomic_reduce_add(
+        (float *)(grad_value + int32_t(nram_offset4[loop])),
+        (float *)(grad_temp3 + loop * deal_num_real), deal_num_real);
+  }
+#else
+  __bang_cycle_mul(grad_temp1, grad_temp4, nram_w1,
+                   num_deal_grid * deal_num_real, num_deal_grid);
+  __bang_transpose(nram_grad_output_br, grad_temp1, deal_num_real,
+                   num_deal_grid);
+
   __bang_cycle_mul(grad_temp1, grad_temp4, nram_w2,
                    num_deal_grid * deal_num_real, num_deal_grid);
-  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
-  for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
-    if (mask1[loop]) {
-      __bang_atomic_add((float *)(grad_temp3 + loop * deal_num_real),
-                        (float *)(grad_value + int32_t(nram_offset2[loop])),
-                        (float *)(grad_temp3 + loop * deal_num_real),
-                        deal_num_real);
-    }
-  }
+  __bang_transpose(nram_grad_output_tl, grad_temp1, deal_num_real,
+                   num_deal_grid);
+
   __bang_cycle_mul(grad_temp1, grad_temp4, nram_w3,
                    num_deal_grid * deal_num_real, num_deal_grid);
-  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
-  for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
-    if (mask4[loop]) {
-      __bang_atomic_add((float *)(grad_temp3 + loop * deal_num_real),
-                        (float *)(grad_value + int32_t(nram_offset3[loop])),
-                        (float *)(grad_temp3 + loop * deal_num_real),
-                        deal_num_real);
-    }
-  }
+  __bang_transpose(nram_grad_output_tr, grad_temp1, deal_num_real,
+                   num_deal_grid);
 
   __bang_cycle_mul(grad_temp1, grad_temp4, nram_w4,
                    num_deal_grid * deal_num_real, num_deal_grid);
-  __bang_transpose(grad_temp3, grad_temp1, deal_num_real, num_deal_grid);
+  __bang_transpose(nram_grad_output_bl, grad_temp1, deal_num_real,
+                   num_deal_grid);
   for (int32_t loop = 0; loop < num_deal_grid; ++loop) {
+    if (mask2[loop]) {
+      __bang_atomic_reduce_add(
+          (float *)(grad_value + int32_t(nram_offset1[loop])),
+          (float *)(nram_grad_output_br + loop * deal_num_real), deal_num_real);
+    }
+    if (mask1[loop]) {
+      __bang_atomic_reduce_add(
+          (float *)(grad_value + int32_t(nram_offset2[loop])),
+          (float *)(nram_grad_output_tl + loop * deal_num_real), deal_num_real);
+    }
+    if (mask4[loop]) {
+      __bang_atomic_reduce_add(
+          (float *)(grad_value + int32_t(nram_offset3[loop])),
+          (float *)(nram_grad_output_tr + loop * deal_num_real), deal_num_real);
+    }
+
     if (mask3[loop]) {
-      __bang_atomic_add((float *)(grad_temp3 + loop * deal_num_real),
-                        (float *)(grad_value + int32_t(nram_offset4[loop])),
-                        (float *)(grad_temp3 + loop * deal_num_real),
-                        deal_num_real);
+      __bang_atomic_reduce_add(
+          (float *)(grad_value + int32_t(nram_offset4[loop])),
+          (float *)(nram_grad_output_bl + loop * deal_num_real), deal_num_real);
     }
   }
+#endif
 #endif
 }
 
 void __mlu_func__ computeGradAttnWeight(
     float *grad_w_weight, float *grad_weight, float *nram_grad_output_tl,
     float *nram_grad_output_tr, float *nram_grad_output_bl,
-    float *nram_grad_output_br, float *grad_temp1, float *grad_temp2,
+    float *nram_grad_output_br, float *grad_temp2,
     const float *grad_attn_weight, float *nram_hw, float *nram_hh,
     float *nram_lw, float *nram_lh, float *grad_h_weight, float *nram_w1,
-    float *nram_w2, float *nram_w3, float *nram_w4, int32_t offset_nram,
-    int32_t num_deal_grid, int32_t deal_num_real, int32_t num_per_time_real,
-    const int32_t num_heads, const int32_t num_levels, const int32_t num_points,
-    int32_t grid_offset, float *nram_h_high_temp) {
-#if __BANG_ARCH__ >= 322
+    float *nram_w2, float *nram_w3, float *nram_w4, const int32_t &offset_nram,
+    const int32_t &num_deal_grid, const int32_t &deal_num_real,
+    const int32_t &num_per_time_real, const int32_t &num_heads,
+    const int32_t &num_levels, const int32_t &num_points,
+    const int32_t &grid_offset, float *nram_h_high_temp) {
+#if __BANG_ARCH__ > 322
   __bang_write_zero(grad_w_weight, 2 * offset_nram);
-
   // grad_output_nram_tl
+
   __bang_transpose(grad_weight, nram_grad_output_tl, num_deal_grid,
                    deal_num_real);
   __bang_cycle_mul(nram_grad_output_tl, grad_weight, nram_hw,
@@ -1701,6 +1858,7 @@ void __mlu_func__ computeGradAttnWeight(
                    num_deal_grid * deal_num_real, num_deal_grid);
   __bang_add(nram_grad_output_tl, nram_grad_output_tl, nram_grad_output_tr,
              num_deal_grid * deal_num_real);
+
   // nram_grad_output_tl
   __bang_transpose(grad_weight, nram_grad_output_bl, num_deal_grid,
                    deal_num_real);
@@ -1714,8 +1872,10 @@ void __mlu_func__ computeGradAttnWeight(
              num_deal_grid * deal_num_real);
   __bang_cycle_mul(nram_grad_output_bl, grad_weight, nram_w3,
                    num_deal_grid * deal_num_real, num_deal_grid);
+
   __bang_add(nram_grad_output_tl, nram_grad_output_tl, nram_grad_output_bl,
              num_deal_grid * deal_num_real);
+
   // nram_grad_output_br
   __bang_transpose(grad_weight, nram_grad_output_br, num_deal_grid,
                    deal_num_real);
@@ -1731,35 +1891,35 @@ void __mlu_func__ computeGradAttnWeight(
                    num_deal_grid * deal_num_real, num_deal_grid);
   __bang_add(nram_grad_output_tl, nram_grad_output_tl, nram_grad_output_br,
              num_deal_grid * deal_num_real);
+
   __bang_transpose(nram_grad_output_br, nram_grad_output_tl, deal_num_real,
                    num_deal_grid);
   __bang_transpose(nram_grad_output_tr, nram_grad_output_br,
                    num_per_time_real * num_heads,
                    num_points * num_levels * deal_num_real);
-  __bang_transpose(grad_temp1, grad_temp2, num_per_time_real * num_heads,
+  __bang_transpose(grad_weight, grad_temp2, num_per_time_real * num_heads,
                    deal_num_real);
-  __bang_cycle_mul(nram_grad_output_tr, nram_grad_output_tr, grad_temp1,
+  __bang_cycle_mul(nram_grad_output_tr, nram_grad_output_tr, grad_weight,
                    num_deal_grid * deal_num_real,
                    num_per_time_real * num_heads * deal_num_real);
   __bang_transpose(nram_grad_output_br, nram_grad_output_tr,
                    num_points * num_levels * deal_num_real,
                    num_per_time_real * num_heads);
-
   __bang_transpose((float *)nram_grad_output_tr, (float *)nram_grad_output_br,
                    num_deal_grid, deal_num_real);
+
   recursiveSumPool(nram_grad_output_tr, num_deal_grid, deal_num_real,
                    ALIGN_NUM);
-  __bang_float2int32((int *)nram_h_high_temp, nram_h_high_temp, num_deal_grid,
-                     0);
-  __nram__ int table[2] = {0, (int)0xffffffff};
-  __bang_lut_s32((int *)nram_h_high_temp, (int *)nram_h_high_temp, (int *)table,
-                 num_deal_grid, 64);
+
+  __bang_float2int32((int32_t *)nram_h_high_temp, nram_h_high_temp,
+                     num_deal_grid, 0);
+  __nram__ int32_t table[2] = {0, (int32_t)0xffffffff};
+  __bang_lut_s32((int32_t *)nram_h_high_temp, (int32_t *)nram_h_high_temp,
+                 (int32_t *)table, num_deal_grid, 64);
   __bang_band((char *)nram_grad_output_tr, (char *)nram_grad_output_tr,
               (char *)nram_h_high_temp, num_deal_grid * sizeof(float));
-
-  __bang_atomic_add((float *)nram_grad_output_tr,
-                    (float *)grad_attn_weight + grid_offset,
-                    (float *)nram_grad_output_tr, num_deal_grid);
+  __bang_atomic_reduce_add((float *)grad_attn_weight + grid_offset,
+                           (float *)nram_grad_output_tr, num_deal_grid);
 #endif
 }
 
@@ -1767,25 +1927,25 @@ void __mlu_func__ computeGradSampingLoc(
     const float *grad_sampling_loc, float *nram_grad_output_tl,
     float *nram_grad_output_tr, float *grad_h_weight, float *grad_w_weight,
     int32_t *nram_spatial_shapes, float *grad_temp1, float *grad_temp2,
-    float *nram_grad_weight, int32_t num_deal_grid, int32_t deal_num_real,
-    int32_t num_per_time_real, const int32_t num_heads,
-    const int32_t num_levels, const int32_t num_points, int32_t grid_offset,
+    float *nram_grad_weight, const int32_t &num_deal_grid,
+    const int32_t &deal_num_real, const int32_t &num_per_time_real,
+    const int32_t &num_heads, const int32_t &num_levels,
+    const int32_t &num_points, const int32_t &grid_offset,
     float *nram_h_high_temp) {
-#if __BANG_ARCH__ >= 322
+#if __BANG_ARCH__ > 322
   __bang_transpose(nram_grad_output_tl, grad_h_weight,
                    num_per_time_real * num_heads * num_levels * deal_num_real,
-                   num_points);
+                   num_points);  // pcxhl
   __bang_cycle_mul(nram_grad_output_tl, nram_grad_output_tl,
                    (float *)nram_spatial_shapes, num_deal_grid * deal_num_real,
                    num_levels);
   __bang_transpose(grad_h_weight, nram_grad_output_tl,
                    num_points * deal_num_real,
                    num_per_time_real * num_heads * num_levels);
-  for (int32_t m = 0; m < deal_num_real; ++m) {
-    __memcpy_async(grad_temp1 + m * num_deal_grid, nram_grad_weight,
-                   num_deal_grid * sizeof(float), NRAM2NRAM);
-  }
-  __sync_io_move_compute();
+
+  __bang_write_zero(grad_temp1, num_deal_grid * deal_num_real);
+  __bang_cycle_add(grad_temp1, grad_temp1, nram_grad_weight,
+                   num_deal_grid * deal_num_real, num_deal_grid);
   __bang_transpose(nram_grad_output_tr, grad_temp1,
                    deal_num_real * num_per_time_real * num_heads,
                    num_levels * num_points);
@@ -1797,6 +1957,7 @@ void __mlu_func__ computeGradSampingLoc(
   __bang_transpose(grad_temp1, nram_grad_output_tr,
                    num_levels * num_points * deal_num_real,
                    num_per_time_real * num_heads);
+
   __bang_mul(grad_h_weight, grad_h_weight, grad_temp1,
              num_deal_grid * deal_num_real);
   __bang_transpose(nram_grad_output_tl, grad_h_weight, num_deal_grid,
@@ -1804,39 +1965,40 @@ void __mlu_func__ computeGradSampingLoc(
   __memcpy_async(grad_h_weight, nram_grad_output_tl,
                  num_deal_grid * deal_num_real * sizeof(float), NRAM2NRAM);
   recursiveSumPool(grad_h_weight, num_deal_grid, deal_num_real, ALIGN_NUM);
-  __nram__ int table[2] = {0, (int)0xffffffff};
-  __bang_lut_s32((int *)nram_h_high_temp, (int *)nram_h_high_temp, (int *)table,
-                 num_deal_grid, 64);
+
+  __nram__ int32_t table[2] = {0, (int32_t)0xffffffff};
+  __bang_lut_s32((int32_t *)nram_h_high_temp, (int32_t *)nram_h_high_temp,
+                 (int32_t *)table, num_deal_grid, 64);
   __bang_band((char *)grad_h_weight, (char *)grad_h_weight,
               (char *)nram_h_high_temp, num_deal_grid * sizeof(float));
+
   __bang_transpose(nram_grad_output_tl, grad_w_weight,
                    num_per_time_real * num_heads * num_levels * deal_num_real,
-                   num_points);
+                   num_points);  // pcxhl
   __bang_cycle_mul(nram_grad_output_tl, nram_grad_output_tl,
                    (float *)(nram_spatial_shapes + num_levels),
                    num_deal_grid * deal_num_real, num_levels);
   __bang_transpose(grad_w_weight, nram_grad_output_tl,
                    num_points * deal_num_real,
                    num_per_time_real * num_heads * num_levels);
+
   __bang_mul(grad_w_weight, grad_w_weight, grad_temp1,
              num_deal_grid * deal_num_real);
   __bang_transpose(nram_grad_output_tl, grad_w_weight, num_deal_grid,
                    deal_num_real);
-  __memcpy(grad_w_weight, nram_grad_output_tl,
-           num_deal_grid * deal_num_real * sizeof(float), NRAM2NRAM);
+  __memcpy_async(grad_w_weight, nram_grad_output_tl,
+                 num_deal_grid * deal_num_real * sizeof(float), NRAM2NRAM);
   recursiveSumPool(grad_w_weight, num_deal_grid, deal_num_real, ALIGN_NUM);
-  __bang_lut_s32((int *)nram_h_high_temp, (int *)nram_h_high_temp, (int *)table,
-                 num_deal_grid, 64);
+  __bang_lut_s32((int32_t *)nram_h_high_temp, (int32_t *)nram_h_high_temp,
+                 (int32_t *)table, num_deal_grid, 64);
   __bang_band((char *)grad_w_weight, (char *)grad_w_weight,
               (char *)nram_h_high_temp, num_deal_grid * sizeof(float));
 
-  __memcpy(grad_w_weight + num_deal_grid, grad_h_weight,
-           num_deal_grid * sizeof(float), NRAM2NRAM);
+  __memcpy_async(grad_w_weight + num_deal_grid, grad_h_weight,
+                 num_deal_grid * sizeof(float), NRAM2NRAM);
   __bang_transpose(nram_grad_output_tl, grad_w_weight, 2, num_deal_grid);
-  __bang_atomic_add((float *)nram_grad_output_tl,
-                    (float *)grad_sampling_loc + grid_offset * 2,
-                    (float *)nram_grad_output_tl, 2 * num_deal_grid);
-
+  __bang_atomic_reduce_add((float *)grad_sampling_loc + grid_offset * 2,
+                           (float *)nram_grad_output_tl, 2 * num_deal_grid);
 #endif
 }
 
@@ -1854,11 +2016,10 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwardSmallChannelsKernel(
   const int32_t C_align = PAD_UP(channels, ALIGN_NUM);
 
   const int32_t num_hlp = num_heads * num_levels * num_points;
-  int32_t num_per_time_theory = (MAX_NRAM_SIZE - num_levels * sizeof(float) -
-                                 3 * num_levels * sizeof(int32_t)) /
-                                sizeof(float) /
-                                (split_num_c * C_align + split_grid_num) /
-                                PAD_UP((num_hlp), ALIGN_NUM);
+  int32_t num_per_time_theory =
+      (MAX_NRAM_SIZE - num_levels * sizeof(float) -
+       3 * PAD_UP(num_levels, 32) * sizeof(int32_t)) /
+      sizeof(float) / (split_num_c * C_align + split_grid_num) / (num_hlp);
 
   int32_t deal_grid_num_theory = num_per_time_theory * num_hlp;
 
@@ -1939,8 +2100,10 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwardSmallChannelsKernel(
       (int32_t *)((float *)nram_buffer + split_num_c * offset_nram +
                   28 * offset_nram_calc);
   int32_t *nram_level_start_index =
-      (int32_t *)(nram_spatial_shapes + 2 * num_levels);
-  float *nram_h_stride = (float *)(nram_level_start_index + 3 * num_levels);
+      (int32_t *)(nram_spatial_shapes + 2 * PAD_UP(num_levels, 32));
+  float *nram_h_stride =
+      (float *)(nram_level_start_index + 3 * PAD_UP(num_levels, 32));
+
   const int32_t total_num = batch * num_query;
   int32_t num_per_core = total_num / taskDim;
   int32_t num_rem = total_num % taskDim;
@@ -1965,7 +2128,8 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwardSmallChannelsKernel(
     nram_base_ptr[loop] = loop * channels;
   }
   const int32_t w_stride = num_heads * channels;
-  for (int32_t grid_loop = 0; grid_loop < repeat_times + 1; grid_loop += 1) {
+
+  for (int32_t grid_loop = 0; grid_loop < repeat_times + 1; ++grid_loop) {
     int32_t grid_offset =
         (start_per_core + grid_loop * num_per_time_theory) * num_hlp;
     if (grid_loop == repeat_times) {
@@ -1978,15 +2142,17 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwardSmallChannelsKernel(
         num_deal_grid = tail_num * num_hlp;
       }
     }
-
     __memcpy_async(nram_spatial_shapes, spatial_shapes,
                    num_levels * 2 * sizeof(int32_t), GDRAM2NRAM);
-    __memcpy_async(nram_level_start_index, data_level_start_index,
-                   num_levels * sizeof(int32_t), GDRAM2NRAM);
+
     __memcpy_async(nram_loc_w, data_sampling_loc + grid_offset * 2,
                    num_deal_grid * 2 * sizeof(float), GDRAM2NRAM);
-    __memcpy(nram_grad_weight, data_attn_weight + grid_offset,
-             num_deal_grid * sizeof(float), GDRAM2NRAM);
+
+    __sync_io_move_compute();
+    __memcpy_async(nram_grad_weight, data_attn_weight + grid_offset,
+                   num_deal_grid * sizeof(float), GDRAM2NRAM);
+    __memcpy_async(nram_level_start_index, data_level_start_index,
+                   num_levels * sizeof(int32_t), GDRAM2NRAM);
     computeGridMaskAndOffset(
         nram_grad_output_tl, nram_grad_output_tr, nram_loc_w, nram_loc_h,
         nram_h_stride, nram_spatial_shapes, nram_w_low_temp, nram_h_high_temp,
@@ -1996,28 +2162,23 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwardSmallChannelsKernel(
         nram_w3, nram_w4, nram_offset_temp, nram_offset1, nram_offset2,
         nram_offset3, nram_offset4, nram_base_ptr, nram_h_low_temp,
         num_deal_grid, num_per_time_real, num_heads, num_levels, num_points,
-        w_stride, qid_stride);
+        w_stride, qid_stride, grad_temp1);
     float *mask1 = nram_h_low_ptr_offset;
     float *mask2 = nram_h_high_ptr_offset;
     float *mask3 = nram_w_low_ptr_offset;
     float *mask4 = nram_w_high_ptr_offset;
+    __memcpy_async(
+        grad_temp2,
+        grad_output + (start_per_core + grid_loop * num_per_time_theory) *
+                          num_heads * deal_num_real,
+        num_per_time_real * num_heads * deal_num_real * sizeof(float),
+        GDRAM2NRAM);
     loadValue(nram_grad_output_tl, nram_grad_output_tr, nram_grad_output_bl,
-              nram_grad_output_br, data_value, grad_output, grad_temp1,
-              grad_temp2, mask1, mask2, mask3, mask4, nram_offset1,
-              nram_offset2, nram_offset3, nram_offset4, nram_grad_weight,
-              nram_level_start_index, offset_nram, start_per_core, grid_loop,
-              num_per_time_theory, num_heads, deal_num_real, num_per_time_real,
-              num_deal_grid, num_query, num_levels, num_points, grid_offset,
-              spatial_size, qid_stride);
-    float *nram_grid_offset1 = nram_loc_h;
-    float *nram_grid_offset2 = nram_loc_w;
-    computeGradValue(
-        grad_temp1, grad_temp2, grad_temp3, grad_temp4, mask1, mask2, mask3,
-        mask4, nram_offset1, nram_offset2, nram_offset3, nram_offset4,
-        nram_level_start_index, deal_num_real, grad_value, nram_w1, nram_w2,
-        nram_w3, nram_w4, num_per_time_real, num_heads, num_levels, num_points,
-        num_query, num_deal_grid, grid_offset, spatial_size, qid_stride,
-        nram_grid_offset1, nram_grid_offset2);
+              nram_grad_output_br, data_value, grad_temp1, grad_temp3, mask1,
+              mask2, mask3, mask4, nram_offset1, nram_offset2, nram_offset3,
+              nram_offset4, nram_grad_weight, nram_level_start_index,
+              offset_nram, num_heads, deal_num_real, num_deal_grid, num_query,
+              num_levels, num_points, grid_offset, spatial_size, qid_stride);
 
     // compute grad_weight
     float *grad_weight = grad_temp1;
@@ -2025,11 +2186,11 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwardSmallChannelsKernel(
     float *grad_w_weight = grad_temp3;
     computeGradAttnWeight(
         grad_w_weight, grad_weight, nram_grad_output_tl, nram_grad_output_tr,
-        nram_grad_output_bl, nram_grad_output_br, grad_temp1, grad_temp2,
-        grad_attn_weight, nram_hw, nram_hh, nram_lw, nram_lh, grad_h_weight,
-        nram_w1, nram_w2, nram_w3, nram_w4, offset_nram, num_deal_grid,
-        deal_num_real, num_per_time_real, num_heads, num_levels, num_points,
-        grid_offset, nram_h_high_temp);
+        nram_grad_output_bl, nram_grad_output_br, grad_temp2, grad_attn_weight,
+        nram_hw, nram_hh, nram_lw, nram_lh, grad_h_weight, nram_w1, nram_w2,
+        nram_w3, nram_w4, offset_nram, num_deal_grid, deal_num_real,
+        num_per_time_real, num_heads, num_levels, num_points, grid_offset,
+        nram_h_high_temp);
 
     // compute grad_sampling_loc
     computeGradSampingLoc(grad_sampling_loc, nram_grad_output_tl,
@@ -2038,6 +2199,18 @@ __mlu_global__ void MLUUnion1KernelMsDeformAttnBackwardSmallChannelsKernel(
                           nram_grad_weight, num_deal_grid, deal_num_real,
                           num_per_time_real, num_heads, num_levels, num_points,
                           grid_offset, nram_h_high_temp);
+
+    float *nram_grid_offset1 = nram_loc_h;
+    float *nram_grid_offset2 = nram_loc_w;
+    computeGradValue(
+        grad_temp1, grad_temp2, grad_temp3, grad_temp4, mask1, mask2, mask3,
+        mask4, nram_offset1, nram_offset2, nram_offset3, nram_offset4,
+        nram_level_start_index, deal_num_real, grad_value, nram_w1, nram_w2,
+        nram_w3, nram_w4, num_per_time_real, num_heads, num_levels, num_points,
+        num_query, num_deal_grid, grid_offset, spatial_size, qid_stride,
+        nram_grid_offset1, nram_grid_offset2, batch, nram_grad_output_tl,
+        nram_grad_output_tr, nram_grad_output_bl, nram_grad_output_br,
+        nram_grad_weight);
   }
 #endif
 }

--- a/mmcv/ops/csrc/common/mlu/ms_deform_attn_mlu_kernel.mlu
+++ b/mmcv/ops/csrc/common/mlu/ms_deform_attn_mlu_kernel.mlu
@@ -1,5 +1,5 @@
-/************************************************************************* 
- *copyright (C) 2022 by Cambricon.
+/*************************************************************************
+ * Copyright (C) 2022 by Cambricon.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/mmcv/ops/csrc/common/mlu/ms_deform_attn_mlu_kernel_fast.mlu
+++ b/mmcv/ops/csrc/common/mlu/ms_deform_attn_mlu_kernel_fast.mlu
@@ -1,0 +1,973 @@
+/*************************************************************************
+ * Copyright (C) [2019-2022] by Cambricon, Inc.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *************************************************************************/
+#include "common_mlu_helper.hpp"
+#include <math.h>
+
+#pragma bang walign(64)
+
+#if (__BANG_ARCH__ >= 370)
+
+#define MEMCORE_FLAG (0x80)
+#define BIT_COLLECT_PAD (8)
+#define MAX_MEMCPY_SEGNUM (65536)
+#define NRAM_REMAIN_SIZE (48 * 1024)
+#define SRAM_REMAIN_SIZE (32 * 1024)
+#define NRAM_AVALIABLE_SIZE (__MLU_NRAM_SIZE__ * 1024 - NRAM_REMAIN_SIZE)
+#define WRAM_AVALIABLE_SIZE (__MLU_WRAM_SIZE__ * 1024)
+#define SRAM_AVALIABLE_SIZE (__MLU_SRAM_SIZE__ * 1024 - SRAM_REMAIN_SIZE)
+#define SRAM_FOR_VALUE_SIZE (SRAM_AVALIABLE_SIZE - 128)
+
+#ifndef LT_NUM
+#define LT_NUM 64
+#endif
+
+#ifndef WRAM_LT_STRIDE
+#define WRAM_LT_STRIDE (__MLU_WRAM_SIZE__ * 1024 / LT_NUM)
+#endif
+
+#ifndef WRAM_ALIGN_SIZE
+#define WRAM_ALIGN_SIZE (64)
+#endif
+
+__nram__ char nram_buffer[NRAM_AVALIABLE_SIZE];
+__mlu_shared__ char sram_buffer[SRAM_AVALIABLE_SIZE];
+__wram__ char wram_buffer[WRAM_AVALIABLE_SIZE];
+
+template <typename T>
+__mlu_func__ void tileWeight2WramAsync(T* dst,
+                                       T* src,  // (co, ci)
+                                       int32_t co, int32_t ci, int32_t pad_co,
+                                       int32_t pad_ci) {
+  int32_t co_num = co / LT_NUM;
+  int32_t co_remain = co % LT_NUM;
+  if (co_num > 0) {
+    __memcpy_async(dst, src, ci * sizeof(T), NRAM2WRAM, WRAM_LT_STRIDE,
+                   LT_NUM - 1, pad_ci * sizeof(T), co_num - 1, ci * sizeof(T),
+                   LT_NUM - 1, LT_NUM * ci * sizeof(T), co_num - 1);
+  }
+  if (co_remain > 0) {
+    __memcpy_async(dst + co_num * pad_ci, src + co_num * LT_NUM * ci,
+                   ci * sizeof(T), NRAM2WRAM, WRAM_LT_STRIDE, ci * sizeof(T),
+                   co_remain - 1);
+  }
+}
+
+template <typename T>
+__mlu_func__ void tileWeight2WramSync(T* dst,
+                                      T* src,  // (co, ci)
+                                      int32_t co, int32_t ci, int32_t pad_co,
+                                      int32_t pad_ci) {
+  int32_t co_num = co / LT_NUM;
+  int32_t co_remain = co % LT_NUM;
+  if (co_num > 0) {
+    __memcpy(dst, src, ci * sizeof(T), NRAM2WRAM, WRAM_LT_STRIDE, LT_NUM - 1,
+             pad_ci * sizeof(T), co_num - 1, ci * sizeof(T), LT_NUM - 1,
+             LT_NUM * ci * sizeof(T), co_num - 1);
+  }
+  if (co_remain > 0) {
+    __memcpy(dst + co_num * pad_ci, src + co_num * LT_NUM * ci, ci * sizeof(T),
+             NRAM2WRAM, WRAM_LT_STRIDE, ci * sizeof(T), co_remain - 1);
+  }
+}
+
+template <typename T>
+__mlu_func__ void isValueContainInfNan(T* input_sram, T* output_sram,
+                                       T* nram_buf, bool& value_contain_infnan,
+                                       int32_t nram_buf_size,
+                                       int32_t data_num) {
+  int32_t core_avg_num = (data_num + coreDim - 1) / coreDim;
+  int32_t core_begin_num = core_avg_num * coreId;
+  int32_t core_act_num = min(data_num - core_begin_num, core_avg_num);
+  int32_t core_step_num =
+      PAD_DOWN(nram_buf_size - NFU_ALIGN_SIZE, NFU_ALIGN_SIZE) / sizeof(T);
+  int32_t c = NFU_ALIGN_SIZE / sizeof(T);
+  int32_t loop_num = (core_act_num + core_step_num - 1) / core_step_num;
+  int32_t remain_num = (int)(loop_num > 0) * (core_act_num % core_step_num);
+  T* input_sram_base = input_sram + core_begin_num;
+  T* nram_out = nram_buf;
+  T* nram_input = nram_buf + NFU_ALIGN_SIZE / sizeof(T);
+  T sum = 0;
+
+  if (remain_num > 0) {
+    int32_t n = (remain_num + c - 1) / c;
+    __bang_write_value(nram_input + (n - 1) * c, c, (T)0);
+  }
+
+  for (int32_t i = 0; i < loop_num; i++) {
+    int32_t deal_num = min(core_step_num, core_act_num - i * core_step_num);
+    int32_t n = (deal_num + c - 1) / c;
+    __memcpy(nram_input, input_sram_base + i * core_step_num,
+             deal_num * sizeof(T), SRAM2NRAM);
+    __bang_sumpool(nram_out, nram_input, c, n, 1, n, 1, 1, 1);
+    __bang_sumpool(nram_input, nram_out, 1, c, 1, c, 1, 1, 1);
+    T tmp = nram_input[0];
+    if (isnan(tmp) || isinf(tmp)) {
+      sum = 1;
+      break;
+    } else {
+      sum = 0;
+    }
+  }
+
+  output_sram[coreId] = sum;
+  __sync_all_ipu_within_cluster();
+  __memcpy(nram_input, output_sram, coreDim * sizeof(T), SRAM2NRAM);
+  value_contain_infnan =
+      (nram_input[0] + nram_input[1] + nram_input[2] + nram_input[3]) > 0;
+}
+
+template <typename T, bool SRAM_STAY>
+__mlu_func__ void getConditionCoordWeight(
+    int32_t* data_offset_nram, T* weight_polation_nram,
+    T* cond_point_polation_nram, T* cond_point_valid_nram, T* loc_nram,
+    T* weight_attn_nram, int8_t* mask_x_nram, int8_t* mask_y_nram,
+    T* spatial_offset_bd_nram, T* spatial_w_bd_nram, T* spatial_h_bd_nram,
+    T* buf_nram, bool& w_contain_inf, const bool value_contain_infnan,
+    const int32_t deal_n, const int32_t num_levels, const int32_t num_points,
+    const int32_t num_heads, const int32_t channels) {
+  int32_t total_points = deal_n * num_levels * num_points;
+  int32_t block_points = num_levels * num_points;
+  T* buf_x_nram = buf_nram;
+  T* buf_y_nram = buf_nram + total_points;
+  T* buf_cond_nram = buf_nram + 2 * total_points;
+  T* buf_x_floor = buf_nram + 2 * total_points;
+  T* buf_x_ceil = buf_nram + 3 * total_points;
+  T* buf_y_floor = buf_nram + 4 * total_points;
+  T* buf_y_ceil = buf_nram + 5 * total_points;
+  //================================================================================================
+  // if weight_attn_nram contain inf
+  int32_t inf_p = 0x7f7fffff;
+  int32_t inf_n = 0xff7fffff;
+  T inf_p_f = *((T*)&inf_p);
+  T inf_n_f = *((T*)&inf_n);
+  __bang_lt_scalar(buf_nram, weight_attn_nram, inf_n_f, total_points);
+  __bang_gt_scalar(buf_nram + total_points, weight_attn_nram, inf_p_f,
+                   total_points);
+  __bang_sumpool(buf_nram + 2 * total_points, buf_nram, 1, 2 * total_points, 1,
+                 2 * total_points, 1, 1, 1);
+  w_contain_inf = buf_nram[2 * total_points] > 0;
+  //================================================================================================
+  int32_t total_coord_pad = PAD_UP(total_points * 2, BIT_COLLECT_PAD);
+  __bang_collect_bitindex(buf_x_nram, loc_nram, mask_x_nram, total_coord_pad);
+  __bang_collect_bitindex(buf_y_nram, loc_nram, mask_y_nram, total_coord_pad);
+  // x = loc_x * spatial_w - 0.5; y = loc_y * spatial_h - 0.5;
+  __bang_fusion(FUSION_FMS, buf_x_nram, buf_x_nram, spatial_w_bd_nram, (T)0.5,
+                total_points, block_points);
+  __bang_fusion(FUSION_FMS, buf_y_nram, buf_y_nram, spatial_h_bd_nram, (T)0.5,
+                total_points, block_points);
+  //================================================================================================
+  // get point condition. use buf0, buf1, buf2
+  // (x > -1 && y > -1 && y < spatial_h && x < spatial_w)
+  __bang_gt_scalar(cond_point_valid_nram, buf_x_nram, (T)-1.0, total_points);
+  __bang_gt_scalar(buf_cond_nram, buf_y_nram, (T)-1.0, total_points);
+  __bang_and(cond_point_valid_nram, cond_point_valid_nram, buf_cond_nram,
+             total_points);
+  __bang_cycle_lt(buf_cond_nram, buf_x_nram, spatial_w_bd_nram, total_points,
+                  block_points);
+  __bang_and(cond_point_valid_nram, cond_point_valid_nram, buf_cond_nram,
+             total_points);
+  __bang_cycle_lt(buf_cond_nram, buf_y_nram, spatial_h_bd_nram, total_points,
+                  block_points);
+  __bang_and(cond_point_valid_nram, cond_point_valid_nram, buf_cond_nram,
+             total_points);
+  //================================================================================================
+  __bang_floor(buf_x_floor, buf_x_nram, total_points);
+  __bang_add_scalar(buf_x_ceil, buf_x_floor, 1.0, total_points);
+  __bang_floor(buf_y_floor, buf_y_nram, total_points);
+  __bang_add_scalar(buf_y_ceil, buf_y_floor, 1.0, total_points);
+  T* cond_point_polation_nram_tl = cond_point_polation_nram;
+  T* cond_point_polation_nram_bl = cond_point_polation_nram + total_points;
+  T* cond_point_polation_nram_tr = cond_point_polation_nram + 2 * total_points;
+  T* cond_point_polation_nram_br = cond_point_polation_nram + 3 * total_points;
+  T* cond_point_polation_nram_cond1 = weight_polation_nram;
+  T* cond_point_polation_nram_cond2 = weight_polation_nram + total_points;
+  T* cond_point_polation_nram_cond3 = weight_polation_nram + 2 * total_points;
+  T* cond_point_polation_nram_cond4 = weight_polation_nram + 3 * total_points;
+  __bang_ge_scalar(cond_point_polation_nram_cond1, buf_x_floor, (T)0,
+                   total_points);
+  __bang_cycle_lt(cond_point_polation_nram_cond2, buf_x_ceil, spatial_w_bd_nram,
+                  total_points, block_points);
+  __bang_ge_scalar(cond_point_polation_nram_cond3, buf_y_floor, (T)0,
+                   total_points);
+  __bang_cycle_lt(cond_point_polation_nram_cond4, buf_y_ceil, spatial_h_bd_nram,
+                  total_points, block_points);
+  __bang_and(cond_point_polation_nram_tl, cond_point_polation_nram_cond1,
+             cond_point_polation_nram_cond4, total_points);
+  __bang_and(cond_point_polation_nram_bl, cond_point_polation_nram_cond1,
+             cond_point_polation_nram_cond3, total_points);
+  __bang_and(cond_point_polation_nram_tr, cond_point_polation_nram_cond2,
+             cond_point_polation_nram_cond4, total_points);
+  __bang_and(cond_point_polation_nram_br, cond_point_polation_nram_cond2,
+             cond_point_polation_nram_cond3, total_points);
+  //================================================================================================
+  // get polation weight.
+  T* buf_dx = (T*)data_offset_nram;
+  T* buf_dy = buf_dx + total_points;
+  T* buf_dx_1 = buf_dy + total_points;
+  T* buf_dy_1 = buf_dx_1 + total_points;
+  // -dx = x_floor-x
+  // -dy = y_floor-y
+  // w1 = (1-dx)*dy     = (dx-1)*(-dy)
+  // w2 = (1-dx)*(1-dy) = (dx-1)*(dy-1)
+  // w3 = dx*dy         = (-dx)*(-dy)
+  // w4 = dx*(1-dy)     = (-dx)*(dy-1)
+  T* weight_polation_nram_1 = weight_polation_nram;
+  T* weight_polation_nram_2 = weight_polation_nram + 1 * total_points;
+  T* weight_polation_nram_3 = weight_polation_nram + 2 * total_points;
+  T* weight_polation_nram_4 = weight_polation_nram + 3 * total_points;
+  // T* weight_polation_nram_buf = buf_nram + 4 * total_points;
+  __bang_sub(buf_dx, buf_x_floor, buf_x_nram, total_points);
+  __bang_sub(buf_dy, buf_y_floor, buf_y_nram, total_points);
+  __bang_fusion(FUSION_FSS, buf_dx_1, buf_x_nram, buf_x_floor, (T)1.0,
+                total_points, total_points);
+  __bang_fusion(FUSION_FSS, buf_dy_1, buf_y_nram, buf_y_floor, (T)1.0,
+                total_points, total_points);
+  __bang_mul(weight_polation_nram_1, buf_dx_1, buf_dy, total_points);
+  __bang_mul(weight_polation_nram_2, buf_dx_1, buf_dy_1, total_points);
+  __bang_mul(weight_polation_nram_3, buf_dx, buf_dy, total_points);
+  __bang_mul(weight_polation_nram_4, buf_dx, buf_dy_1, total_points);
+  //================================================================================================
+  // correct the x,y in [0, w-1] and [0, h-1]
+  T* spatial_w1_bd_nram = buf_nram;
+  T* spatial_h1_bd_nram = buf_nram + block_points;
+  __bang_sub_scalar(spatial_w1_bd_nram, spatial_w_bd_nram, (T)1, block_points);
+  __bang_sub_scalar(spatial_h1_bd_nram, spatial_h_bd_nram, (T)1, block_points);
+  __bang_maxeq_scalar(buf_x_floor, buf_x_floor, (T)0, total_points);
+  __bang_maxeq_scalar(buf_x_ceil, buf_x_ceil, (T)0, total_points);
+  __bang_cycle_minequal(buf_x_floor, buf_x_floor, spatial_w1_bd_nram,
+                        total_points, block_points);
+  __bang_cycle_minequal(buf_x_ceil, buf_x_ceil, spatial_w1_bd_nram,
+                        total_points, block_points);
+  __bang_maxeq_scalar(buf_y_floor, buf_y_floor, (T)0, total_points);
+  __bang_maxeq_scalar(buf_y_ceil, buf_y_ceil, (T)0, total_points);
+  __bang_cycle_minequal(buf_y_floor, buf_y_floor, spatial_h1_bd_nram,
+                        total_points, block_points);
+  __bang_cycle_minequal(buf_y_ceil, buf_y_ceil, spatial_h1_bd_nram,
+                        total_points, block_points);
+  //================================================================================================
+  // offset = y*w + x
+  T* buf_hw_offset = buf_nram;
+  T* data_offset_nram_tl = (T*)data_offset_nram;
+  T* data_offset_nram_bl = data_offset_nram_tl + total_points;
+  T* data_offset_nram_tr = data_offset_nram_bl + total_points;
+  T* data_offset_nram_br = data_offset_nram_tr + total_points;
+  // y_ceil*w + offset + x_floor
+  __bang_fusion(FUSION_FMA, buf_hw_offset, buf_y_ceil, spatial_w_bd_nram,
+                spatial_offset_bd_nram, total_points, block_points);
+  __bang_add(data_offset_nram_tl, buf_hw_offset, buf_x_floor, total_points);
+  // y_ceil*w + offset + x_ceil
+  __bang_add(data_offset_nram_tr, buf_hw_offset, buf_x_ceil, total_points);
+  // y_floor*w + offset + x_foor
+  __bang_fusion(FUSION_FMA, buf_hw_offset, buf_y_floor, spatial_w_bd_nram,
+                spatial_offset_bd_nram, total_points, block_points);
+  __bang_add(data_offset_nram_bl, buf_hw_offset, buf_x_floor, total_points);
+  // y_floor*w + offset + x_ceil
+  __bang_add(data_offset_nram_br, buf_hw_offset, buf_x_ceil, total_points);
+  //================================================================================================
+  // merge and select conditions and weight
+  T* weight_polation_nram_tmp = (T*)buf_nram;
+  __bang_cycle_and(cond_point_polation_nram, cond_point_polation_nram,
+                   cond_point_valid_nram, 4 * total_points, total_points);
+  if (!w_contain_inf) {
+    __bang_cycle_mul(weight_polation_nram, weight_polation_nram,
+                     weight_attn_nram, 4 * total_points, total_points);
+  }
+  __bang_mul_scalar(buf_nram, weight_attn_nram, (T)1, total_points);
+  __bang_collect((float*)weight_attn_nram, (float*)buf_nram,
+                 cond_point_valid_nram, total_points);
+  __bang_float2int32((int32_t*)cond_point_polation_nram,
+                     cond_point_polation_nram, total_points * 4, 0);
+  __bang_mul_scalar((int32_t*)cond_point_polation_nram,
+                    (int32_t*)cond_point_polation_nram, (int32_t)0xffffffff,
+                    total_points * 4);
+  __bang_band((char*)weight_polation_nram_tmp, (char*)weight_polation_nram,
+              (char*)cond_point_polation_nram,
+              total_points * 4 * sizeof(float));
+  __bang_collect((float*)weight_polation_nram, (float*)weight_polation_nram_tmp,
+                 cond_point_valid_nram, total_points);
+  __bang_collect((float*)weight_polation_nram + total_points,
+                 (float*)weight_polation_nram_tmp + total_points,
+                 cond_point_valid_nram, total_points);
+  __bang_collect((float*)weight_polation_nram + 2 * total_points,
+                 (float*)weight_polation_nram_tmp + 2 * total_points,
+                 cond_point_valid_nram, total_points);
+  __bang_collect((float*)weight_polation_nram + 3 * total_points,
+                 (float*)weight_polation_nram_tmp + 3 * total_points,
+                 cond_point_valid_nram, total_points);
+  //================================================================================================
+  // select cond_point_polation_nram if value_contain_infnan
+  if (value_contain_infnan) {
+    int32_t* cond_point_polation_nram_tmp = (int32_t*)buf_nram;
+    __bang_mul_scalar((int32_t*)cond_point_polation_nram_tmp,
+                      (int32_t*)cond_point_polation_nram, (int32_t)1,
+                      total_points * 4);
+    __bang_collect((float*)cond_point_polation_nram,
+                   (float*)cond_point_polation_nram_tmp, cond_point_valid_nram,
+                   total_points);
+    __bang_collect((float*)cond_point_polation_nram + total_points,
+                   (float*)cond_point_polation_nram_tmp + total_points,
+                   cond_point_valid_nram, total_points);
+    __bang_collect((float*)cond_point_polation_nram + 2 * total_points,
+                   (float*)cond_point_polation_nram_tmp + 2 * total_points,
+                   cond_point_valid_nram, total_points);
+    __bang_collect((float*)cond_point_polation_nram + 3 * total_points,
+                   (float*)cond_point_polation_nram_tmp + 3 * total_points,
+                   cond_point_valid_nram, total_points);
+  }
+  //================================================================================================
+  // compute and select offset and stride
+  int32_t* data_offset_nram_tl_tmp = (int32_t*)buf_nram;
+  int32_t* data_offset_nram_bl_tmp = data_offset_nram_tl_tmp + total_points;
+  int32_t* data_offset_nram_tr_tmp = data_offset_nram_bl_tmp + total_points;
+  __bang_float2int32(data_offset_nram_tl_tmp, data_offset_nram_tl,
+                     total_points * 4, 0);
+  int32_t stride =
+      SRAM_STAY ? channels * sizeof(T) : num_heads * channels * sizeof(T);
+  __bang_mul_scalar(data_offset_nram_tl_tmp, data_offset_nram_tl_tmp, stride,
+                    total_points * 4);
+  __bang_sub((int32_t*)data_offset_nram_bl_tmp,
+             (int32_t*)data_offset_nram_bl_tmp,
+             (int32_t*)data_offset_nram_tl_tmp, total_points);
+  __bang_sub((int32_t*)data_offset_nram_tr_tmp,
+             (int32_t*)data_offset_nram_tr_tmp,
+             (int32_t*)data_offset_nram_tl_tmp, total_points);
+  __bang_collect((float*)data_offset_nram_tl, (float*)data_offset_nram_tl_tmp,
+                 cond_point_valid_nram, total_points);
+  __bang_collect((float*)data_offset_nram_bl, (float*)data_offset_nram_bl_tmp,
+                 cond_point_valid_nram, total_points);
+  __bang_collect((float*)data_offset_nram_tr, (float*)data_offset_nram_tr_tmp,
+                 cond_point_valid_nram, total_points);
+}
+
+/*
+  shape of each tensor:
+  output_nram:          (channels)
+  input_nram:           (4, valid_num, channels)
+  input_trans:          (channels, 4, valid_num)
+  input_pooled:         (channels, valid_num)
+  cond_selected_base:   (4, deal_n, num_levels, num_points)
+  weight_selected_base: (4, deal_n, num_levels, num_points)
+  weight_attn_nram:     (valid_num)
+  weight_compute:       (4, valid_num)
+  cond_compute:         (4, valid_num)
+  input_wram:           (channels, 4 * valid_num)
+
+  valid_num <= num_levels * num_points
+  sample_stride_3 = deal_n * num_levels * num_points
+
+  Note:
+  If w_contain_inf is true, cannot merge attn_w and polation_w, so use sumpool
+  twice. If w_contain_inf is false, merge attn_w and polation_w and use matmul
+  instead. If value_contain_infnan is true, fill data_value of invalid
+  neighbors with 0.
+*/
+template <typename T>
+__mlu_func__ void reduceLevelByConv(
+    T* output_nram, T* input_nram, T* input_trans, T* input_pooled,
+    int32_t* cond_selected_base, T* weight_selected_base, T* weight_attn_nram,
+    T* weight_compute, int32_t* cond_compute, T* input_wram,
+    const int32_t valid_num, const int32_t channels,
+    const int32_t sample_stride_3, const bool w_contain_inf,
+    const bool value_contain_infnan) {
+  if (valid_num > 0) {
+    int32_t ci = 4 * valid_num;
+    int32_t pad_ci = PAD_UP(ci, WRAM_ALIGN_SIZE / sizeof(T));
+    int32_t co = channels;
+    int32_t pad_co = PAD_UP(co, LT_NUM);
+    if (value_contain_infnan) {
+      __memcpy_async(cond_compute, cond_selected_base,
+                     valid_num * sizeof(int32_t), NRAM2NRAM,
+                     valid_num * sizeof(T), sample_stride_3 * sizeof(T), 3);
+    }
+    __memcpy_async(weight_compute, weight_selected_base, valid_num * sizeof(T),
+                   NRAM2NRAM, valid_num * sizeof(T),
+                   sample_stride_3 * sizeof(T), 3);
+    __bang_transpose(input_trans, input_nram, ci, co);
+    __sync_move();
+
+    if (value_contain_infnan) {
+      __bang_cycle_band((char*)input_trans, (char*)input_trans,
+                        (char*)cond_compute, co * ci * sizeof(T),
+                        ci * sizeof(T));
+    }
+
+    if (w_contain_inf) {
+      __bang_cycle_mul(input_trans, input_trans, weight_compute, co * ci, ci);
+      __bang_sumpool(input_pooled, input_trans, valid_num, channels, 4, 1, 4, 1,
+                     1);
+      __bang_cycle_mul(input_pooled, input_pooled, weight_attn_nram,
+                       channels * valid_num, valid_num);
+      __bang_transpose(input_trans, input_pooled, channels, valid_num);
+      __bang_sumpool(output_nram, input_trans, channels, valid_num, 1, valid_num,
+                     1, 1, 1);
+    } else {
+      tileWeight2WramSync(input_wram, input_trans, co, ci, pad_co, pad_ci);
+      __bang_conv(output_nram, weight_compute, input_wram, ci, 1, 1, 1, 1, 1, 1,
+                  co);
+    }
+
+  } else {
+    __bang_write_value(output_nram, channels, (T)0);
+  }
+}
+
+template <typename T>
+__mlu_func__ int32_t getReduceLevelByConvWramSize(const int32_t num_levels,
+                                                  const int32_t num_points,
+                                                  const int32_t channels) {
+  int32_t ci = 4 * num_levels * num_points;
+  int32_t pad_ci = PAD_UP(ci, WRAM_ALIGN_SIZE / sizeof(T));
+  int32_t co = channels;
+  int32_t pad_co = PAD_UP(co, LT_NUM);
+  return pad_co * pad_ci * sizeof(T);
+}
+
+__mlu_func__ void loadNram2Gpr(int32_t& v1, int32_t& v2, int32_t& v3,
+                               int32_t* p1, int32_t* p2, int32_t* p3) {
+  v1 = __load_nram(p1);
+  v2 = __load_nram(p2);
+  v3 = __load_nram(p3);
+}
+
+/*
+  Load 4 neighbors use one 3D-memcpy, just use offset of N1, stride_3_1 and
+  stride_2_1.
+        |<- stride_3_1 ->|
+        N1               N3
+        ^
+        |
+     stride_2_1
+        |
+        v
+        N2               N4
+
+  Trickly fold the loop as 2.
+*/
+template <typename T, mluMemcpyDirection_t DIR>
+__mlu_func__ void loadDataValueXram2NramAsync(
+    T* buf_value_nram_1, int32_t* offset_1, int32_t* stride_2_1,
+    int32_t* stride_3_1, T* value_src, const int32_t num_levels_points,
+    const int32_t channel_size, const int32_t value_stride_3_size) {
+  int32_t offset_1_a, stride_2_1_a, stride_3_1_a;
+  int32_t offset_1_b, stride_2_1_b, stride_3_1_b;
+  loadNram2Gpr(offset_1_a, stride_2_1_a, stride_3_1_a, offset_1, stride_2_1,
+               stride_3_1);
+  loadNram2Gpr(offset_1_b, stride_2_1_b, stride_3_1_b, offset_1 + 1,
+               stride_2_1 + 1, stride_3_1 + 1);
+  int32_t value_offset = 0;
+  int32_t next = 0;
+  int32_t loop_num = num_levels_points / 2;
+  int32_t remain = num_levels_points % 2;
+  int32_t data_value_stride = num_levels_points * channel_size;
+  for (int32_t j = 0; j < loop_num * 2; j += 2) {
+    value_offset = j * channel_size;
+    next = j + 2;
+    __memcpy_async((int8_t*)buf_value_nram_1 + value_offset,
+                   (int8_t*)value_src + offset_1_a, channel_size, DIR,
+                   2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_a,
+                   1, stride_2_1_a, 1);
+
+    loadNram2Gpr(offset_1_a, stride_2_1_a, stride_3_1_a, offset_1 + next,
+                 stride_2_1 + next, stride_3_1 + next);
+
+    __memcpy_async((int8_t*)buf_value_nram_1 + value_offset + channel_size,
+                   (int8_t*)value_src + offset_1_b, channel_size, DIR,
+                   2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_b,
+                   1, stride_2_1_b, 1);
+
+    loadNram2Gpr(offset_1_b, stride_2_1_b, stride_3_1_b, offset_1 + next + 1,
+                 stride_2_1 + next + 1, stride_3_1 + next + 1);
+  }
+
+  if (remain > 0) {
+    value_offset = loop_num * 2 * channel_size;
+    __memcpy_async((int8_t*)buf_value_nram_1 + value_offset,
+                   (int8_t*)value_src + offset_1_a, channel_size, DIR,
+                   2 * data_value_stride, 1, data_value_stride, 1, stride_3_1_a,
+                   1, stride_2_1_a, 1);
+  }
+}
+
+/*
+  use matmul to count valid samples.
+  sample_valid_count:     (deal_n)
+  cond_point_valid_nram:  (deal_n, num_levels, num_points)
+  nram_ones:              (num_levels, num_points)
+*/
+template <typename T>
+__mlu_func__ void countValidSamples(int32_t* sample_valid_count,
+                                    T* cond_point_valid_nram, T* nram_ones,
+                                    T* wram_buffer, int32_t num_levels,
+                                    int32_t num_points, int32_t deal_n) {
+  int32_t ci = num_levels * num_points;
+  int32_t pad_ci = PAD_UP(ci, WRAM_ALIGN_SIZE / sizeof(T));
+  int32_t co = deal_n;
+  int32_t pad_co = PAD_UP(co, LT_NUM);
+  tileWeight2WramSync(wram_buffer, cond_point_valid_nram, co, ci, pad_co,
+                      pad_ci);
+  __bang_conv((T*)sample_valid_count, nram_ones, wram_buffer, ci, 1, 1, 1, 1, 1,
+              1, co);
+  __bang_float2int32(sample_valid_count, (T*)sample_valid_count, deal_n, 0);
+}
+
+template <typename T, bool SRAM_STAY, int32_t REDUCE_TYPE = 0>
+__mlu_func__ void loadNeighborPolationAttn(
+    T* value_output_nram, T* value_sram, T* value_gdram,
+    int32_t* data_offset_nram, T* weight_polation_nram,
+    T* cond_point_polation_nram, T* cond_point_valid_nram, T* weight_attn_nram,
+    T* buf_nram, T* compute_buf_nram, T* nram_ones, const int32_t deal_n,
+    const int32_t num_levels, const int32_t num_points, const int32_t num_keys,
+    const int32_t channels, const bool w_contain_inf,
+    const bool value_contain_infnan) {
+  int32_t channel_size = channels * sizeof(T);
+  int32_t sample_stride_3 = deal_n * num_levels * num_points;
+  int32_t value_stride_3 = num_levels * num_points * channels;
+  int32_t value_stride_3_size = value_stride_3 * sizeof(T);
+  T* buf_value_nram = buf_nram;  // (4, num_levels, num_points, channels)
+  T* buf_value_nram_trans =
+      buf_nram + 4 * value_stride_3;  // (4, num_levels, num_points, channels)
+  T* buf_value_nram_pool =
+      buf_nram + 8 * value_stride_3;  // (1, num_levels, num_points, channels)
+  int32_t* sample_valid_count =
+      (int32_t*)(buf_nram + 9 * value_stride_3);  // (deal_n)
+  T* weight_compute_nram = compute_buf_nram;      // (4, num_levels, num_points)
+  int32_t* cond_compute_nram =
+      (int32_t*)(weight_compute_nram + 4 * num_levels * num_points);
+
+  countValidSamples(sample_valid_count, cond_point_valid_nram, nram_ones,
+                    (T*)wram_buffer, num_levels, num_points, deal_n);
+  __sync_compute();
+
+  int32_t* offset = data_offset_nram;
+  int32_t* stride_2_1 = offset + sample_stride_3;
+  int32_t* stride_3_1 = stride_2_1 + sample_stride_3;
+  T* output_nram = value_output_nram;
+  int32_t step_offset = 0;
+  T* value_src = SRAM_STAY ? value_sram : value_gdram;
+  for (int32_t i = 0; i < deal_n; i++) {
+    int32_t valid_num = sample_valid_count[i];
+    if (SRAM_STAY) {
+      loadDataValueXram2NramAsync<T, SRAM2NRAM>(
+          buf_value_nram, offset, stride_2_1, stride_3_1, value_src, valid_num,
+          channel_size, value_stride_3_size);
+      __sync_move();
+    } else {
+      loadDataValueXram2NramAsync<T, GDRAM2NRAM>(
+          buf_value_nram, offset, stride_2_1, stride_3_1, value_src, valid_num,
+          channel_size, value_stride_3_size);
+      __sync_io();
+    }
+    reduceLevelByConv(
+        output_nram, buf_value_nram, buf_value_nram_trans, buf_value_nram_pool,
+        (int32_t*)cond_point_polation_nram + step_offset,
+        weight_polation_nram + step_offset, weight_attn_nram + step_offset,
+        weight_compute_nram, cond_compute_nram, (T*)wram_buffer, valid_num,
+        channels, sample_stride_3, w_contain_inf, value_contain_infnan);
+    step_offset += valid_num;
+    offset = data_offset_nram + step_offset;
+    stride_2_1 = offset + sample_stride_3;
+    stride_3_1 = stride_2_1 + sample_stride_3;
+    output_nram += channels;
+  }
+}
+
+__mlu_func__ void broadcastSpatialHW(
+    float* spatial_offset_bd_nram,  // (num_levels, num_points)
+    float* spatial_h_bd_nram,       // (num_levels, num_points)
+    float* spatial_w_bd_nram,       // (num_levels, num_points)
+    int32_t* spatial_shapes_nram,   // (num_levels, 2)
+    int32_t* spatial_offset_nram,   // (num_levels)
+    const int32_t num_levels, const int32_t num_points) {
+  __bang_int322float((float*)spatial_shapes_nram, spatial_shapes_nram,
+                     num_levels * 2, 0);
+  __memcpy(spatial_h_bd_nram, spatial_shapes_nram, sizeof(float), NRAM2NRAM,
+           sizeof(float), num_points - 1, num_points * sizeof(float),
+           num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
+           num_levels - 1);
+  __memcpy(spatial_w_bd_nram, (float*)spatial_shapes_nram + 1, sizeof(float),
+           NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
+           num_levels - 1, 0, num_points - 1, 2 * sizeof(float),
+           num_levels - 1);
+  __bang_int322float((float*)spatial_offset_nram, spatial_offset_nram,
+                     num_levels, 0);
+  __memcpy(spatial_offset_bd_nram, spatial_offset_nram, sizeof(float),
+           NRAM2NRAM, sizeof(float), num_points - 1, num_points * sizeof(float),
+           num_levels - 1, 0, num_points - 1, sizeof(float), num_levels - 1);
+}
+
+template <typename T>
+__mlu_func__ void prepareLoop(
+    T* ones_nram, int32_t* spatial_offset_nram, int32_t* spatial_hw_nram,
+    int8_t* mask_x_nram, int8_t* mask_y_nram, T* spatial_offset_bd_nram,
+    T* spatial_h_bd_nram, T* spatial_w_bd_nram, T* value_sram,
+    const char* data_level_start_index_gdram,
+    const char* data_spatial_shapes_gdram, const int32_t num_keys,
+    const int32_t num_levels, const int32_t num_points,
+    const int32_t max_deal_n, const int32_t mask_size, const int32_t channels) {
+  int32_t pad_num_points_levels =
+      PAD_UP(num_levels * num_points, WRAM_ALIGN_SIZE / sizeof(T));
+  __bang_write_value(ones_nram, pad_num_points_levels, (T)0);
+  __bang_write_value(ones_nram, num_levels * num_points, (T)1);
+  __bang_write_value(mask_x_nram, mask_size, (char)0x55);
+  __bang_write_value(mask_y_nram, mask_size, (char)0xAA);
+  __memcpy_async(spatial_offset_nram, data_level_start_index_gdram,
+                 num_levels * sizeof(int32_t), GDRAM2NRAM);
+  __memcpy_async(spatial_hw_nram, data_spatial_shapes_gdram,
+                 num_levels * 2 * sizeof(int32_t), GDRAM2NRAM);
+  __sync_io_move_compute();
+  broadcastSpatialHW(spatial_offset_bd_nram, spatial_h_bd_nram,
+                     spatial_w_bd_nram, spatial_hw_nram, spatial_offset_nram,
+                     num_levels, num_points);
+}
+
+template <typename T>
+__mlu_func__ void loadDataValueGdram2Sram(T* value_sram, T* data_value_gdram,
+                                          const int32_t batch_idx,
+                                          const int32_t head_idx,
+                                          const int32_t num_keys,
+                                          const int32_t num_heads,
+                                          const int32_t channels) {
+  int32_t loop_num = (num_keys + MAX_MEMCPY_SEGNUM - 1) / MAX_MEMCPY_SEGNUM;
+  int32_t num_heads_channels = num_heads * channels;
+  for (int32_t i = 0; i < loop_num; i++) {
+    int32_t load_num = min(MAX_MEMCPY_SEGNUM, num_keys - i * MAX_MEMCPY_SEGNUM);
+    size_t src_offset = ((size_t)batch_idx * num_keys + i * MAX_MEMCPY_SEGNUM) *
+                            num_heads_channels +
+                        head_idx * channels;
+    int32_t dst_offset = i * MAX_MEMCPY_SEGNUM * channels;
+    __memcpy(value_sram + dst_offset, (T*)data_value_gdram + src_offset,
+             channels * sizeof(T), GDRAM2SRAM, channels * sizeof(T),
+             num_heads_channels * sizeof(T), load_num - 1);
+  }
+}
+
+/*
+  The shape of each tensor:
+  ones_nram:                 (num_levels, num_points)
+  buf_compute_nram:          (8, num_levels, num_points)
+  spatial_offset_nram:       (num_levels)
+  spatial_hw_nram:           (num_levels, 2)
+  spatial_offset_bd_nram:    (num_levels, num_points)
+  spatial_w_bd_nram:         (num_levels, num_points)
+  spatial_h_bd_nram:         (num_levels, num_points)
+  mask_x_nram:               (deal_n, num_levels, num_points, 2) / 8
+  mask_y_nram:               (deal_n, num_levels, num_points, 2) / 8
+  value_output_nram:         (deal_n, channels)
+  data_offset_nram:          (4, deal_n, num_levels, num_points)
+  weight_polation_nram:      (4, deal_n, num_levels, num_points)
+  cond_point_polation_nram:  (4, deal_n, num_levels, num_points)
+  cond_point_valid_nram:     (deal_n, num_levels, num_points)
+  loc_nram:                  (deal_n, num_levels, num_points, 2)
+  weight_attn_nram:          (deal_n, num_levels, num_points)
+  buf_nram:                  (6, deal_n, num_levels, num_points)
+
+  Note: buf_nram is reused in polation computing.
+*/
+template <typename T>
+__mlu_func__ void memPolicy(
+    T*& buf_compute_nram, T*& ones_nram, T*& value_output_nram,
+    int32_t*& data_offset_nram, T*& weight_polation_nram,
+    T*& cond_point_polation_nram, T*& cond_point_valid_nram, T*& loc_nram,
+    T*& weight_attn_nram, T*& buf_nram, T*& buf_nram_end, int8_t*& mask_x_nram,
+    int8_t*& mask_y_nram, T*& spatial_offset_bd_nram, T*& spatial_w_bd_nram,
+    T*& spatial_h_bd_nram, int32_t*& spatial_offset_nram,
+    int32_t*& spatial_hw_nram, T*& value_sram, int32_t& max_deal_n,
+    int32_t& mask_size, const int32_t batch_size, const int32_t num_keys,
+    const int32_t num_heads, const int32_t channels, const int32_t num_levels,
+    const int32_t num_queries, const int32_t num_points) {
+  int32_t num_points_levels = num_levels * num_points;
+  int32_t pad_num_points_levels =
+      PAD_UP(num_points_levels, WRAM_ALIGN_SIZE / sizeof(T));
+  int32_t pad_num_points_levels_8 =
+      PAD_UP(8 * num_points_levels, WRAM_ALIGN_SIZE / sizeof(T));
+  int32_t spatial_info_size =
+      PAD_UP(3 * num_levels * sizeof(int32_t), NFU_ALIGN_SIZE);
+  int32_t fix_space_size =
+      spatial_info_size + 2 * BIT_COLLECT_PAD * sizeof(T) +
+      (4 * pad_num_points_levels + pad_num_points_levels_8) * sizeof(T);
+  int32_t left_space_size = NRAM_AVALIABLE_SIZE - fix_space_size;
+  int32_t common_buffer_size_each = 6 * num_points_levels * sizeof(T);
+  int32_t inter_result_size_each =
+      17 * num_points_levels * sizeof(T) + channels * sizeof(T);
+
+  max_deal_n =
+      left_space_size / (common_buffer_size_each + inter_result_size_each);
+  int32_t compute_buffer_size =
+      (9 * num_points_levels * channels + max_deal_n) * sizeof(T);
+  int32_t common_buffer_size = max_deal_n * common_buffer_size_each;
+  // make sure buf_nram is large enough for compute
+  if (compute_buffer_size > common_buffer_size) {
+    int32_t tmp_deal_n =
+        (left_space_size - compute_buffer_size) / inter_result_size_each;
+    max_deal_n = min(max_deal_n, tmp_deal_n);
+  }
+
+  int32_t reduce_need_wram_size =
+      getReduceLevelByConvWramSize<T>(num_levels, num_points, channels);
+  int32_t count_valid_max =
+      PAD_DOWN(WRAM_AVALIABLE_SIZE / sizeof(T) / pad_num_points_levels, LT_NUM);
+  int32_t wram_deal_n =
+      (int)(reduce_need_wram_size <= WRAM_AVALIABLE_SIZE) * count_valid_max;
+  max_deal_n = min(max_deal_n, wram_deal_n);
+
+  int32_t total_points = max_deal_n * num_points_levels;
+  int32_t total_coord_pad = PAD_UP(total_points * 2, BIT_COLLECT_PAD);
+  mask_size = total_coord_pad / BIT_COLLECT_PAD;
+  ones_nram = (T*)nram_buffer;
+  buf_compute_nram = ones_nram + pad_num_points_levels;
+  spatial_offset_nram = (int32_t*)(buf_compute_nram + pad_num_points_levels_8);
+  spatial_hw_nram = spatial_offset_nram + num_levels;
+  spatial_offset_bd_nram = (T*)(spatial_hw_nram + num_levels * 2);
+  spatial_w_bd_nram = spatial_offset_bd_nram + num_points_levels;
+  spatial_h_bd_nram = spatial_w_bd_nram + num_points_levels;
+  mask_x_nram = (int8_t*)(spatial_h_bd_nram + num_points_levels);
+  mask_y_nram = mask_x_nram + mask_size;
+  value_output_nram = (T*)(mask_y_nram + mask_size);
+  data_offset_nram = (int32_t*)(value_output_nram + max_deal_n * channels);
+  weight_polation_nram = (T*)(data_offset_nram + 4 * total_points);
+  cond_point_polation_nram = weight_polation_nram + 4 * total_points;
+  cond_point_valid_nram = cond_point_polation_nram + 4 * total_points;
+  loc_nram = cond_point_valid_nram + total_points;
+  weight_attn_nram = loc_nram + total_coord_pad;
+  buf_nram = weight_attn_nram + total_points;
+  buf_nram_end = buf_nram + 6 * max_deal_n * num_points_levels;
+  value_sram = (T*)sram_buffer;
+}
+
+template <typename T, int32_t POLICY>
+__mlu_func__ void MLUKernelMsDeformAttnForwardFastImpl(
+    const char* data_value_gdram, const char* data_spatial_shapes_gdram,
+    const char* data_level_start_index_gdram,
+    const char* data_sampling_loc_gdram, const char* data_attn_weight_gdram,
+    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
+    const int32_t num_points, char* data_col_gdram) {
+  int32_t input_stride_4 = num_queries * num_heads * num_levels * num_points;
+  int32_t input_stride_3 = num_heads * num_levels * num_points;
+  int32_t input_stride_2 = num_levels * num_points;
+  int32_t output_stride_3 = num_queries * num_heads * channels;
+  int32_t output_stride_2 = num_heads * channels;
+  int32_t data_value_stride_3 = num_keys * num_heads * channels;
+  constexpr bool sram_stay = (POLICY == 0);
+
+  T* value_output_nram = nullptr;         // (deal_n, channels)
+  int32_t* data_offset_nram = nullptr;    // (4, deal_n, num_levels, num_points)
+  T* weight_polation_nram = nullptr;      // (4, deal_n, num_levels, num_points)
+  T* cond_point_polation_nram = nullptr;  // (4, deal_n, num_levels, num_points)
+  T* cond_point_valid_nram = nullptr;     // (deal_n, num_levels, num_points)
+  T* loc_nram = nullptr;                  // (deal_n, num_levels, num_points, 2)
+  T* weight_attn_nram = nullptr;          // (deal_n, num_levels, num_points)
+  T* buf_nram = nullptr;                  // (6, deal_n, num_levels, num_points)
+  T* buf_nram_end = nullptr;
+  int8_t* mask_x_nram = nullptr;  // (deal_n, num_levels, num_points, 2) / 8
+  int8_t* mask_y_nram = nullptr;  // (deal_n, num_levels, num_points, 2) / 8
+  T* spatial_offset_bd_nram = nullptr;     // (num_levels, num_points)
+  T* spatial_w_bd_nram = nullptr;          // (num_levels, num_points)
+  T* spatial_h_bd_nram = nullptr;          // (num_levels, num_points)
+  int32_t* spatial_offset_nram = nullptr;  // (num_levels)
+  int32_t* spatial_hw_nram = nullptr;      // (num_levels, 2)
+  T* buf_compute_nram = nullptr;           // (8, num_levels, num_points)
+  T* ones_nram = nullptr;                  // (1, num_levels, num_points)
+  T* value_sram = nullptr;                 // (num_keys, channels)
+  int32_t max_deal_n = 0;
+  int32_t mask_size = 0;
+  memPolicy(buf_compute_nram, ones_nram, value_output_nram, data_offset_nram,
+            weight_polation_nram, cond_point_polation_nram,
+            cond_point_valid_nram, loc_nram, weight_attn_nram, buf_nram,
+            buf_nram_end, mask_x_nram, mask_y_nram, spatial_offset_bd_nram,
+            spatial_w_bd_nram, spatial_h_bd_nram, spatial_offset_nram,
+            spatial_hw_nram, value_sram, max_deal_n, mask_size, batch_size,
+            num_keys, num_heads, channels, num_levels, num_queries, num_points);
+  if (max_deal_n <= 0) {
+    return;
+  }
+
+  // split batch*head into taskDimY
+  int32_t batch_head = batch_size * num_heads;
+  int32_t cluster_avg_batch_head = (batch_head + taskDimY - 1) / taskDimY;
+  int32_t cluster_begin_batch_head = taskIdY * cluster_avg_batch_head;
+  int32_t cluster_act_batch_head =
+      min(cluster_avg_batch_head, batch_head - cluster_begin_batch_head);
+  int32_t cluster_end_batch_head =
+      cluster_begin_batch_head + cluster_act_batch_head;
+  // split query into coreDim
+  int32_t core_avg_query = (num_queries + coreDim - 1) / coreDim;
+  int32_t core_begin_query = coreId * core_avg_query;
+  int32_t core_act_query = min(num_queries - core_begin_query, core_avg_query);
+  int32_t core_loop_num = (core_act_query + max_deal_n - 1) / max_deal_n;
+  int32_t core_step_query =
+      core_loop_num > 0 ? (core_act_query + core_loop_num - 1) / core_loop_num
+                        : 0;
+  int32_t core_remain_query =
+      core_act_query - (core_loop_num - 1) * core_step_query;
+  int32_t first_deal_query =
+      (int)(core_loop_num > 0) *
+      (core_loop_num > 1 ? core_step_query : core_remain_query);
+
+  prepareLoop(ones_nram, spatial_offset_nram, spatial_hw_nram, mask_x_nram,
+              mask_y_nram, spatial_offset_bd_nram, spatial_h_bd_nram,
+              spatial_w_bd_nram, value_sram, data_level_start_index_gdram,
+              data_spatial_shapes_gdram, num_keys, num_levels, num_points,
+              max_deal_n, mask_size, channels);
+
+  for (int32_t bh_idx = cluster_begin_batch_head;
+       bh_idx < cluster_end_batch_head; bh_idx++) {
+    int32_t b = bh_idx / num_heads;
+    int32_t head_idx = bh_idx % num_heads;
+    bool w_contain_inf = false;
+    bool value_contain_infnan = true;
+
+    size_t output_base_offset =
+        (size_t)b * output_stride_3 + head_idx * channels;
+    int32_t attn_weight_base_offset =
+        b * input_stride_4 + head_idx * input_stride_2;
+
+    if (sram_stay && coreId == MEMCORE_FLAG) {
+      loadDataValueGdram2Sram(value_sram, (T*)data_value_gdram, b, head_idx,
+                              num_keys, num_heads, channels);
+    }
+    __sync_cluster();
+
+    if (coreId != MEMCORE_FLAG) {
+      if (sram_stay) {
+        int32_t buf_size =
+            (int)((char*)buf_nram_end - (char*)value_output_nram);
+        isValueContainInfNan(value_sram, value_sram + num_keys * channels,
+                             value_output_nram, value_contain_infnan, buf_size,
+                             num_keys * channels);
+      }
+      // compute weight, offset and condition
+      int32_t attn_weight_offset =
+          attn_weight_base_offset + core_begin_query * input_stride_3;
+      int32_t loc_offset = attn_weight_offset * 2;
+      if (first_deal_query > 0) {
+        __memcpy(loc_nram, (T*)data_sampling_loc_gdram + loc_offset,
+                 input_stride_2 * 2 * sizeof(T), GDRAM2NRAM,
+                 input_stride_2 * 2 * sizeof(T), input_stride_3 * 2 * sizeof(T),
+                 first_deal_query - 1);
+        __memcpy(
+            weight_attn_nram, (T*)data_attn_weight_gdram + attn_weight_offset,
+            input_stride_2 * sizeof(T), GDRAM2NRAM, input_stride_2 * sizeof(T),
+            input_stride_3 * sizeof(T), first_deal_query - 1);
+        getConditionCoordWeight<T, sram_stay>(
+            data_offset_nram, weight_polation_nram, cond_point_polation_nram,
+            cond_point_valid_nram, loc_nram, weight_attn_nram, mask_x_nram,
+            mask_y_nram, spatial_offset_bd_nram, spatial_w_bd_nram,
+            spatial_h_bd_nram, buf_nram, w_contain_inf, value_contain_infnan,
+            first_deal_query, num_levels, num_points, num_heads, channels);
+      }
+    }
+
+    for (int32_t i = 0; coreId != MEMCORE_FLAG && i < core_loop_num; i++) {
+      int32_t deal_n =
+          i < core_loop_num - 1 ? core_step_query : core_remain_query;
+      int32_t load_n =
+          i < core_loop_num - 2 ? core_step_query : core_remain_query;
+      // load value and polation
+      loadNeighborPolationAttn<T, sram_stay>(
+          value_output_nram, value_sram,
+          (T*)data_value_gdram + b * data_value_stride_3 + head_idx * channels,
+          data_offset_nram, weight_polation_nram, cond_point_polation_nram,
+          cond_point_valid_nram, weight_attn_nram, buf_nram, buf_compute_nram,
+          ones_nram, deal_n, num_levels, num_points, num_keys, channels,
+          w_contain_inf, value_contain_infnan);
+      __sync_io_move_compute();
+      // load next weight and loc
+      if (i < core_loop_num - 1) {
+        int32_t core_query_offset = (i + 1) * core_step_query;
+        int32_t attn_weight_offset =
+            attn_weight_base_offset +
+            (core_begin_query + core_query_offset) * input_stride_3;
+        int32_t loc_offset = attn_weight_offset * 2;
+        __memcpy_async(loc_nram, (T*)data_sampling_loc_gdram + loc_offset,
+                       input_stride_2 * 2 * sizeof(T), GDRAM2NRAM,
+                       input_stride_2 * 2 * sizeof(T),
+                       input_stride_3 * 2 * sizeof(T), load_n - 1);
+        __memcpy_async(
+            weight_attn_nram, (T*)data_attn_weight_gdram + attn_weight_offset,
+            input_stride_2 * sizeof(T), GDRAM2NRAM, input_stride_2 * sizeof(T),
+            input_stride_3 * sizeof(T), load_n - 1);
+        __sync_io_move_compute();
+      }
+      // store result
+      size_t output_offset =
+          ((size_t)core_begin_query + i * core_step_query) * output_stride_2;
+      __memcpy_async((T*)data_col_gdram + output_base_offset + output_offset,
+                     value_output_nram, channels * sizeof(T), NRAM2GDRAM,
+                     output_stride_2 * sizeof(T), channels * sizeof(T),
+                     deal_n - 1);
+
+      // compute cond/weight/offset
+      if (i < core_loop_num - 1) {
+        getConditionCoordWeight<T, sram_stay>(
+            data_offset_nram, weight_polation_nram, cond_point_polation_nram,
+            cond_point_valid_nram, loc_nram, weight_attn_nram, mask_x_nram,
+            mask_y_nram, spatial_offset_bd_nram, spatial_w_bd_nram,
+            spatial_h_bd_nram, buf_nram, w_contain_inf, value_contain_infnan,
+            load_n, num_levels, num_points, num_heads, channels);
+      }
+      __sync_io_move_compute();
+    }
+    __sync_cluster();
+  }
+}
+
+#endif
+
+template <typename T>
+__mlu_global__ void MLUKernelMsDeformAttnForwardFast(
+    const char* data_value_gdram, const char* data_spatial_shapes_gdram,
+    const char* data_level_start_index_gdram,
+    const char* data_sampling_loc_gdram, const char* data_attn_weight_gdram,
+    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
+    const int32_t num_points, char* data_col_gdram) {
+#if (__BANG_ARCH__ >= 370)
+  size_t single_value_size = num_keys * channels * sizeof(T);
+  if (single_value_size <= SRAM_FOR_VALUE_SIZE) {
+    MLUKernelMsDeformAttnForwardFastImpl<float, 0>(
+        data_value_gdram, data_spatial_shapes_gdram,
+        data_level_start_index_gdram, data_sampling_loc_gdram,
+        data_attn_weight_gdram, batch_size, num_keys, num_heads, channels,
+        num_levels, num_queries, num_points, data_col_gdram);
+  } else {
+    MLUKernelMsDeformAttnForwardFastImpl<float, 1>(
+        data_value_gdram, data_spatial_shapes_gdram,
+        data_level_start_index_gdram, data_sampling_loc_gdram,
+        data_attn_weight_gdram, batch_size, num_keys, num_heads, channels,
+        num_levels, num_queries, num_points, data_col_gdram);
+  }
+#endif
+}
+
+template __mlu_global__ void MLUKernelMsDeformAttnForwardFast<float>(
+    const char* data_value_gdram, const char* data_spatial_shapes_gdram,
+    const char* data_level_start_index_gdram,
+    const char* data_sampling_loc_gdram, const char* data_attn_weight_gdram,
+    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
+    const int32_t num_points, char* data_col_gdram);
+
+void KernelMsDeformAttnForwardFast(
+    cnrtDim3_t k_dim, cnrtFunctionType_t k_type, cnrtQueue_t queue,
+    const cnrtDataType_t d_type, const char* data_value_gdram,
+    const char* data_spatial_shapes_gdram,
+    const char* data_level_start_index_gdram,
+    const char* data_sampling_loc_gdram, const char* data_attn_weight_gdram,
+    const int32_t batch_size, const int32_t num_keys, const int32_t num_heads,
+    const int32_t channels, const int32_t num_levels, const int32_t num_queries,
+    const int32_t num_points, char* data_col_gdram) {
+  MLUKernelMsDeformAttnForwardFast<float><<<k_dim, k_type, queue>>>(
+      data_value_gdram, data_spatial_shapes_gdram, data_level_start_index_gdram,
+      data_sampling_loc_gdram, data_attn_weight_gdram, batch_size, num_keys,
+      num_heads, channels, num_levels, num_queries, num_points, data_col_gdram);
+}

--- a/mmcv/ops/csrc/common/mlu/ms_deform_attn_mlu_kernel_fast.mlu
+++ b/mmcv/ops/csrc/common/mlu/ms_deform_attn_mlu_kernel_fast.mlu
@@ -407,8 +407,8 @@ __mlu_func__ void reduceLevelByConv(
       __bang_cycle_mul(input_pooled, input_pooled, weight_attn_nram,
                        channels * valid_num, valid_num);
       __bang_transpose(input_trans, input_pooled, channels, valid_num);
-      __bang_sumpool(output_nram, input_trans, channels, valid_num, 1, valid_num,
-                     1, 1, 1);
+      __bang_sumpool(output_nram, input_trans, channels, valid_num, 1,
+                     valid_num, 1, 1, 1);
     } else {
       tileWeight2WramSync(input_wram, input_trans, co, ci, pad_co, pad_ci);
       __bang_conv(output_nram, weight_compute, input_wram, ci, 1, 1, 1, 1, 1, 1,

--- a/mmcv/ops/csrc/pytorch/mlu/ms_deform_attn_mlu.cpp
+++ b/mmcv/ops/csrc/pytorch/mlu/ms_deform_attn_mlu.cpp
@@ -9,9 +9,9 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *************************************************************************/
+#include "mlu_common_helper.h"
 #include "pytorch_device_registry.hpp"
 #include "pytorch_mlu_helper.hpp"
-#include "mlu_common_helper.h"
 
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The motivation of the PR is to improve the performance of ms_deform_attn on Cambricon MLU backend, especially for small channel cases.

## Modification

MLU src code
Modify MLU src code of ms_deform_attn_mlu_kernel in directory mmcv/ops/csrc/common/mlu/ms_deform_attn_mlu_kernel.mlu.
mmcv/ops/csrc/common/mlu/ms_deform_attn_mlu_kernel_fast.mlu
PyTorch adaptation
Modify ms_deform_attn for PyTorch in mmcv/ops/csrc/pytorch/mlu/ms_deform_attn_mlu.cpp.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
