### PR TITLE
[Fix] Scatter.forward raises unexpected exception

### DIFF
--- a/mmcv/parallel/_functions.py
+++ b/mmcv/parallel/_functions.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Union
 
 import torch
 from torch import Tensor
+from torch._utils import _get_device_index
 from torch.nn.parallel._functions import _get_stream
 
 
@@ -67,7 +68,10 @@ def get_input_device(input: Union[List, Tensor]) -> int:
 class Scatter:
 
     @staticmethod
-    def forward(target_gpus: List[int], input: Union[List, Tensor]) -> tuple:
+    def forward(target_gpus, input: Union[List, Tensor]) -> tuple:
+        # target_gpus may be a list of int, str or torch.device,
+        # normalize them to List[int]
+        target_gpus = [_get_device_index(x, True) for x in target_gpus]
         input_device = get_input_device(input)
         streams = None
         if input_device == -1 and target_gpus != [-1]:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In some downstream repos, users may use `mmcv.parallel.scatter` directly with a valid device list of arbitrary types (usually the `torch.device`). See [mmdet](https://github.com/open-mmlab/mmdetection/blob/e9cae2d0787cd5c2fc6165a6061f92fa09e48fb1/mmdet/apis/inference.py#L148) and [mmedit](https://github.com/open-mmlab/mmediting/blob/31421842b4ffbab76067740505693355a042cfa6/mmedit/apis/generation_inference.py#L34)

However, `scatter` only accepts list of int, because it doesn't normalize device type as [pytorch does](https://github.com/pytorch/pytorch/blob/1b59c3feb55b28744bfe9f7d9c59d34b3b92d232/torch/nn/parallel/_functions.py#L89).

## Modification

Remove the `List[int]` type hint and normalize input device list to a list of integers.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
