### PR TITLE
[Fix] Skip fused_lrelu op when gcc is less than 6.0 or cuda is less than 10.2

### DIFF
--- a/mmcv/ops/csrc/pytorch/cuda/cudabind.cpp
+++ b/mmcv/ops/csrc/pytorch/cuda/cudabind.cpp
@@ -538,20 +538,6 @@ torch::Tensor bias_act_op(const torch::Tensor &input, const torch::Tensor &bias,
 
 REGISTER_DEVICE_IMPL(bias_act_op_impl, CUDA, bias_act_op);
 
-std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op_impl(
-    torch::Tensor x, torch::Tensor fu, torch::Tensor fd, torch::Tensor b,
-    torch::Tensor si, int up, int down, int px0, int px1, int py0, int py1,
-    int sx, int sy, float gain, float slope, float clamp, bool flip_filters,
-    bool writeSigns);
-
-std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
-    torch::Tensor x, torch::Tensor fu, torch::Tensor fd, torch::Tensor b,
-    torch::Tensor si, int up, int down, int px0, int px1, int py0, int py1,
-    int sx, int sy, float gain, float slope, float clamp, bool flip_filters,
-    bool writeSigns);
-
-REGISTER_DEVICE_IMPL(filtered_lrelu_op_impl, CUDA, filtered_lrelu_op);
-
 torch::Tensor filtered_lrelu_act_op_impl(torch::Tensor x, torch::Tensor si,
                                          int sx, int sy, float gain,
                                          float slope, float clamp,

--- a/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
@@ -18,98 +18,98 @@
 
 struct filtered_lrelu_kernel_params {
   // These parameters decide which kernel to use.
-  int up;        // upsampling ratio (1, 2, 4)
-  int down;      // downsampling ratio (1, 2, 4)
-  int2 fuShape;  // [size, 1] | [size, size]
-  int2 fdShape;  // [size, 1] | [size, size]
+  int up;       // upsampling ratio (1, 2, 4)
+  int down;     // downsampling ratio (1, 2, 4)
+  int2 fuShape; // [size, 1] | [size, size]
+  int2 fdShape; // [size, 1] | [size, size]
 
-  int _dummy;  // Alignment.
+  int _dummy; // Alignment.
 
   // Rest of the parameters.
-  const void* x;     // Input tensor.
-  void* y;           // Output tensor.
-  const void* b;     // Bias tensor.
-  unsigned char* s;  // Sign tensor in/out. NULL if unused.
-  const float* fu;   // Upsampling filter.
-  const float* fd;   // Downsampling filter.
+  const void *x;    // Input tensor.
+  void *y;          // Output tensor.
+  const void *b;    // Bias tensor.
+  unsigned char *s; // Sign tensor in/out. NULL if unused.
+  const float *fu;  // Upsampling filter.
+  const float *fd;  // Downsampling filter.
 
-  int2 pad0;    // Left/top padding.
-  float gain;   // Additional gain factor.
-  float slope;  // Leaky ReLU slope on negative side.
-  float clamp;  // Clamp after nonlinearity.
-  int flip;     // Filter kernel flip for gradient computation.
+  int2 pad0;   // Left/top padding.
+  float gain;  // Additional gain factor.
+  float slope; // Leaky ReLU slope on negative side.
+  float clamp; // Clamp after nonlinearity.
+  int flip;    // Filter kernel flip for gradient computation.
 
-  int tilesXdim;  // Original number of horizontal output tiles.
-  int tilesXrep;  // Number of horizontal tiles per CTA.
-  int blockZofs;  // Block z offset to support large minibatch, channel
-                  // dimensions.
+  int tilesXdim; // Original number of horizontal output tiles.
+  int tilesXrep; // Number of horizontal tiles per CTA.
+  int blockZofs; // Block z offset to support large minibatch, channel
+                 // dimensions.
 
-  int4 xShape;  // [width, height, channel, batch]
-  int4 yShape;  // [width, height, channel, batch]
-  int2 sShape;  // [width, height] - width is in bytes. Contiguous. Zeros if
-                // unused.
-  int2 sOfs;  // [ofs_x, ofs_y] - offset between upsampled data and sign tensor.
-  int swLimit;  // Active width of sign tensor in bytes.
+  int4 xShape; // [width, height, channel, batch]
+  int4 yShape; // [width, height, channel, batch]
+  int2 sShape; // [width, height] - width is in bytes. Contiguous. Zeros if
+               // unused.
+  int2 sOfs; // [ofs_x, ofs_y] - offset between upsampled data and sign tensor.
+  int swLimit; // Active width of sign tensor in bytes.
 
-  longlong4 xStride;   // Strides of all tensors except signs, same component
-                       // order as shapes.
-  longlong4 yStride;   //
-  int64_t bStride;     //
-  longlong3 fuStride;  //
-  longlong3 fdStride;  //
+  longlong4 xStride;  // Strides of all tensors except signs, same component
+                      // order as shapes.
+  longlong4 yStride;  //
+  int64_t bStride;    //
+  longlong3 fuStride; //
+  longlong3 fdStride; //
 };
 
 struct filtered_lrelu_act_kernel_params {
-  void* x;           // Input/output, modified in-place.
-  unsigned char* s;  // Sign tensor in/out. NULL if unused.
+  void *x;          // Input/output, modified in-place.
+  unsigned char *s; // Sign tensor in/out. NULL if unused.
 
-  float gain;   // Additional gain factor.
-  float slope;  // Leaky ReLU slope on negative side.
-  float clamp;  // Clamp after nonlinearity.
+  float gain;  // Additional gain factor.
+  float slope; // Leaky ReLU slope on negative side.
+  float clamp; // Clamp after nonlinearity.
 
-  int4 xShape;        // [width, height, channel, batch]
-  longlong4 xStride;  // Input/output tensor strides, same order as in shape.
-  int2 sShape;  // [width, height] - width is in elements. Contiguous. Zeros if
-                // unused.
-  int2 sOfs;  // [ofs_x, ofs_y] - offset between upsampled data and sign tensor.
+  int4 xShape;       // [width, height, channel, batch]
+  longlong4 xStride; // Input/output tensor strides, same order as in shape.
+  int2 sShape; // [width, height] - width is in elements. Contiguous. Zeros if
+               // unused.
+  int2 sOfs; // [ofs_x, ofs_y] - offset between upsampled data and sign tensor.
 };
 
 //------------------------------------------------------------------------
 // CUDA kernel specialization.
 
 struct filtered_lrelu_kernel_spec {
-  void* setup;   // Function for filter kernel setup.
-  void* exec;    // Function for main operation.
-  int2 tileOut;  // Width/height of launch tile.
-  int numWarps;  // Number of warps per thread block, determines launch block
-                 // size.
-  int xrep;      // For processing multiple horizontal tiles per thread block.
-  int dynamicSharedKB;  // How much dynamic shared memory the exec kernel wants.
+  void *setup;  // Function for filter kernel setup.
+  void *exec;   // Function for main operation.
+  int2 tileOut; // Width/height of launch tile.
+  int numWarps; // Number of warps per thread block, determines launch block
+                // size.
+  int xrep;     // For processing multiple horizontal tiles per thread block.
+  int dynamicSharedKB; // How much dynamic shared memory the exec kernel wants.
 };
 
 //------------------------------------------------------------------------
 // CUDA kernel selection.
 
 template <class T, class index_t, bool signWrite, bool signRead>
-filtered_lrelu_kernel_spec choose_filtered_lrelu_kernel(
-    const filtered_lrelu_kernel_params& p, int sharedKB);
+filtered_lrelu_kernel_spec
+choose_filtered_lrelu_kernel(const filtered_lrelu_kernel_params &p,
+                             int sharedKB);
 template <class T, bool signWrite, bool signRead>
-void* choose_filtered_lrelu_act_kernel(void);
+void *choose_filtered_lrelu_act_kernel(void);
 
 //------------------------------------------------------------------------
 // Helpers.
 
-enum              // Filter modes.
-{ MODE_SUSD = 0,  // Separable upsampling, separable downsampling.
-  MODE_FUSD = 1,  // Full upsampling, separable downsampling.
-  MODE_SUFD = 2,  // Separable upsampling, full downsampling.
-  MODE_FUFD = 3,  // Full upsampling, full downsampling.
+enum // Filter modes.
+{
+  MODE_SUSD = 0, // Separable upsampling, separable downsampling.
+  MODE_FUSD = 1, // Full upsampling, separable downsampling.
+  MODE_SUFD = 2, // Separable upsampling, full downsampling.
+  MODE_FUFD = 3, // Full upsampling, full downsampling.
 };
 
-template <class T>
-struct InternalType;
-template <>
-struct InternalType<double> {
+template <class T> struct InternalType;
+template <> struct InternalType<double> {
   typedef double scalar_t;
   typedef double2 vec2_t;
   typedef double4 vec4_t;
@@ -123,8 +123,7 @@ struct InternalType<double> {
     return fmin(fmax(x, -c), c);
   }
 };
-template <>
-struct InternalType<float> {
+template <> struct InternalType<float> {
   typedef float scalar_t;
   typedef float2 vec2_t;
   typedef float4 vec4_t;
@@ -138,8 +137,7 @@ struct InternalType<float> {
     return fminf(fmaxf(x, -c), c);
   }
 };
-template <>
-struct InternalType<c10::Half> {
+template <> struct InternalType<c10::Half> {
   typedef float scalar_t;
   typedef float2 vec2_t;
   typedef float4 vec4_t;
@@ -156,19 +154,18 @@ struct InternalType<c10::Half> {
 
 #define MIN(A, B) ((A) < (B) ? (A) : (B))
 #define MAX(A, B) ((A) > (B) ? (A) : (B))
-#define CEIL_DIV(A, B)                                   \
-  (((B) == 1)                                            \
-       ? (A)                                             \
-       : ((B) == 2) ? ((int)((A) + 1) >> 1)              \
-                    : ((B) == 4) ? ((int)((A) + 3) >> 2) \
-                                 : (((A) + ((A) > 0 ? (B)-1 : 0)) / (B)))
+#define CEIL_DIV(A, B)                                                         \
+  (((B) == 1)   ? (A)                                                          \
+   : ((B) == 2) ? ((int)((A) + 1) >> 1)                                        \
+   : ((B) == 4) ? ((int)((A) + 3) >> 2)                                        \
+                : (((A) + ((A) > 0 ? (B)-1 : 0)) / (B)))
 
 // This works only up to blocks of size 256 x 256 and for all N that are powers
 // of two.
 template <int N>
-__device__ __forceinline__ void fast_div_mod(int& x, int& y, unsigned int i) {
+__device__ __forceinline__ void fast_div_mod(int &x, int &y, unsigned int i) {
   if ((N & (N - 1)) && N <= 256)
-    y = (i * ((1 << 24) / N + 1)) >> 24;  // Assumes N <= 256, i < N*256.
+    y = (i * ((1 << 24) / N + 1)) >> 24; // Assumes N <= 256, i < N*256.
   else
     y = i / N;
 
@@ -176,9 +173,8 @@ __device__ __forceinline__ void fast_div_mod(int& x, int& y, unsigned int i) {
 }
 
 // Type cast stride before reading it.
-template <class T>
-__device__ __forceinline__ T get_stride(const int64_t& x) {
-  return *reinterpret_cast<const T*>(&x);
+template <class T> __device__ __forceinline__ T get_stride(const int64_t &x) {
+  return *reinterpret_cast<const T *>(&x);
 }
 
 //------------------------------------------------------------------------
@@ -188,12 +184,12 @@ __device__ __forceinline__ T get_stride(const int64_t& x) {
 
 // Combined up/down filter buffers so that transfer can be done with one copy.
 __device__ float
-    g_fbuf[2 * MAX_FILTER_SIZE * MAX_FILTER_SIZE];  // Filters in global memory,
-                                                    // written by setup kernel.
+    g_fbuf[2 * MAX_FILTER_SIZE * MAX_FILTER_SIZE]; // Filters in global memory,
+                                                   // written by setup kernel.
 __device__ __constant__ float
     c_fbuf[2 * MAX_FILTER_SIZE *
-           MAX_FILTER_SIZE];  // Filters in constant memory, read by main
-                              // kernel.
+           MAX_FILTER_SIZE]; // Filters in constant memory, read by main
+                             // kernel.
 
 // Accessors to combined buffers to index up/down filters individually.
 #define c_fu (c_fbuf)
@@ -233,9 +229,10 @@ static __global__ void setup_filters_kernel(filtered_lrelu_kernel_params p) {
 // Host function to copy filters written by setup kernel into constant buffer
 // for main kernel.
 static cudaError_t copy_filters(cudaStream_t stream) {
-  void* src = 0;
+  void *src = 0;
   cudaError_t err = cudaGetSymbolAddress(&src, g_fbuf);
-  if (err) return err;
+  if (err)
+    return err;
   return cudaMemcpyToSymbolAsync(
       c_fbuf, src, 2 * MAX_FILTER_SIZE * MAX_FILTER_SIZE * sizeof(float), 0,
       cudaMemcpyDeviceToDevice, stream);
@@ -260,9 +257,9 @@ static cudaError_t copy_filters(cudaStream_t stream) {
 // - outY = tileOutY + relOutY
 
 extern __shared__ char
-    s_buf_raw[];  // When sharedKB <= 48, allocate shared memory statically
-                  // inside the kernel, otherwise use the externally allocated
-                  // shared memory buffer.
+    s_buf_raw[]; // When sharedKB <= 48, allocate shared memory statically
+                 // inside the kernel, otherwise use the externally allocated
+                 // shared memory buffer.
 
 template <class T, class index_t, int sharedKB, bool signWrite, bool signRead,
           int filterMode, int up, int fuSize, int down, int fdSize,
@@ -305,20 +302,19 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
   typedef typename InternalType<T>::vec2_t vec2_t;
   typedef typename InternalType<T>::vec4_t vec4_t;
   const int tileUpW = (tileOutW * down + (fdSize - 1) - (down - 1) + 3) &
-                      ~3;  // Upsampled tile width, rounded up to multiple of 4.
+                      ~3; // Upsampled tile width, rounded up to multiple of 4.
   const int tileUpH =
-      tileOutH * down + (fdSize - 1) - (down - 1);  // Upsampled tile height.
-  const int tileInW =
-      CEIL_DIV(tileUpW + (fuSize - 1), up);  // Input tile width.
+      tileOutH * down + (fdSize - 1) - (down - 1); // Upsampled tile height.
+  const int tileInW = CEIL_DIV(tileUpW + (fuSize - 1), up); // Input tile width.
   const int tileInH =
-      CEIL_DIV(tileUpH + (fuSize - 1), up);  // Input tile height.
+      CEIL_DIV(tileUpH + (fuSize - 1), up); // Input tile height.
   const int tileUpH_up =
       CEIL_DIV(tileUpH, up) *
-      up;  // Upsampled tile height rounded up to a multiple of up.
+      up; // Upsampled tile height rounded up to a multiple of up.
   const int tileInH_up =
       CEIL_DIV(tileUpH_up + (fuSize - 1),
-               up);  // For allocations only, to avoid shared memory read
-                     // overruns with up=2 and up=4.
+               up); // For allocations only, to avoid shared memory read
+                    // overruns with up=2 and up=4.
 
   // Merge 1x1 downsampling into last upsampling step for upf1 and ups2.
   const bool downInline =
@@ -332,60 +328,54 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
   const int szDownX = tileUpH * tileOutW;
 
   // Sizes for shared memory arrays.
-  const int s_buf0_size_base =
-      (filterMode == MODE_SUSD)
-          ? MAX(szIn, szUpXY)
-          : (filterMode == MODE_FUSD)
-                ? MAX(szIn, szDownX)
-                : (filterMode == MODE_SUFD)
-                      ? MAX(szIn, szUpXY)
-                      : (filterMode == MODE_FUFD) ? szIn : -1;
-  const int s_buf1_size_base =
-      (filterMode == MODE_SUSD)
-          ? MAX(szUpX, szDownX)
-          : (filterMode == MODE_FUSD)
-                ? szUpXY
-                : (filterMode == MODE_SUFD)
-                      ? szUpX
-                      : (filterMode == MODE_FUFD) ? szUpXY : -1;
+  const int s_buf0_size_base = (filterMode == MODE_SUSD)   ? MAX(szIn, szUpXY)
+                               : (filterMode == MODE_FUSD) ? MAX(szIn, szDownX)
+                               : (filterMode == MODE_SUFD) ? MAX(szIn, szUpXY)
+                               : (filterMode == MODE_FUFD) ? szIn
+                                                           : -1;
+  const int s_buf1_size_base = (filterMode == MODE_SUSD)   ? MAX(szUpX, szDownX)
+                               : (filterMode == MODE_FUSD) ? szUpXY
+                               : (filterMode == MODE_SUFD) ? szUpX
+                               : (filterMode == MODE_FUFD) ? szUpXY
+                                                           : -1;
 
   // Ensure U128 alignment.
   const int s_buf0_size = (s_buf0_size_base + 3) & ~3;
   const int s_buf1_size = (s_buf1_size_base + 3) & ~3;
 
   // Check at compile time that we don't use too much shared memory.
-  static_assert(
-      (s_buf0_size + s_buf1_size) * sizeof(scalar_t) <= (sharedKB << 10),
-      "shared memory overflow");
+  static_assert((s_buf0_size + s_buf1_size) * sizeof(scalar_t) <=
+                    (sharedKB << 10),
+                "shared memory overflow");
 
   // Declare shared memory arrays.
-  scalar_t* s_buf0;
-  scalar_t* s_buf1;
+  scalar_t *s_buf0;
+  scalar_t *s_buf1;
   if (sharedKB <= 48) {
     // Allocate shared memory arrays here.
     __shared__ scalar_t
         s_buf0_st[(sharedKB > 48)
                       ? (1 << 24)
                       : (s_buf0_size +
-                         s_buf1_size)];  // Prevent launching if this isn't
-                                         // optimized away when unused.
+                         s_buf1_size)]; // Prevent launching if this isn't
+                                        // optimized away when unused.
     s_buf0 = s_buf0_st;
     s_buf1 = s_buf0 + s_buf0_size;
   } else {
     // Use the dynamically allocated shared memory array.
-    s_buf0 = (scalar_t*)s_buf_raw;
+    s_buf0 = (scalar_t *)s_buf_raw;
     s_buf1 = s_buf0 + s_buf0_size;
   }
 
   // Pointers to the buffers.
-  scalar_t*
-      s_tileIn;  // Input tile:                      [relInX * tileInH + relInY]
-  scalar_t* s_tileUpX;   // After horizontal upsampling:     [relInY * tileUpW +
+  scalar_t
+      *s_tileIn; // Input tile:                      [relInX * tileInH + relInY]
+  scalar_t *s_tileUpX;   // After horizontal upsampling:     [relInY * tileUpW +
                          // relUpX]
-  scalar_t* s_tileUpXY;  // After upsampling:                [relUpY * tileUpW +
+  scalar_t *s_tileUpXY;  // After upsampling:                [relUpY * tileUpW +
                          // relUpX]
-  scalar_t* s_tileDownX;  // After horizontal downsampling:   [relUpY * tileOutW
-                          // + relOutX]
+  scalar_t *s_tileDownX; // After horizontal downsampling:   [relUpY * tileOutW
+                         // + relOutX]
   if (filterMode == MODE_SUSD) {
     s_tileIn = s_buf0;
     s_tileUpX = s_buf1;
@@ -444,8 +434,8 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
 
     // Load input tile & apply bias. Unrolled.
     scalar_t b =
-        (scalar_t) * (const T*)((const char*)p.b +
-                                (channelIdx * get_stride<index_t>(p.bStride)));
+        (scalar_t) * (const T *)((const char *)p.b +
+                                 (channelIdx * get_stride<index_t>(p.bStride)));
     index_t mapOfsIn = channelIdx * get_stride<index_t>(p.xStride.z) +
                        batchIdx * get_stride<index_t>(p.xStride.w);
     int idx = threadIdx.x;
@@ -459,20 +449,21 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
       scalar_t v = 0;
 
       if ((uint32_t)inX < p.xShape.x && (uint32_t)inY < p.xShape.y)
-        v = (scalar_t) * ((const T*)((const char*)p.x +
-                                     (inX * get_stride<index_t>(p.xStride.x) +
-                                      inY * get_stride<index_t>(p.xStride.y) +
-                                      mapOfsIn))) +
+        v = (scalar_t) * ((const T *)((const char *)p.x +
+                                      (inX * get_stride<index_t>(p.xStride.x) +
+                                       inY * get_stride<index_t>(p.xStride.y) +
+                                       mapOfsIn))) +
             b;
 
       bool skip = (loop == loopCountIN - 1) && (idx >= tileInW * tileInH);
-      if (!skip) s_tileIn[idx] = v;
+      if (!skip)
+        s_tileIn[idx] = v;
 
       idx += threadsPerBlock;
     }
 
     if (filterMode == MODE_SUSD ||
-        filterMode == MODE_SUFD)  // Separable upsampling filter.
+        filterMode == MODE_SUFD) // Separable upsampling filter.
     {
       // Horizontal upsampling.
       __syncthreads();
@@ -513,7 +504,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               a = s_tileIn[src0 + step + 1];
               v.w += a * (scalar_t)c_fu[step * up + 3];
             }
-          } else  // (phaseInX == 3)
+          } else // (phaseInX == 3)
           {
 #pragma unroll
             for (int step = 0; step < fuSize / up; step++) {
@@ -540,7 +531,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
           int dst = relInY * tileUpW + relUpX0;
           vec2_t v = InternalType<T>::zero_vec2();
           scalar_t a = s_tileIn[src0];
-          if (p0)  // (phaseInX == 0)
+          if (p0) // (phaseInX == 0)
           {
 #pragma unroll
             for (int step = 0; step < fuSize / up; step++) {
@@ -548,7 +539,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               a = s_tileIn[src0 + step + 1];
               v.y += a * (scalar_t)c_fu[step * up + 1];
             }
-          } else  // (phaseInX == 1)
+          } else // (phaseInX == 1)
           {
 #pragma unroll
             for (int step = 0; step < fuSize / up; step++) {
@@ -567,12 +558,12 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
       __syncthreads();
       int groupMask = 15 << ((threadIdx.x & 31) & ~3);
       int minY = tileOutY ? (tileOutY - tileOutH) * down + tileUpH
-                          : 0;  // Skip already written signs.
+                          : 0; // Skip already written signs.
       int sShapeMaxY =
           MIN(p.sShape.y,
-              tileOutY * down + tileUpH);  // Avoid out-of-tile sign writes.
+              tileOutY * down + tileUpH); // Avoid out-of-tile sign writes.
       if (up == 4) {
-        minY -= 3;  // Adjust according to block height.
+        minY -= 3; // Adjust according to block height.
         for (int idx = threadIdx.x; idx < tileUpW * tileUpH_up / up;
              idx += blockDim.x) {
           int relUpX, relInY0;
@@ -610,7 +601,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               a = s_tileUpX[src0 + (step + 1) * tileUpW];
               v.w += a * (scalar_t)c_fu[step * up + 3];
             }
-          } else  // (phaseInY == 3)
+          } else // (phaseInY == 3)
           {
 #pragma unroll
             for (int step = 0; step < fuSize / up; step++) {
@@ -646,10 +637,14 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               int sy = __float_as_uint(v.y) >> 31 << 8;
               int sz = __float_as_uint(v.z) >> 31 << 16;
               int sw = __float_as_uint(v.w) >> 31 << 24;
-              if (sx) v.x *= p.slope;
-              if (sy) v.y *= p.slope;
-              if (sz) v.z *= p.slope;
-              if (sw) v.w *= p.slope;
+              if (sx)
+                v.x *= p.slope;
+              if (sy)
+                v.y *= p.slope;
+              if (sz)
+                v.z *= p.slope;
+              if (sw)
+                v.w *= p.slope;
               if (fabsf(v.x) > p.clamp) {
                 sx = 2 << 0;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
@@ -695,10 +690,14 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 int sy = __float_as_uint(v.y) >> 31 << 8;
                 int sz = __float_as_uint(v.z) >> 31 << 16;
                 int sw = __float_as_uint(v.w) >> 31 << 24;
-                if (sx) v.x *= p.slope;
-                if (sy) v.y *= p.slope;
-                if (sz) v.z *= p.slope;
-                if (sw) v.w *= p.slope;
+                if (sx)
+                  v.x *= p.slope;
+                if (sy)
+                  v.y *= p.slope;
+                if (sz)
+                  v.z *= p.slope;
+                if (sw)
+                  v.w *= p.slope;
                 if (fabsf(v.x) > p.clamp) {
                   sx = 2 << 0;
                   v.x = InternalType<T>::clamp(v.x, p.clamp);
@@ -737,60 +736,79 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 }
               } else {
                 // Just compute the values.
-                if (v.x < 0.f) v.x *= p.slope;
+                if (v.x < 0.f)
+                  v.x *= p.slope;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
-                if (v.y < 0.f) v.y *= p.slope;
+                if (v.y < 0.f)
+                  v.y *= p.slope;
                 v.y = InternalType<T>::clamp(v.y, p.clamp);
-                if (v.z < 0.f) v.z *= p.slope;
+                if (v.z < 0.f)
+                  v.z *= p.slope;
                 v.z = InternalType<T>::clamp(v.z, p.clamp);
-                if (v.w < 0.f) v.w *= p.slope;
+                if (v.w < 0.f)
+                  v.w *= p.slope;
                 v.w = InternalType<T>::clamp(v.w, p.clamp);
               }
             }
-          } else if (signRead)  // Read signs and apply.
+          } else if (signRead) // Read signs and apply.
           {
             if ((uint32_t)signXb < p.swLimit) {
               int ss = (signX & 3) << 1;
               if ((uint32_t)(signY + 0) < p.sShape.y) {
                 int s = p.s[si0] >> ss;
-                if (s & 1) v.x *= p.slope;
-                if (s & 2) v.x = 0.f;
+                if (s & 1)
+                  v.x *= p.slope;
+                if (s & 2)
+                  v.x = 0.f;
               }
               if ((uint32_t)(signY + 1) < p.sShape.y) {
                 int s = p.s[si1] >> ss;
-                if (s & 1) v.y *= p.slope;
-                if (s & 2) v.y = 0.f;
+                if (s & 1)
+                  v.y *= p.slope;
+                if (s & 2)
+                  v.y = 0.f;
               }
               if ((uint32_t)(signY + 2) < p.sShape.y) {
                 int s = p.s[si2] >> ss;
-                if (s & 1) v.z *= p.slope;
-                if (s & 2) v.z = 0.f;
+                if (s & 1)
+                  v.z *= p.slope;
+                if (s & 2)
+                  v.z = 0.f;
               }
               if ((uint32_t)(signY + 3) < p.sShape.y) {
                 int s = p.s[si3] >> ss;
-                if (s & 1) v.w *= p.slope;
-                if (s & 2) v.w = 0.f;
+                if (s & 1)
+                  v.w *= p.slope;
+                if (s & 2)
+                  v.w = 0.f;
               }
             }
-          } else  // Forward pass with no sign write.
+          } else // Forward pass with no sign write.
           {
-            if (v.x < 0.f) v.x *= p.slope;
+            if (v.x < 0.f)
+              v.x *= p.slope;
             v.x = InternalType<T>::clamp(v.x, p.clamp);
-            if (v.y < 0.f) v.y *= p.slope;
+            if (v.y < 0.f)
+              v.y *= p.slope;
             v.y = InternalType<T>::clamp(v.y, p.clamp);
-            if (v.z < 0.f) v.z *= p.slope;
+            if (v.z < 0.f)
+              v.z *= p.slope;
             v.z = InternalType<T>::clamp(v.z, p.clamp);
-            if (v.w < 0.f) v.w *= p.slope;
+            if (v.w < 0.f)
+              v.w *= p.slope;
             v.w = InternalType<T>::clamp(v.w, p.clamp);
           }
 
           s_tileUpXY[dst + 0 * tileUpW] = v.x;
-          if (relUpY0 + 1 < tileUpH) s_tileUpXY[dst + 1 * tileUpW] = v.y;
-          if (relUpY0 + 2 < tileUpH) s_tileUpXY[dst + 2 * tileUpW] = v.z;
-          if (relUpY0 + 3 < tileUpH) s_tileUpXY[dst + 3 * tileUpW] = v.w;
+          if (relUpY0 + 1 < tileUpH)
+            s_tileUpXY[dst + 1 * tileUpW] = v.y;
+          if (relUpY0 + 2 < tileUpH)
+            s_tileUpXY[dst + 2 * tileUpW] = v.z;
+          if (relUpY0 + 3 < tileUpH)
+            s_tileUpXY[dst + 3 * tileUpW] = v.w;
         }
       } else if (up == 2) {
-        minY -= 1;  // Adjust according to block height.
+        minY -= 1; // Adjust according to block height.
         for (int idx = threadIdx.x; idx < tileUpW * tileUpH_up / up;
              idx += blockDim.x) {
           int relUpX, relInY0;
@@ -808,7 +826,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               a = s_tileUpX[src0 + (step + 1) * tileUpW];
               v.y += a * (scalar_t)c_fu[step * up + 1];
             }
-          } else  // (phaseInY == 1)
+          } else // (phaseInY == 1)
           {
 #pragma unroll
             for (int step = 0; step < fuSize / up; step++) {
@@ -836,8 +854,10 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               // Determine and write signs.
               int sx = __float_as_uint(v.x) >> 31 << 0;
               int sy = __float_as_uint(v.y) >> 31 << 8;
-              if (sx) v.x *= p.slope;
-              if (sy) v.y *= p.slope;
+              if (sx)
+                v.x *= p.slope;
+              if (sy)
+                v.y *= p.slope;
               if (fabsf(v.x) > p.clamp) {
                 sx = 2 << 0;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
@@ -867,8 +887,10 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               if ((uint32_t)signXb < p.swLimit && signY >= minY) {
                 int sx = __float_as_uint(v.x) >> 31 << 0;
                 int sy = __float_as_uint(v.y) >> 31 << 8;
-                if (sx) v.x *= p.slope;
-                if (sy) v.y *= p.slope;
+                if (sx)
+                  v.x *= p.slope;
+                if (sy)
+                  v.y *= p.slope;
                 if (fabsf(v.x) > p.clamp) {
                   sx = 2 << 0;
                   v.x = InternalType<T>::clamp(v.x, p.clamp);
@@ -893,38 +915,47 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 }
               } else {
                 // Just compute the values.
-                if (v.x < 0.f) v.x *= p.slope;
+                if (v.x < 0.f)
+                  v.x *= p.slope;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
-                if (v.y < 0.f) v.y *= p.slope;
+                if (v.y < 0.f)
+                  v.y *= p.slope;
                 v.y = InternalType<T>::clamp(v.y, p.clamp);
               }
             }
-          } else if (signRead)  // Read signs and apply.
+          } else if (signRead) // Read signs and apply.
           {
             if ((uint32_t)signXb < p.swLimit) {
               if ((uint32_t)(signY + 0) < p.sShape.y) {
                 int s = p.s[si0] >> signXo;
-                if (s & 1) v.x *= p.slope;
-                if (s & 2) v.x = 0.f;
+                if (s & 1)
+                  v.x *= p.slope;
+                if (s & 2)
+                  v.x = 0.f;
               }
               if ((uint32_t)(signY + 1) < p.sShape.y) {
                 int s = p.s[si1] >> signXo;
-                if (s & 1) v.y *= p.slope;
-                if (s & 2) v.y = 0.f;
+                if (s & 1)
+                  v.y *= p.slope;
+                if (s & 2)
+                  v.y = 0.f;
               }
             }
-          } else  // Forward pass with no sign write.
+          } else // Forward pass with no sign write.
           {
-            if (v.x < 0.f) v.x *= p.slope;
+            if (v.x < 0.f)
+              v.x *= p.slope;
             v.x = InternalType<T>::clamp(v.x, p.clamp);
-            if (v.y < 0.f) v.y *= p.slope;
+            if (v.y < 0.f)
+              v.y *= p.slope;
             v.y = InternalType<T>::clamp(v.y, p.clamp);
           }
 
           if (!downInline) {
             // Write into temporary buffer.
             s_tileUpXY[dst] = v.x;
-            if (relUpY0 < tileUpH - 1) s_tileUpXY[dst + tileUpW] = v.y;
+            if (relUpY0 < tileUpH - 1)
+              s_tileUpXY[dst + tileUpW] = v.y;
           } else {
             // Write directly into output buffer.
             if ((uint32_t)x < p.yShape.x) {
@@ -932,9 +963,9 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               index_t ofs = x * get_stride<index_t>(p.yStride.x) +
                             y * get_stride<index_t>(p.yStride.y) + mapOfsOut;
               if ((uint32_t)y + 0 < p.yShape.y)
-                *((T*)((char*)p.y + ofs)) = (T)(v.x * (scalar_t)c_fd[0]);
+                *((T *)((char *)p.y + ofs)) = (T)(v.x * (scalar_t)c_fd[0]);
               if ((uint32_t)y + 1 < ymax)
-                *((T*)((char*)p.y + ofs + get_stride<index_t>(p.yStride.y))) =
+                *((T *)((char *)p.y + ofs + get_stride<index_t>(p.yStride.y))) =
                     (T)(v.y * (scalar_t)c_fd[0]);
             }
           }
@@ -947,7 +978,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
         // 2 x 2-wide.
         __syncthreads();
         int minY = tileOutY ? (tileOutY - tileOutH) * down + tileUpH + p.sOfs.y
-                            : 0;  // Skip already written signs.
+                            : 0; // Skip already written signs.
         for (int idx = threadIdx.x * 4; idx < tileUpW * tileUpH;
              idx += blockDim.x * 4) {
           int relUpX0, relUpY0;
@@ -957,24 +988,24 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
           int src0 = relInX0 + tileInW * relInY0;
           int tap0y = (relInY0 * up + phaseInY - relUpY0);
 
-#define X_LOOP(TAPY, PX)                                             \
-  for (int sx = 0; sx < fuSize / up; sx++) {                         \
-    v.x += a * (scalar_t)c_fu[(sx * up + (((PX)-0) & (up - 1))) +    \
-                              (sy * up + (TAPY)) * MAX_FILTER_SIZE]; \
-    v.z += b * (scalar_t)c_fu[(sx * up + (((PX)-0) & (up - 1))) +    \
-                              (sy * up + (TAPY)) * MAX_FILTER_SIZE]; \
-    if ((PX) == 0) {                                                 \
-      a = b;                                                         \
-      b = s_tileIn[src0 + 2 + sx + sy * tileInW];                    \
-    }                                                                \
-    v.y += a * (scalar_t)c_fu[(sx * up + (((PX)-1) & (up - 1))) +    \
-                              (sy * up + (TAPY)) * MAX_FILTER_SIZE]; \
-    v.w += b * (scalar_t)c_fu[(sx * up + (((PX)-1) & (up - 1))) +    \
-                              (sy * up + (TAPY)) * MAX_FILTER_SIZE]; \
-    if ((PX) == 1) {                                                 \
-      a = b;                                                         \
-      b = s_tileIn[src0 + 2 + sx + sy * tileInW];                    \
-    }                                                                \
+#define X_LOOP(TAPY, PX)                                                       \
+  for (int sx = 0; sx < fuSize / up; sx++) {                                   \
+    v.x += a * (scalar_t)c_fu[(sx * up + (((PX)-0) & (up - 1))) +              \
+                              (sy * up + (TAPY)) * MAX_FILTER_SIZE];           \
+    v.z += b * (scalar_t)c_fu[(sx * up + (((PX)-0) & (up - 1))) +              \
+                              (sy * up + (TAPY)) * MAX_FILTER_SIZE];           \
+    if ((PX) == 0) {                                                           \
+      a = b;                                                                   \
+      b = s_tileIn[src0 + 2 + sx + sy * tileInW];                              \
+    }                                                                          \
+    v.y += a * (scalar_t)c_fu[(sx * up + (((PX)-1) & (up - 1))) +              \
+                              (sy * up + (TAPY)) * MAX_FILTER_SIZE];           \
+    v.w += b * (scalar_t)c_fu[(sx * up + (((PX)-1) & (up - 1))) +              \
+                              (sy * up + (TAPY)) * MAX_FILTER_SIZE];           \
+    if ((PX) == 1) {                                                           \
+      a = b;                                                                   \
+      b = s_tileIn[src0 + 2 + sx + sy * tileInW];                              \
+    }                                                                          \
   }
 
           vec4_t v = InternalType<T>::zero_vec4();
@@ -1034,22 +1065,26 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               int sy = __float_as_uint(v.y) >> 31;
               int sz = __float_as_uint(v.z) >> 31;
               int sw = __float_as_uint(v.w) >> 31;
-              if (sx) v.x *= p.slope;
+              if (sx)
+                v.x *= p.slope;
               if (fabsf(v.x) > p.clamp) {
                 sx = 2;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
               }
-              if (sy) v.y *= p.slope;
+              if (sy)
+                v.y *= p.slope;
               if (fabsf(v.y) > p.clamp) {
                 sy = 2;
                 v.y = InternalType<T>::clamp(v.y, p.clamp);
               }
-              if (sz) v.z *= p.slope;
+              if (sz)
+                v.z *= p.slope;
               if (fabsf(v.z) > p.clamp) {
                 sz = 2;
                 v.z = InternalType<T>::clamp(v.z, p.clamp);
               }
-              if (sw) v.w *= p.slope;
+              if (sw)
+                v.w *= p.slope;
               if (fabsf(v.w) > p.clamp) {
                 sw = 2;
                 v.w = InternalType<T>::clamp(v.w, p.clamp);
@@ -1067,22 +1102,26 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 int sy = __float_as_uint(v.y) >> 31;
                 int sz = __float_as_uint(v.z) >> 31;
                 int sw = __float_as_uint(v.w) >> 31;
-                if (sx) v.x *= p.slope;
+                if (sx)
+                  v.x *= p.slope;
                 if (fabsf(v.x) > p.clamp) {
                   sx = 2;
                   v.x = InternalType<T>::clamp(v.x, p.clamp);
                 }
-                if (sy) v.y *= p.slope;
+                if (sy)
+                  v.y *= p.slope;
                 if (fabsf(v.y) > p.clamp) {
                   sy = 2;
                   v.y = InternalType<T>::clamp(v.y, p.clamp);
                 }
-                if (sz) v.z *= p.slope;
+                if (sz)
+                  v.z *= p.slope;
                 if (fabsf(v.z) > p.clamp) {
                   sz = 2;
                   v.z = InternalType<T>::clamp(v.z, p.clamp);
                 }
-                if (sw) v.w *= p.slope;
+                if (sw)
+                  v.w *= p.slope;
                 if (fabsf(v.w) > p.clamp) {
                   sw = 2;
                   v.w = InternalType<T>::clamp(v.w, p.clamp);
@@ -1091,41 +1130,59 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 p.s[si] = sx + (sy << 2) + (sz << 4) + (sw << 6);
               } else {
                 // Just compute the values.
-                if (v.x < 0.f) v.x *= p.slope;
+                if (v.x < 0.f)
+                  v.x *= p.slope;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
-                if (v.y < 0.f) v.y *= p.slope;
+                if (v.y < 0.f)
+                  v.y *= p.slope;
                 v.y = InternalType<T>::clamp(v.y, p.clamp);
-                if (v.z < 0.f) v.z *= p.slope;
+                if (v.z < 0.f)
+                  v.z *= p.slope;
                 v.z = InternalType<T>::clamp(v.z, p.clamp);
-                if (v.w < 0.f) v.w *= p.slope;
+                if (v.w < 0.f)
+                  v.w *= p.slope;
                 v.w = InternalType<T>::clamp(v.w, p.clamp);
               }
             }
-          } else if (signRead)  // Read sign and apply.
+          } else if (signRead) // Read sign and apply.
           {
             if ((uint32_t)signY < p.sShape.y) {
               int s = 0;
-              if ((uint32_t)signXb < p.swLimit) s = p.s[si];
-              if ((uint32_t)signXb + 1 < p.swLimit) s |= p.s[si + 1] << 8;
+              if ((uint32_t)signXb < p.swLimit)
+                s = p.s[si];
+              if ((uint32_t)signXb + 1 < p.swLimit)
+                s |= p.s[si + 1] << 8;
               s >>= (signX & 3) << 1;
-              if (s & 0x01) v.x *= p.slope;
-              if (s & 0x02) v.x = 0.f;
-              if (s & 0x04) v.y *= p.slope;
-              if (s & 0x08) v.y = 0.f;
-              if (s & 0x10) v.z *= p.slope;
-              if (s & 0x20) v.z = 0.f;
-              if (s & 0x40) v.w *= p.slope;
-              if (s & 0x80) v.w = 0.f;
+              if (s & 0x01)
+                v.x *= p.slope;
+              if (s & 0x02)
+                v.x = 0.f;
+              if (s & 0x04)
+                v.y *= p.slope;
+              if (s & 0x08)
+                v.y = 0.f;
+              if (s & 0x10)
+                v.z *= p.slope;
+              if (s & 0x20)
+                v.z = 0.f;
+              if (s & 0x40)
+                v.w *= p.slope;
+              if (s & 0x80)
+                v.w = 0.f;
             }
-          } else  // Forward pass with no sign write.
+          } else // Forward pass with no sign write.
           {
-            if (v.x < 0.f) v.x *= p.slope;
+            if (v.x < 0.f)
+              v.x *= p.slope;
             v.x = InternalType<T>::clamp(v.x, p.clamp);
-            if (v.y < 0.f) v.y *= p.slope;
+            if (v.y < 0.f)
+              v.y *= p.slope;
             v.y = InternalType<T>::clamp(v.y, p.clamp);
-            if (v.z < 0.f) v.z *= p.slope;
+            if (v.z < 0.f)
+              v.z *= p.slope;
             v.z = InternalType<T>::clamp(v.z, p.clamp);
-            if (v.w < 0.f) v.w *= p.slope;
+            if (v.w < 0.f)
+              v.w *= p.slope;
             v.w = InternalType<T>::clamp(v.w, p.clamp);
           }
 
@@ -1138,12 +1195,12 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
         __syncthreads();
         uint32_t groupMask = 15 << ((threadIdx.x & 31) & ~3);
         int minY = tileOutY ? (tileOutY - tileOutH) * down + tileUpH
-                            : 0;  // Skip already written signs.
+                            : 0; // Skip already written signs.
         for (int idx = threadIdx.x; idx < tileUpW * tileUpH;
              idx += blockDim.x) {
           int relUpX0, relUpY0;
           fast_div_mod<tileUpW>(relUpX0, relUpY0, idx);
-          scalar_t v = s_tileIn[idx] * (scalar_t)c_fu[0];  // 1x1 filter.
+          scalar_t v = s_tileIn[idx] * (scalar_t)c_fu[0]; // 1x1 filter.
 
           int x = tileOutX * down + relUpX0;
           int y = tileOutY * down + relUpY0;
@@ -1170,9 +1227,9 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               }
               if ((uint32_t)signXb < p.swLimit &&
                   (uint32_t)signY < p.sShape.y && signY >= minY) {
-                s += __shfl_xor_sync(groupMask, s, 1);  // Coalesce.
-                s += __shfl_xor_sync(groupMask, s, 2);  // Coalesce.
-                p.s[si] = s;                            // Write.
+                s += __shfl_xor_sync(groupMask, s, 1); // Coalesce.
+                s += __shfl_xor_sync(groupMask, s, 2); // Coalesce.
+                p.s[si] = s;                           // Write.
               }
             } else {
               // Determine and write sign.
@@ -1188,12 +1245,13 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                   s = signXbit * 2;
                   v = InternalType<T>::clamp(v, p.clamp);
                 }
-                s += __shfl_xor_sync(groupMask, s, 1);  // Coalesce.
-                s += __shfl_xor_sync(groupMask, s, 2);  // Coalesce.
-                p.s[si] = s;                            // Write.
+                s += __shfl_xor_sync(groupMask, s, 1); // Coalesce.
+                s += __shfl_xor_sync(groupMask, s, 2); // Coalesce.
+                p.s[si] = s;                           // Write.
               } else {
                 // Just compute the value.
-                if (v < 0.f) v *= p.slope;
+                if (v < 0.f)
+                  v *= p.slope;
                 v = InternalType<T>::clamp(v, p.clamp);
               }
             }
@@ -1202,23 +1260,26 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
             if ((uint32_t)signXb < p.swLimit && (uint32_t)signY < p.sShape.y) {
               int s = p.s[si];
               s >>= signXo;
-              if (s & 1) v *= p.slope;
-              if (s & 2) v = 0.f;
+              if (s & 1)
+                v *= p.slope;
+              if (s & 2)
+                v = 0.f;
             }
-          } else  // Forward pass with no sign write.
+          } else // Forward pass with no sign write.
           {
-            if (v < 0.f) v *= p.slope;
+            if (v < 0.f)
+              v *= p.slope;
             v = InternalType<T>::clamp(v, p.clamp);
           }
 
-          if (!downInline)  // Write into temporary buffer.
+          if (!downInline) // Write into temporary buffer.
             s_tileUpXY[idx] = v;
           else if ((uint32_t)x < p.yShape.x &&
                    (uint32_t)y <
-                       p.yShape.y)  // Write directly into output buffer
-            *((T*)((char*)p.y + (x * get_stride<index_t>(p.yStride.x) +
-                                 y * get_stride<index_t>(p.yStride.y) +
-                                 mapOfsOut))) = (T)(v * (scalar_t)c_fd[0]);
+                       p.yShape.y) // Write directly into output buffer
+            *((T *)((char *)p.y + (x * get_stride<index_t>(p.yStride.x) +
+                                   y * get_stride<index_t>(p.yStride.y) +
+                                   mapOfsOut))) = (T)(v * (scalar_t)c_fd[0]);
         }
       }
     }
@@ -1298,9 +1359,9 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
         int outY = tileOutY + relOutY0;
 
         if (outX < p.yShape.x & outY < p.yShape.y)
-          *((T*)((char*)p.y +
-                 (outX * get_stride<index_t>(p.yStride.x) +
-                  outY * get_stride<index_t>(p.yStride.y) + mapOfsOut))) = (T)v;
+          *((T *)((char *)p.y + (outX * get_stride<index_t>(p.yStride.x) +
+                                 outY * get_stride<index_t>(p.yStride.y) +
+                                 mapOfsOut))) = (T)v;
       }
     } else if (filterMode == MODE_SUFD || filterMode == MODE_FUFD) {
       // Full downsampling filter.
@@ -1330,9 +1391,10 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
           if ((uint32_t)outY < p.yShape.y) {
             index_t ofs = outX * get_stride<index_t>(p.yStride.x) +
                           outY * get_stride<index_t>(p.yStride.y) + mapOfsOut;
-            if (outX + 0 < p.yShape.x) *((T*)((char*)p.y + ofs)) = (T)v.x;
+            if (outX + 0 < p.yShape.x)
+              *((T *)((char *)p.y + ofs)) = (T)v.x;
             if (outX + 1 < p.yShape.x)
-              *((T*)((char*)p.y + ofs + get_stride<index_t>(p.yStride.x))) =
+              *((T *)((char *)p.y + ofs + get_stride<index_t>(p.yStride.x))) =
                   (T)v.y;
           }
         }
@@ -1343,19 +1405,20 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
              idx += blockDim.x) {
           int relOutX0, relOutY0;
           fast_div_mod<tileOutW>(relOutX0, relOutY0, idx);
-          scalar_t v = s_tileUpXY[idx] * (scalar_t)c_fd[0];  // 1x1 filter.
+          scalar_t v = s_tileUpXY[idx] * (scalar_t)c_fd[0]; // 1x1 filter.
 
           int outX = tileOutX + relOutX0;
           int outY = tileOutY + relOutY0;
           if ((uint32_t)outX < p.yShape.x && (uint32_t)outY < p.yShape.y)
-            *((T*)((char*)p.y + (outX * get_stride<index_t>(p.yStride.x) +
-                                 outY * get_stride<index_t>(p.yStride.y) +
-                                 mapOfsOut))) = (T)v;
+            *((T *)((char *)p.y + (outX * get_stride<index_t>(p.yStride.x) +
+                                   outY * get_stride<index_t>(p.yStride.y) +
+                                   mapOfsOut))) = (T)v;
         }
       }
     }
 
-    if (!enableXrep) break;
+    if (!enableXrep)
+      break;
   }
 }
 
@@ -1366,15 +1429,15 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
 // 64-bit indexing is always used.
 
 template <class T, bool signWrite, bool signRead>
-static __global__ void filtered_lrelu_act_kernel(
-    filtered_lrelu_act_kernel_params p) {
+static __global__ void
+filtered_lrelu_act_kernel(filtered_lrelu_act_kernel_params p) {
   typedef typename InternalType<T>::scalar_t scalar_t;
 
   // Indexing.
   int32_t x = threadIdx.x + blockIdx.x * blockDim.x;
   int32_t ymax = signWrite ? p.sShape.y : p.xShape.y;
   int32_t qmax =
-      p.xShape.z * p.xShape.w;  // Combined minibatch*channel maximum index.
+      p.xShape.z * p.xShape.w; // Combined minibatch*channel maximum index.
 
   // Loop to accommodate oversized tensors.
   for (int32_t q = blockIdx.z; q < qmax; q += gridDim.z)
@@ -1390,45 +1453,45 @@ static __global__ void filtered_lrelu_act_kernel(
         if (x < p.xShape.x && y < p.xShape.y) {
           int64_t ix = x * p.xStride.x + y * p.xStride.y + z * p.xStride.z +
                        w * p.xStride.w;
-          T* pv = ((T*)p.x) + ix;
+          T *pv = ((T *)p.x) + ix;
           scalar_t v = (scalar_t)(*pv);
 
           // Gain, LReLU, clamp.
           v *= p.gain;
           if (v < 0.f) {
             v *= p.slope;
-            s = 1;  // Sign.
+            s = 1; // Sign.
           }
           if (fabsf(v) > p.clamp) {
             v = InternalType<T>::clamp(v, p.clamp);
-            s = 2;  // Clamp.
+            s = 2; // Clamp.
           }
 
-          *pv = (T)v;  // Write value.
+          *pv = (T)v; // Write value.
         }
 
         // Coalesce into threads 0 and 16 of warp.
         uint32_t m = (threadIdx.x & 16) ? 0xffff0000u : 0x0000ffffu;
-        s <<= ((threadIdx.x & 15) << 1);  // Shift into place.
-        s |= __shfl_xor_sync(m, s, 1);    // Distribute.
+        s <<= ((threadIdx.x & 15) << 1); // Shift into place.
+        s |= __shfl_xor_sync(m, s, 1);   // Distribute.
         s |= __shfl_xor_sync(m, s, 2);
         s |= __shfl_xor_sync(m, s, 4);
         s |= __shfl_xor_sync(m, s, 8);
 
         // Write signs if leader and in p.s.
-        if (!(threadIdx.x & 15) && x < p.sShape.x)  // y is always in.
+        if (!(threadIdx.x & 15) && x < p.sShape.x) // y is always in.
         {
           uint64_t is =
-              x + p.sShape.x * (y + (int64_t)p.sShape.y * q);  // Contiguous.
-          ((uint32_t*)p.s)[is >> 4] = s;
+              x + p.sShape.x * (y + (int64_t)p.sShape.y * q); // Contiguous.
+          ((uint32_t *)p.s)[is >> 4] = s;
         }
       } else if (signRead) {
         // Process value if in p.x.
-        if (x < p.xShape.x)  // y is always in.
+        if (x < p.xShape.x) // y is always in.
         {
           int64_t ix = x * p.xStride.x + y * p.xStride.y + z * p.xStride.z +
                        w * p.xStride.w;
-          T* pv = ((T*)p.x) + ix;
+          T *pv = ((T *)p.x) + ix;
           scalar_t v = (scalar_t)(*pv);
           v *= p.gain;
 
@@ -1440,45 +1503,48 @@ static __global__ void filtered_lrelu_act_kernel(
           if (sx < p.sShape.x && sy < p.sShape.y) {
             uint64_t is =
                 (sx >> 2) + (p.sShape.x >> 2) *
-                                (sy + (uint64_t)p.sShape.y * q);  // Contiguous.
+                                (sy + (uint64_t)p.sShape.y * q); // Contiguous.
             unsigned char s = p.s[is];
-            s >>= (sx & 3) << 1;  // Shift into place.
-            if (s & 1)            // Sign?
+            s >>= (sx & 3) << 1; // Shift into place.
+            if (s & 1)           // Sign?
               v *= p.slope;
-            if (s & 2)  // Clamp?
+            if (s & 2) // Clamp?
               v = 0.f;
           }
 
-          *pv = (T)v;  // Write value.
+          *pv = (T)v; // Write value.
         }
       } else {
         // Forward pass with no sign write. Process value if in p.x.
-        if (x < p.xShape.x)  // y is always in.
+        if (x < p.xShape.x) // y is always in.
         {
           int64_t ix = x * p.xStride.x + y * p.xStride.y + z * p.xStride.z +
                        w * p.xStride.w;
-          T* pv = ((T*)p.x) + ix;
+          T *pv = ((T *)p.x) + ix;
           scalar_t v = (scalar_t)(*pv);
           v *= p.gain;
-          if (v < 0.f) v *= p.slope;
-          if (fabsf(v) > p.clamp) v = InternalType<T>::clamp(v, p.clamp);
-          *pv = (T)v;  // Write value.
+          if (v < 0.f)
+            v *= p.slope;
+          if (fabsf(v) > p.clamp)
+            v = InternalType<T>::clamp(v, p.clamp);
+          *pv = (T)v; // Write value.
         }
       }
     }
 }
 
 template <class T, bool signWrite, bool signRead>
-void* choose_filtered_lrelu_act_kernel(void) {
-  return (void*)filtered_lrelu_act_kernel<T, signWrite, signRead>;
+void *choose_filtered_lrelu_act_kernel(void) {
+  return (void *)filtered_lrelu_act_kernel<T, signWrite, signRead>;
 }
 
 //------------------------------------------------------------------------
 // CUDA kernel selection.
 
 template <class T, class index_t, bool signWrite, bool signRead>
-filtered_lrelu_kernel_spec choose_filtered_lrelu_kernel(
-    const filtered_lrelu_kernel_params& p, int sharedKB) {
+filtered_lrelu_kernel_spec
+choose_filtered_lrelu_kernel(const filtered_lrelu_kernel_params &p,
+                             int sharedKB) {
   filtered_lrelu_kernel_spec s = {0};
 
   // Return the first matching kernel.
@@ -1498,8 +1564,8 @@ filtered_lrelu_kernel_spec choose_filtered_lrelu_kernel(
           static_assert(FD % D == 0,                                           \
                         "downscaling filter size must be multiple of "         \
                         "downscaling factor");                                 \
-          s.setup = (void*)setup_filters_kernel;                               \
-          s.exec = (void*)                                                     \
+          s.setup = (void *)setup_filters_kernel;                              \
+          s.exec = (void *)                                                    \
               filtered_lrelu_kernel<T, index_t, SH, signWrite, signRead, MODE, \
                                     U, FU, D, FD, TW, TH, W * 32, !!XR, !!WS>; \
           s.tileOut = make_int2(TW, TH);                                       \
@@ -1515,79 +1581,90 @@ filtered_lrelu_kernel_spec choose_filtered_lrelu_kernel(
   // must be listed before those that use less, for the same reason.
 
   CASE(/*sharedKB*/ 48, /*up,fu*/ 1, 1, /*down,fd*/ 1, 1, /*mode*/ MODE_FUFD,
-       /*tw,th,warps,xrep,wskip*/ 64, 178, 32, 0, 0)  // 1t-upf1-downf1
+       /*tw,th,warps,xrep,wskip*/ 64, 178, 32, 0, 0) // 1t-upf1-downf1
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 1, 1, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 152, 95, 16, 0, 0)  // 4t-ups2-downf1
+       /*tw,th,warps,xrep,wskip*/ 152, 95, 16, 0, 0) // 4t-ups2-downf1
   CASE(/*sharedKB*/ 48, /*up,fu*/ 1, 1, /*down,fd*/ 2, 8, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 56, 22, 16, 0, 0)  // 4t-upf1-downs2
+       /*tw,th,warps,xrep,wskip*/ 56, 22, 16, 0, 0) // 4t-upf1-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 2, 8, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 56, 29, 16, 11, 0)  // 4t-ups2-downs2
+       /*tw,th,warps,xrep,wskip*/ 56, 29, 16, 11, 0) // 4t-ups2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 2, 8, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 60, 28, 16, 0, 0)  // 4t-upf2-downs2
+       /*tw,th,warps,xrep,wskip*/ 60, 28, 16, 0, 0) // 4t-upf2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 2, 8, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 56, 28, 16, 0, 0)  // 4t-ups2-downf2
+       /*tw,th,warps,xrep,wskip*/ 56, 28, 16, 0, 0) // 4t-ups2-downf2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 16, /*down,fd*/ 2, 8, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 56, 31, 16, 11, 0)  // 4t-ups4-downs2
+       /*tw,th,warps,xrep,wskip*/ 56, 31, 16, 11, 0) // 4t-ups4-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 16, /*down,fd*/ 2, 8, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 56, 36, 16, 0, 0)  // 4t-ups4-downf2
+       /*tw,th,warps,xrep,wskip*/ 56, 36, 16, 0, 0) // 4t-ups4-downf2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 4, 16, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 16, 22, 16, 12, 0)  // 4t-ups2-downs4
+       /*tw,th,warps,xrep,wskip*/ 16, 22, 16, 12, 0) // 4t-ups2-downs4
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 4, 16, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 29, 15, 16, 0, 0)  // 4t-upf2-downs4
+       /*tw,th,warps,xrep,wskip*/ 29, 15, 16, 0, 0) // 4t-upf2-downs4
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 1, 1, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 96, 150, 28, 0, 0)  // 6t-ups2-downf1
+       /*tw,th,warps,xrep,wskip*/ 96, 150, 28, 0, 0) // 6t-ups2-downf1
   CASE(/*sharedKB*/ 48, /*up,fu*/ 1, 1, /*down,fd*/ 2, 12, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 35, 24, 0, 0)  // 6t-upf1-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 35, 24, 0, 0) // 6t-upf1-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 2, 12, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 46, 16, 10, 0)  // 6t-ups2-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 46, 16, 10, 0) // 6t-ups2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 2, 12, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 58, 28, 24, 8, 0)  // 6t-upf2-downs2
+       /*tw,th,warps,xrep,wskip*/ 58, 28, 24, 8, 0) // 6t-upf2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 2, 12, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 52, 28, 16, 0, 0)  // 6t-ups2-downf2
+       /*tw,th,warps,xrep,wskip*/ 52, 28, 16, 0, 0) // 6t-ups2-downf2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 24, /*down,fd*/ 2, 12, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 51, 16, 5, 0)  // 6t-ups4-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 51, 16, 5, 0) // 6t-ups4-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 24, /*down,fd*/ 2, 12, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 32, 56, 16, 6, 0)  // 6t-ups4-downf2
+       /*tw,th,warps,xrep,wskip*/ 32, 56, 16, 6, 0) // 6t-ups4-downf2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 4, 24, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 16, 18, 16, 12, 0)  // 6t-ups2-downs4
+       /*tw,th,warps,xrep,wskip*/ 16, 18, 16, 12, 0) // 6t-ups2-downs4
   CASE(/*sharedKB*/ 96, /*up,fu*/ 2, 12, /*down,fd*/ 4, 24, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 27, 31, 32, 6, 0)  // 6t-upf2-downs4 96kB
+       /*tw,th,warps,xrep,wskip*/ 27, 31, 32, 6, 0) // 6t-upf2-downs4 96kB
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 4, 24, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 27, 13, 24, 0, 0)  // 6t-upf2-downs4
+       /*tw,th,warps,xrep,wskip*/ 27, 13, 24, 0, 0) // 6t-upf2-downs4
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 1, 1, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 148, 89, 24, 0, 0)  // 8t-ups2-downf1
+       /*tw,th,warps,xrep,wskip*/ 148, 89, 24, 0, 0) // 8t-ups2-downf1
   CASE(/*sharedKB*/ 48, /*up,fu*/ 1, 1, /*down,fd*/ 2, 16, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 31, 16, 5, 0)  // 8t-upf1-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 31, 16, 5, 0) // 8t-upf1-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 2, 16, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 41, 16, 9, 0)  // 8t-ups2-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 41, 16, 9, 0) // 8t-ups2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 2, 16, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 56, 26, 24, 0, 0)  // 8t-upf2-downs2
+       /*tw,th,warps,xrep,wskip*/ 56, 26, 24, 0, 0) // 8t-upf2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 2, 16, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 32, 40, 16, 0, 0)  // 8t-ups2-downf2
+       /*tw,th,warps,xrep,wskip*/ 32, 40, 16, 0, 0) // 8t-ups2-downf2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 32, /*down,fd*/ 2, 16, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 46, 24, 5, 0)  // 8t-ups4-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 46, 24, 5, 0) // 8t-ups4-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 32, /*down,fd*/ 2, 16, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 32, 50, 16, 0, 0)  // 8t-ups4-downf2
+       /*tw,th,warps,xrep,wskip*/ 32, 50, 16, 0, 0) // 8t-ups4-downf2
   CASE(/*sharedKB*/ 96, /*up,fu*/ 2, 16, /*down,fd*/ 4, 32, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 24, 24, 32, 12, 1)  // 8t-ups2-downs4 96kB
+       /*tw,th,warps,xrep,wskip*/ 24, 24, 32, 12, 1) // 8t-ups2-downs4 96kB
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 4, 32, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 16, 13, 16, 10, 1)  // 8t-ups2-downs4
+       /*tw,th,warps,xrep,wskip*/ 16, 13, 16, 10, 1) // 8t-ups2-downs4
   CASE(/*sharedKB*/ 96, /*up,fu*/ 2, 16, /*down,fd*/ 4, 32, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 25, 28, 28, 4, 0)  // 8t-upf2-downs4 96kB
+       /*tw,th,warps,xrep,wskip*/ 25, 28, 28, 4, 0) // 8t-upf2-downs4 96kB
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 4, 32, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 25, 10, 24, 0, 0)  // 8t-upf2-downs4
+       /*tw,th,warps,xrep,wskip*/ 25, 10, 24, 0, 0) // 8t-upf2-downs4
 
 #undef CASE
-  return s;  // No kernel found.
+  return s; // No kernel found.
 }
 
 //------------------------------------------------------------------------
 
-std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
-    torch::Tensor x, torch::Tensor fu, torch::Tensor fd, torch::Tensor b,
-    torch::Tensor si, int up, int down, int px0, int px1, int py0, int py1,
-    int sx, int sy, float gain, float slope, float clamp, bool flip_filters,
-    bool writeSigns) {
+#define BUILD_FILTERED_LRELU_OP 1
+
+#ifdef __GNUC__
+#if __GNUC__ < 6
+#undef BUILD_FILTERED_LRELU_OP
+#define BUILD_FILTERED_LRELU_OP 0
+#endif
+#endif
+
+#if BUILD_FILTERED_LRELU_OP == 1
+std::tuple<torch::Tensor, torch::Tensor, int>
+filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
+                  torch::Tensor b, torch::Tensor si, int up, int down, int px0,
+                  int px1, int py0, int py1, int sx, int sy, float gain,
+                  float slope, float clamp, bool flip_filters,
+                  bool writeSigns) {
   // Set CUDA device.
   TORCH_CHECK(x.is_cuda(), "x must reside on CUDA device");
   const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
@@ -1606,9 +1683,9 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
                   x.size(3) <= INT_MAX,
               "x is too large");
   TORCH_CHECK(x.numel() > 0, "x is empty");
-  TORCH_CHECK(
-      (fu.dim() == 1 || fu.dim() == 2) && (fd.dim() == 1 || fd.dim() == 2),
-      "fu and fd must be rank 1 or 2");
+  TORCH_CHECK((fu.dim() == 1 || fu.dim() == 2) &&
+                  (fd.dim() == 1 || fd.dim() == 2),
+              "fu and fd must be rank 1 or 2");
   TORCH_CHECK(fu.size(0) <= INT_MAX && fu.size(-1) <= INT_MAX,
               "fu is too large");
   TORCH_CHECK(fd.size(0) <= INT_MAX && fd.size(-1) <= INT_MAX,
@@ -1633,7 +1710,7 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
   p.fuShape =
       make_int2((int)fu.size(-1),
                 fu.dim() == 2 ? (int)fu.size(0)
-                              : 0);  // shape [n, 0] indicates separable filter.
+                              : 0); // shape [n, 0] indicates separable filter.
   p.fdShape = make_int2((int)fd.size(-1), fd.dim() == 2 ? (int)fd.size(0) : 0);
   filtered_lrelu_kernel_spec test_spec =
       choose_filtered_lrelu_kernel<float, int32_t, false, false>(p, sharedKB);
@@ -1674,12 +1751,12 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
   torch::Tensor so;
   torch::Tensor s = si;
   bool readSigns = !!s.numel();
-  int64_t sw_active = 0;  // Active width of sign tensor.
+  int64_t sw_active = 0; // Active width of sign tensor.
   if (writeSigns) {
-    sw_active = yw * down - (down - 1) + fdt_w;   // Active width in elements.
-    int64_t sh = yh * down - (down - 1) + fdt_h;  // Height = active height.
-    int64_t sw = (sw_active + 15) & ~15;  // Width  = active width in elements,
-                                          // rounded up to multiple of 16.
+    sw_active = yw * down - (down - 1) + fdt_w;  // Active width in elements.
+    int64_t sh = yh * down - (down - 1) + fdt_h; // Height = active height.
+    int64_t sw = (sw_active + 15) & ~15; // Width  = active width in elements,
+                                         // rounded up to multiple of 16.
     TORCH_CHECK(sh <= INT_MAX && (sw >> 2) <= INT_MAX, "signs is too large");
     s = so = torch::empty({x.size(0), x.size(1), sh, sw >> 2},
                           x.options().dtype(torch::kUInt8),
@@ -1718,9 +1795,9 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
       make_int4((int)y.size(3), (int)y.size(2), (int)y.size(1), (int)y.size(0));
   p.sShape = (readSigns || writeSigns)
                  ? make_int2((int)s.size(3), (int)s.size(2))
-                 : make_int2(0, 0);  // Width is in bytes. Contiguous.
+                 : make_int2(0, 0); // Width is in bytes. Contiguous.
   p.sOfs = make_int2(sx, sy);
-  p.swLimit = (sw_active + 3) >> 2;  // Rounded up to bytes.
+  p.swLimit = (sw_active + 3) >> 2; // Rounded up to bytes.
 
   // x, y, b strides are in bytes.
   p.xStride = make_longlong4(sz * x.stride(3), sz * x.stride(2),
@@ -1738,7 +1815,8 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
   // Determine if indices don't fit in int32. Support negative strides although
   // Torch currently never produces those.
   bool index64b = false;
-  if (std::abs(p.bStride * x.size(1)) > INT_MAX) index64b = true;
+  if (std::abs(p.bStride * x.size(1)) > INT_MAX)
+    index64b = true;
   if (std::min(x.size(0) * p.xStride.w, 0ll) +
           std::min(x.size(1) * p.xStride.z, 0ll) +
           std::min(x.size(2) * p.xStride.y, 0ll) +
@@ -1763,15 +1841,15 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
           std::max(y.size(3) * p.yStride.x, 0ll) >
       INT_MAX)
     index64b = true;
-  if (s.numel() > INT_MAX) index64b = true;
+  if (s.numel() > INT_MAX)
+    index64b = true;
 
   // Choose CUDA kernel.
   filtered_lrelu_kernel_spec spec = {0};
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       x.scalar_type(), "filtered_lrelu_cuda", [&] {
-        if constexpr (sizeof(scalar_t) <=
-                      4)  // Exclude doubles. constexpr prevents template
-                          // instantiation.
+        if constexpr (sizeof(scalar_t) <= 4) // Exclude doubles. constexpr
+                                             // prevents template instantiation.
         {
           // Choose kernel based on index type, datatype and sign read/write
           // modes.
@@ -1799,12 +1877,12 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
       });
   TORCH_CHECK(
       spec.exec,
-      "internal error - CUDA kernel not found")  // This should not happen
-                                                 // because we tested earlier
-                                                 // that kernel exists.
+      "internal error - CUDA kernel not found") // This should not happen
+                                                // because we tested earlier
+                                                // that kernel exists.
 
   // Launch CUDA kernel.
-  void* args[] = {&p};
+  void *args[] = {&p};
   int bx = spec.numWarps * 32;
   int gx = (p.yShape.x - 1) / spec.tileOut.x + 1;
   int gy = (p.yShape.y - 1) / spec.tileOut.y + 1;
@@ -1836,7 +1914,7 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
 
   // Set cache and shared memory configurations for main kernel.
   AT_CUDA_CHECK(cudaFuncSetCacheConfig(spec.exec, cudaFuncCachePreferShared));
-  if (spec.dynamicSharedKB)  // Need dynamically allocated shared memory?
+  if (spec.dynamicSharedKB) // Need dynamically allocated shared memory?
     AT_CUDA_CHECK(cudaFuncSetAttribute(
         spec.exec, cudaFuncAttributeMaxDynamicSharedMemorySize,
         spec.dynamicSharedKB << 10));
@@ -1844,9 +1922,9 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
       cudaFuncSetSharedMemConfig(spec.exec, cudaSharedMemBankSizeFourByte));
 
   // Launch main kernel.
-  const int maxSubGz = 65535;  // CUDA maximum for block z dimension.
+  const int maxSubGz = 65535; // CUDA maximum for block z dimension.
   for (int zofs = 0; zofs < gz;
-       zofs += maxSubGz)  // Do multiple launches if gz is too big.
+       zofs += maxSubGz) // Do multiple launches if gz is too big.
   {
     p.blockZofs = zofs;
     int subGz = std::min(maxSubGz, gz - zofs);
@@ -1858,6 +1936,19 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
   // Done.
   return std::make_tuple(y, so, 0);
 }
+#else
+std::tuple<torch::Tensor, torch::Tensor, int>
+filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
+                  torch::Tensor b, torch::Tensor si, int up, int down, int px0,
+                  int px1, int py0, int py1, int sx, int sy, float gain,
+                  float slope, float clamp, bool flip_filters,
+                  bool writeSigns) {
+  TORCH_CHECK(false, "filtered_lrelu_op is not available. Please update your "
+                     "compiler and try again.");
+  return std::tuple<torch::Tensor, torch::Tensor, int>();
+}
+#endif
+#undef BUILD_FILTERED_LRELU_OP
 
 //------------------------------------------------------------------------
 
@@ -1884,7 +1975,7 @@ torch::Tensor filtered_lrelu_act_op(torch::Tensor x, torch::Tensor si, int sx,
   bool readSigns = !!s.numel();
   if (writeSigns) {
     int64_t sw = x.size(3);
-    sw = (sw + 15) & ~15;  // Round to a multiple of 16 for coalescing.
+    sw = (sw + 15) & ~15; // Round to a multiple of 16 for coalescing.
     s = so = torch::empty({x.size(0), x.size(1), x.size(2), sw >> 2},
                           x.options().dtype(torch::kUInt8),
                           at::MemoryFormat::Contiguous);
@@ -1916,11 +2007,11 @@ torch::Tensor filtered_lrelu_act_op(torch::Tensor x, torch::Tensor si, int sx,
       make_longlong4(x.stride(3), x.stride(2), x.stride(1), x.stride(0));
   p.sShape = (readSigns || writeSigns)
                  ? make_int2((int)s.size(3) << 2, (int)s.size(2))
-                 : make_int2(0, 0);  // Width is in elements. Contiguous.
+                 : make_int2(0, 0); // Width is in elements. Contiguous.
   p.sOfs = make_int2(sx, sy);
 
   // Choose CUDA kernel.
-  void* func = 0;
+  void *func = 0;
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       x.scalar_type(), "filtered_lrelu_act_cuda", [&] {
         if (writeSigns)
@@ -1933,14 +2024,14 @@ torch::Tensor filtered_lrelu_act_op(torch::Tensor x, torch::Tensor si, int sx,
   TORCH_CHECK(func, "internal error - CUDA kernel not found");
 
   // Launch CUDA kernel.
-  void* args[] = {&p};
-  int bx = 128;  // 4 warps per block.
+  void *args[] = {&p};
+  int bx = 128; // 4 warps per block.
 
   // Logical size of launch = writeSigns ? p.s : p.x
   uint32_t gx = writeSigns ? p.sShape.x : p.xShape.x;
   uint32_t gy = writeSigns ? p.sShape.y : p.xShape.y;
   uint32_t gz =
-      p.xShape.z * p.xShape.w;  // Same as in p.sShape if signs are in use.
+      p.xShape.z * p.xShape.w; // Same as in p.sShape if signs are in use.
   gx = (gx - 1) / bx + 1;
 
   // Make sure grid y and z dimensions are within CUDA launch limits. Kernel

--- a/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
@@ -12,6 +12,7 @@
 #include <cstdint>
 
 #include "pytorch_cuda_helper.hpp"
+#include "pytorch_device_registry.hpp"
 
 //------------------------------------------------------------------------
 // CUDA kernel parameters.
@@ -1873,17 +1874,21 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
   // Done.
   return std::make_tuple(y, so, 0);
 }
-#else
-std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
+
+std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op_impl(
     torch::Tensor x, torch::Tensor fu, torch::Tensor fd, torch::Tensor b,
     torch::Tensor si, int up, int down, int px0, int px1, int py0, int py1,
     int sx, int sy, float gain, float slope, float clamp, bool flip_filters,
-    bool writeSigns) {
-  TORCH_CHECK(false,
-              "filtered_lrelu_op is not available. Please update your "
-              "compiler and cuda version.");
-  return std::tuple<torch::Tensor, torch::Tensor, int>();
-}
+    bool writeSigns);
+
+REGISTER_DEVICE_IMPL(filtered_lrelu_op_impl, CUDA, filtered_lrelu_op);
+
+#else
+
+#pragma message(                           \
+    "filtered_lrelu_op is not available. " \
+    "Please update your compiler and cuda version.")
+
 #endif
 #undef BUILD_FILTERED_LRELU_OP
 

--- a/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
@@ -18,98 +18,98 @@
 
 struct filtered_lrelu_kernel_params {
   // These parameters decide which kernel to use.
-  int up;       // upsampling ratio (1, 2, 4)
-  int down;     // downsampling ratio (1, 2, 4)
-  int2 fuShape; // [size, 1] | [size, size]
-  int2 fdShape; // [size, 1] | [size, size]
+  int up;        // upsampling ratio (1, 2, 4)
+  int down;      // downsampling ratio (1, 2, 4)
+  int2 fuShape;  // [size, 1] | [size, size]
+  int2 fdShape;  // [size, 1] | [size, size]
 
-  int _dummy; // Alignment.
+  int _dummy;  // Alignment.
 
   // Rest of the parameters.
-  const void *x;    // Input tensor.
-  void *y;          // Output tensor.
-  const void *b;    // Bias tensor.
-  unsigned char *s; // Sign tensor in/out. NULL if unused.
-  const float *fu;  // Upsampling filter.
-  const float *fd;  // Downsampling filter.
+  const void *x;     // Input tensor.
+  void *y;           // Output tensor.
+  const void *b;     // Bias tensor.
+  unsigned char *s;  // Sign tensor in/out. NULL if unused.
+  const float *fu;   // Upsampling filter.
+  const float *fd;   // Downsampling filter.
 
-  int2 pad0;   // Left/top padding.
-  float gain;  // Additional gain factor.
-  float slope; // Leaky ReLU slope on negative side.
-  float clamp; // Clamp after nonlinearity.
-  int flip;    // Filter kernel flip for gradient computation.
+  int2 pad0;    // Left/top padding.
+  float gain;   // Additional gain factor.
+  float slope;  // Leaky ReLU slope on negative side.
+  float clamp;  // Clamp after nonlinearity.
+  int flip;     // Filter kernel flip for gradient computation.
 
-  int tilesXdim; // Original number of horizontal output tiles.
-  int tilesXrep; // Number of horizontal tiles per CTA.
-  int blockZofs; // Block z offset to support large minibatch, channel
-                 // dimensions.
+  int tilesXdim;  // Original number of horizontal output tiles.
+  int tilesXrep;  // Number of horizontal tiles per CTA.
+  int blockZofs;  // Block z offset to support large minibatch, channel
+                  // dimensions.
 
-  int4 xShape; // [width, height, channel, batch]
-  int4 yShape; // [width, height, channel, batch]
-  int2 sShape; // [width, height] - width is in bytes. Contiguous. Zeros if
-               // unused.
-  int2 sOfs; // [ofs_x, ofs_y] - offset between upsampled data and sign tensor.
-  int swLimit; // Active width of sign tensor in bytes.
+  int4 xShape;  // [width, height, channel, batch]
+  int4 yShape;  // [width, height, channel, batch]
+  int2 sShape;  // [width, height] - width is in bytes. Contiguous. Zeros if
+                // unused.
+  int2 sOfs;  // [ofs_x, ofs_y] - offset between upsampled data and sign tensor.
+  int swLimit;  // Active width of sign tensor in bytes.
 
-  longlong4 xStride;  // Strides of all tensors except signs, same component
-                      // order as shapes.
-  longlong4 yStride;  //
-  int64_t bStride;    //
-  longlong3 fuStride; //
-  longlong3 fdStride; //
+  longlong4 xStride;   // Strides of all tensors except signs, same component
+                       // order as shapes.
+  longlong4 yStride;   //
+  int64_t bStride;     //
+  longlong3 fuStride;  //
+  longlong3 fdStride;  //
 };
 
 struct filtered_lrelu_act_kernel_params {
-  void *x;          // Input/output, modified in-place.
-  unsigned char *s; // Sign tensor in/out. NULL if unused.
+  void *x;           // Input/output, modified in-place.
+  unsigned char *s;  // Sign tensor in/out. NULL if unused.
 
-  float gain;  // Additional gain factor.
-  float slope; // Leaky ReLU slope on negative side.
-  float clamp; // Clamp after nonlinearity.
+  float gain;   // Additional gain factor.
+  float slope;  // Leaky ReLU slope on negative side.
+  float clamp;  // Clamp after nonlinearity.
 
-  int4 xShape;       // [width, height, channel, batch]
-  longlong4 xStride; // Input/output tensor strides, same order as in shape.
-  int2 sShape; // [width, height] - width is in elements. Contiguous. Zeros if
-               // unused.
-  int2 sOfs; // [ofs_x, ofs_y] - offset between upsampled data and sign tensor.
+  int4 xShape;        // [width, height, channel, batch]
+  longlong4 xStride;  // Input/output tensor strides, same order as in shape.
+  int2 sShape;  // [width, height] - width is in elements. Contiguous. Zeros if
+                // unused.
+  int2 sOfs;  // [ofs_x, ofs_y] - offset between upsampled data and sign tensor.
 };
 
 //------------------------------------------------------------------------
 // CUDA kernel specialization.
 
 struct filtered_lrelu_kernel_spec {
-  void *setup;  // Function for filter kernel setup.
-  void *exec;   // Function for main operation.
-  int2 tileOut; // Width/height of launch tile.
-  int numWarps; // Number of warps per thread block, determines launch block
-                // size.
-  int xrep;     // For processing multiple horizontal tiles per thread block.
-  int dynamicSharedKB; // How much dynamic shared memory the exec kernel wants.
+  void *setup;   // Function for filter kernel setup.
+  void *exec;    // Function for main operation.
+  int2 tileOut;  // Width/height of launch tile.
+  int numWarps;  // Number of warps per thread block, determines launch block
+                 // size.
+  int xrep;      // For processing multiple horizontal tiles per thread block.
+  int dynamicSharedKB;  // How much dynamic shared memory the exec kernel wants.
 };
 
 //------------------------------------------------------------------------
 // CUDA kernel selection.
 
 template <class T, class index_t, bool signWrite, bool signRead>
-filtered_lrelu_kernel_spec
-choose_filtered_lrelu_kernel(const filtered_lrelu_kernel_params &p,
-                             int sharedKB);
+filtered_lrelu_kernel_spec choose_filtered_lrelu_kernel(
+    const filtered_lrelu_kernel_params &p, int sharedKB);
 template <class T, bool signWrite, bool signRead>
 void *choose_filtered_lrelu_act_kernel(void);
 
 //------------------------------------------------------------------------
 // Helpers.
 
-enum // Filter modes.
-{
-  MODE_SUSD = 0, // Separable upsampling, separable downsampling.
-  MODE_FUSD = 1, // Full upsampling, separable downsampling.
-  MODE_SUFD = 2, // Separable upsampling, full downsampling.
-  MODE_FUFD = 3, // Full upsampling, full downsampling.
+enum              // Filter modes.
+{ MODE_SUSD = 0,  // Separable upsampling, separable downsampling.
+  MODE_FUSD = 1,  // Full upsampling, separable downsampling.
+  MODE_SUFD = 2,  // Separable upsampling, full downsampling.
+  MODE_FUFD = 3,  // Full upsampling, full downsampling.
 };
 
-template <class T> struct InternalType;
-template <> struct InternalType<double> {
+template <class T>
+struct InternalType;
+template <>
+struct InternalType<double> {
   typedef double scalar_t;
   typedef double2 vec2_t;
   typedef double4 vec4_t;
@@ -123,7 +123,8 @@ template <> struct InternalType<double> {
     return fmin(fmax(x, -c), c);
   }
 };
-template <> struct InternalType<float> {
+template <>
+struct InternalType<float> {
   typedef float scalar_t;
   typedef float2 vec2_t;
   typedef float4 vec4_t;
@@ -137,7 +138,8 @@ template <> struct InternalType<float> {
     return fminf(fmaxf(x, -c), c);
   }
 };
-template <> struct InternalType<c10::Half> {
+template <>
+struct InternalType<c10::Half> {
   typedef float scalar_t;
   typedef float2 vec2_t;
   typedef float4 vec4_t;
@@ -154,18 +156,19 @@ template <> struct InternalType<c10::Half> {
 
 #define MIN(A, B) ((A) < (B) ? (A) : (B))
 #define MAX(A, B) ((A) > (B) ? (A) : (B))
-#define CEIL_DIV(A, B)                                                         \
-  (((B) == 1)   ? (A)                                                          \
-   : ((B) == 2) ? ((int)((A) + 1) >> 1)                                        \
-   : ((B) == 4) ? ((int)((A) + 3) >> 2)                                        \
-                : (((A) + ((A) > 0 ? (B)-1 : 0)) / (B)))
+#define CEIL_DIV(A, B)                                   \
+  (((B) == 1)                                            \
+       ? (A)                                             \
+       : ((B) == 2) ? ((int)((A) + 1) >> 1)              \
+                    : ((B) == 4) ? ((int)((A) + 3) >> 2) \
+                                 : (((A) + ((A) > 0 ? (B)-1 : 0)) / (B)))
 
 // This works only up to blocks of size 256 x 256 and for all N that are powers
 // of two.
 template <int N>
 __device__ __forceinline__ void fast_div_mod(int &x, int &y, unsigned int i) {
   if ((N & (N - 1)) && N <= 256)
-    y = (i * ((1 << 24) / N + 1)) >> 24; // Assumes N <= 256, i < N*256.
+    y = (i * ((1 << 24) / N + 1)) >> 24;  // Assumes N <= 256, i < N*256.
   else
     y = i / N;
 
@@ -173,7 +176,8 @@ __device__ __forceinline__ void fast_div_mod(int &x, int &y, unsigned int i) {
 }
 
 // Type cast stride before reading it.
-template <class T> __device__ __forceinline__ T get_stride(const int64_t &x) {
+template <class T>
+__device__ __forceinline__ T get_stride(const int64_t &x) {
   return *reinterpret_cast<const T *>(&x);
 }
 
@@ -184,12 +188,12 @@ template <class T> __device__ __forceinline__ T get_stride(const int64_t &x) {
 
 // Combined up/down filter buffers so that transfer can be done with one copy.
 __device__ float
-    g_fbuf[2 * MAX_FILTER_SIZE * MAX_FILTER_SIZE]; // Filters in global memory,
-                                                   // written by setup kernel.
+    g_fbuf[2 * MAX_FILTER_SIZE * MAX_FILTER_SIZE];  // Filters in global memory,
+                                                    // written by setup kernel.
 __device__ __constant__ float
     c_fbuf[2 * MAX_FILTER_SIZE *
-           MAX_FILTER_SIZE]; // Filters in constant memory, read by main
-                             // kernel.
+           MAX_FILTER_SIZE];  // Filters in constant memory, read by main
+                              // kernel.
 
 // Accessors to combined buffers to index up/down filters individually.
 #define c_fu (c_fbuf)
@@ -231,8 +235,7 @@ static __global__ void setup_filters_kernel(filtered_lrelu_kernel_params p) {
 static cudaError_t copy_filters(cudaStream_t stream) {
   void *src = 0;
   cudaError_t err = cudaGetSymbolAddress(&src, g_fbuf);
-  if (err)
-    return err;
+  if (err) return err;
   return cudaMemcpyToSymbolAsync(
       c_fbuf, src, 2 * MAX_FILTER_SIZE * MAX_FILTER_SIZE * sizeof(float), 0,
       cudaMemcpyDeviceToDevice, stream);
@@ -257,9 +260,9 @@ static cudaError_t copy_filters(cudaStream_t stream) {
 // - outY = tileOutY + relOutY
 
 extern __shared__ char
-    s_buf_raw[]; // When sharedKB <= 48, allocate shared memory statically
-                 // inside the kernel, otherwise use the externally allocated
-                 // shared memory buffer.
+    s_buf_raw[];  // When sharedKB <= 48, allocate shared memory statically
+                  // inside the kernel, otherwise use the externally allocated
+                  // shared memory buffer.
 
 template <class T, class index_t, int sharedKB, bool signWrite, bool signRead,
           int filterMode, int up, int fuSize, int down, int fdSize,
@@ -302,19 +305,20 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
   typedef typename InternalType<T>::vec2_t vec2_t;
   typedef typename InternalType<T>::vec4_t vec4_t;
   const int tileUpW = (tileOutW * down + (fdSize - 1) - (down - 1) + 3) &
-                      ~3; // Upsampled tile width, rounded up to multiple of 4.
+                      ~3;  // Upsampled tile width, rounded up to multiple of 4.
   const int tileUpH =
-      tileOutH * down + (fdSize - 1) - (down - 1); // Upsampled tile height.
-  const int tileInW = CEIL_DIV(tileUpW + (fuSize - 1), up); // Input tile width.
+      tileOutH * down + (fdSize - 1) - (down - 1);  // Upsampled tile height.
+  const int tileInW =
+      CEIL_DIV(tileUpW + (fuSize - 1), up);  // Input tile width.
   const int tileInH =
-      CEIL_DIV(tileUpH + (fuSize - 1), up); // Input tile height.
+      CEIL_DIV(tileUpH + (fuSize - 1), up);  // Input tile height.
   const int tileUpH_up =
       CEIL_DIV(tileUpH, up) *
-      up; // Upsampled tile height rounded up to a multiple of up.
+      up;  // Upsampled tile height rounded up to a multiple of up.
   const int tileInH_up =
       CEIL_DIV(tileUpH_up + (fuSize - 1),
-               up); // For allocations only, to avoid shared memory read
-                    // overruns with up=2 and up=4.
+               up);  // For allocations only, to avoid shared memory read
+                     // overruns with up=2 and up=4.
 
   // Merge 1x1 downsampling into last upsampling step for upf1 and ups2.
   const bool downInline =
@@ -328,25 +332,31 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
   const int szDownX = tileUpH * tileOutW;
 
   // Sizes for shared memory arrays.
-  const int s_buf0_size_base = (filterMode == MODE_SUSD)   ? MAX(szIn, szUpXY)
-                               : (filterMode == MODE_FUSD) ? MAX(szIn, szDownX)
-                               : (filterMode == MODE_SUFD) ? MAX(szIn, szUpXY)
-                               : (filterMode == MODE_FUFD) ? szIn
-                                                           : -1;
-  const int s_buf1_size_base = (filterMode == MODE_SUSD)   ? MAX(szUpX, szDownX)
-                               : (filterMode == MODE_FUSD) ? szUpXY
-                               : (filterMode == MODE_SUFD) ? szUpX
-                               : (filterMode == MODE_FUFD) ? szUpXY
-                                                           : -1;
+  const int s_buf0_size_base =
+      (filterMode == MODE_SUSD)
+          ? MAX(szIn, szUpXY)
+          : (filterMode == MODE_FUSD)
+                ? MAX(szIn, szDownX)
+                : (filterMode == MODE_SUFD)
+                      ? MAX(szIn, szUpXY)
+                      : (filterMode == MODE_FUFD) ? szIn : -1;
+  const int s_buf1_size_base =
+      (filterMode == MODE_SUSD)
+          ? MAX(szUpX, szDownX)
+          : (filterMode == MODE_FUSD)
+                ? szUpXY
+                : (filterMode == MODE_SUFD)
+                      ? szUpX
+                      : (filterMode == MODE_FUFD) ? szUpXY : -1;
 
   // Ensure U128 alignment.
   const int s_buf0_size = (s_buf0_size_base + 3) & ~3;
   const int s_buf1_size = (s_buf1_size_base + 3) & ~3;
 
   // Check at compile time that we don't use too much shared memory.
-  static_assert((s_buf0_size + s_buf1_size) * sizeof(scalar_t) <=
-                    (sharedKB << 10),
-                "shared memory overflow");
+  static_assert(
+      (s_buf0_size + s_buf1_size) * sizeof(scalar_t) <= (sharedKB << 10),
+      "shared memory overflow");
 
   // Declare shared memory arrays.
   scalar_t *s_buf0;
@@ -357,8 +367,8 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
         s_buf0_st[(sharedKB > 48)
                       ? (1 << 24)
                       : (s_buf0_size +
-                         s_buf1_size)]; // Prevent launching if this isn't
-                                        // optimized away when unused.
+                         s_buf1_size)];  // Prevent launching if this isn't
+                                         // optimized away when unused.
     s_buf0 = s_buf0_st;
     s_buf1 = s_buf0 + s_buf0_size;
   } else {
@@ -368,14 +378,14 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
   }
 
   // Pointers to the buffers.
-  scalar_t
-      *s_tileIn; // Input tile:                      [relInX * tileInH + relInY]
+  scalar_t *
+      s_tileIn;  // Input tile:                      [relInX * tileInH + relInY]
   scalar_t *s_tileUpX;   // After horizontal upsampling:     [relInY * tileUpW +
                          // relUpX]
   scalar_t *s_tileUpXY;  // After upsampling:                [relUpY * tileUpW +
                          // relUpX]
-  scalar_t *s_tileDownX; // After horizontal downsampling:   [relUpY * tileOutW
-                         // + relOutX]
+  scalar_t *s_tileDownX;  // After horizontal downsampling:   [relUpY * tileOutW
+                          // + relOutX]
   if (filterMode == MODE_SUSD) {
     s_tileIn = s_buf0;
     s_tileUpX = s_buf1;
@@ -456,14 +466,13 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
             b;
 
       bool skip = (loop == loopCountIN - 1) && (idx >= tileInW * tileInH);
-      if (!skip)
-        s_tileIn[idx] = v;
+      if (!skip) s_tileIn[idx] = v;
 
       idx += threadsPerBlock;
     }
 
     if (filterMode == MODE_SUSD ||
-        filterMode == MODE_SUFD) // Separable upsampling filter.
+        filterMode == MODE_SUFD)  // Separable upsampling filter.
     {
       // Horizontal upsampling.
       __syncthreads();
@@ -504,7 +513,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               a = s_tileIn[src0 + step + 1];
               v.w += a * (scalar_t)c_fu[step * up + 3];
             }
-          } else // (phaseInX == 3)
+          } else  // (phaseInX == 3)
           {
 #pragma unroll
             for (int step = 0; step < fuSize / up; step++) {
@@ -531,7 +540,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
           int dst = relInY * tileUpW + relUpX0;
           vec2_t v = InternalType<T>::zero_vec2();
           scalar_t a = s_tileIn[src0];
-          if (p0) // (phaseInX == 0)
+          if (p0)  // (phaseInX == 0)
           {
 #pragma unroll
             for (int step = 0; step < fuSize / up; step++) {
@@ -539,7 +548,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               a = s_tileIn[src0 + step + 1];
               v.y += a * (scalar_t)c_fu[step * up + 1];
             }
-          } else // (phaseInX == 1)
+          } else  // (phaseInX == 1)
           {
 #pragma unroll
             for (int step = 0; step < fuSize / up; step++) {
@@ -558,12 +567,12 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
       __syncthreads();
       int groupMask = 15 << ((threadIdx.x & 31) & ~3);
       int minY = tileOutY ? (tileOutY - tileOutH) * down + tileUpH
-                          : 0; // Skip already written signs.
+                          : 0;  // Skip already written signs.
       int sShapeMaxY =
           MIN(p.sShape.y,
-              tileOutY * down + tileUpH); // Avoid out-of-tile sign writes.
+              tileOutY * down + tileUpH);  // Avoid out-of-tile sign writes.
       if (up == 4) {
-        minY -= 3; // Adjust according to block height.
+        minY -= 3;  // Adjust according to block height.
         for (int idx = threadIdx.x; idx < tileUpW * tileUpH_up / up;
              idx += blockDim.x) {
           int relUpX, relInY0;
@@ -601,7 +610,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               a = s_tileUpX[src0 + (step + 1) * tileUpW];
               v.w += a * (scalar_t)c_fu[step * up + 3];
             }
-          } else // (phaseInY == 3)
+          } else  // (phaseInY == 3)
           {
 #pragma unroll
             for (int step = 0; step < fuSize / up; step++) {
@@ -637,14 +646,10 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               int sy = __float_as_uint(v.y) >> 31 << 8;
               int sz = __float_as_uint(v.z) >> 31 << 16;
               int sw = __float_as_uint(v.w) >> 31 << 24;
-              if (sx)
-                v.x *= p.slope;
-              if (sy)
-                v.y *= p.slope;
-              if (sz)
-                v.z *= p.slope;
-              if (sw)
-                v.w *= p.slope;
+              if (sx) v.x *= p.slope;
+              if (sy) v.y *= p.slope;
+              if (sz) v.z *= p.slope;
+              if (sw) v.w *= p.slope;
               if (fabsf(v.x) > p.clamp) {
                 sx = 2 << 0;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
@@ -690,14 +695,10 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 int sy = __float_as_uint(v.y) >> 31 << 8;
                 int sz = __float_as_uint(v.z) >> 31 << 16;
                 int sw = __float_as_uint(v.w) >> 31 << 24;
-                if (sx)
-                  v.x *= p.slope;
-                if (sy)
-                  v.y *= p.slope;
-                if (sz)
-                  v.z *= p.slope;
-                if (sw)
-                  v.w *= p.slope;
+                if (sx) v.x *= p.slope;
+                if (sy) v.y *= p.slope;
+                if (sz) v.z *= p.slope;
+                if (sw) v.w *= p.slope;
                 if (fabsf(v.x) > p.clamp) {
                   sx = 2 << 0;
                   v.x = InternalType<T>::clamp(v.x, p.clamp);
@@ -736,79 +737,60 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 }
               } else {
                 // Just compute the values.
-                if (v.x < 0.f)
-                  v.x *= p.slope;
+                if (v.x < 0.f) v.x *= p.slope;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
-                if (v.y < 0.f)
-                  v.y *= p.slope;
+                if (v.y < 0.f) v.y *= p.slope;
                 v.y = InternalType<T>::clamp(v.y, p.clamp);
-                if (v.z < 0.f)
-                  v.z *= p.slope;
+                if (v.z < 0.f) v.z *= p.slope;
                 v.z = InternalType<T>::clamp(v.z, p.clamp);
-                if (v.w < 0.f)
-                  v.w *= p.slope;
+                if (v.w < 0.f) v.w *= p.slope;
                 v.w = InternalType<T>::clamp(v.w, p.clamp);
               }
             }
-          } else if (signRead) // Read signs and apply.
+          } else if (signRead)  // Read signs and apply.
           {
             if ((uint32_t)signXb < p.swLimit) {
               int ss = (signX & 3) << 1;
               if ((uint32_t)(signY + 0) < p.sShape.y) {
                 int s = p.s[si0] >> ss;
-                if (s & 1)
-                  v.x *= p.slope;
-                if (s & 2)
-                  v.x = 0.f;
+                if (s & 1) v.x *= p.slope;
+                if (s & 2) v.x = 0.f;
               }
               if ((uint32_t)(signY + 1) < p.sShape.y) {
                 int s = p.s[si1] >> ss;
-                if (s & 1)
-                  v.y *= p.slope;
-                if (s & 2)
-                  v.y = 0.f;
+                if (s & 1) v.y *= p.slope;
+                if (s & 2) v.y = 0.f;
               }
               if ((uint32_t)(signY + 2) < p.sShape.y) {
                 int s = p.s[si2] >> ss;
-                if (s & 1)
-                  v.z *= p.slope;
-                if (s & 2)
-                  v.z = 0.f;
+                if (s & 1) v.z *= p.slope;
+                if (s & 2) v.z = 0.f;
               }
               if ((uint32_t)(signY + 3) < p.sShape.y) {
                 int s = p.s[si3] >> ss;
-                if (s & 1)
-                  v.w *= p.slope;
-                if (s & 2)
-                  v.w = 0.f;
+                if (s & 1) v.w *= p.slope;
+                if (s & 2) v.w = 0.f;
               }
             }
-          } else // Forward pass with no sign write.
+          } else  // Forward pass with no sign write.
           {
-            if (v.x < 0.f)
-              v.x *= p.slope;
+            if (v.x < 0.f) v.x *= p.slope;
             v.x = InternalType<T>::clamp(v.x, p.clamp);
-            if (v.y < 0.f)
-              v.y *= p.slope;
+            if (v.y < 0.f) v.y *= p.slope;
             v.y = InternalType<T>::clamp(v.y, p.clamp);
-            if (v.z < 0.f)
-              v.z *= p.slope;
+            if (v.z < 0.f) v.z *= p.slope;
             v.z = InternalType<T>::clamp(v.z, p.clamp);
-            if (v.w < 0.f)
-              v.w *= p.slope;
+            if (v.w < 0.f) v.w *= p.slope;
             v.w = InternalType<T>::clamp(v.w, p.clamp);
           }
 
           s_tileUpXY[dst + 0 * tileUpW] = v.x;
-          if (relUpY0 + 1 < tileUpH)
-            s_tileUpXY[dst + 1 * tileUpW] = v.y;
-          if (relUpY0 + 2 < tileUpH)
-            s_tileUpXY[dst + 2 * tileUpW] = v.z;
-          if (relUpY0 + 3 < tileUpH)
-            s_tileUpXY[dst + 3 * tileUpW] = v.w;
+          if (relUpY0 + 1 < tileUpH) s_tileUpXY[dst + 1 * tileUpW] = v.y;
+          if (relUpY0 + 2 < tileUpH) s_tileUpXY[dst + 2 * tileUpW] = v.z;
+          if (relUpY0 + 3 < tileUpH) s_tileUpXY[dst + 3 * tileUpW] = v.w;
         }
       } else if (up == 2) {
-        minY -= 1; // Adjust according to block height.
+        minY -= 1;  // Adjust according to block height.
         for (int idx = threadIdx.x; idx < tileUpW * tileUpH_up / up;
              idx += blockDim.x) {
           int relUpX, relInY0;
@@ -826,7 +808,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               a = s_tileUpX[src0 + (step + 1) * tileUpW];
               v.y += a * (scalar_t)c_fu[step * up + 1];
             }
-          } else // (phaseInY == 1)
+          } else  // (phaseInY == 1)
           {
 #pragma unroll
             for (int step = 0; step < fuSize / up; step++) {
@@ -854,10 +836,8 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               // Determine and write signs.
               int sx = __float_as_uint(v.x) >> 31 << 0;
               int sy = __float_as_uint(v.y) >> 31 << 8;
-              if (sx)
-                v.x *= p.slope;
-              if (sy)
-                v.y *= p.slope;
+              if (sx) v.x *= p.slope;
+              if (sy) v.y *= p.slope;
               if (fabsf(v.x) > p.clamp) {
                 sx = 2 << 0;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
@@ -887,10 +867,8 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               if ((uint32_t)signXb < p.swLimit && signY >= minY) {
                 int sx = __float_as_uint(v.x) >> 31 << 0;
                 int sy = __float_as_uint(v.y) >> 31 << 8;
-                if (sx)
-                  v.x *= p.slope;
-                if (sy)
-                  v.y *= p.slope;
+                if (sx) v.x *= p.slope;
+                if (sy) v.y *= p.slope;
                 if (fabsf(v.x) > p.clamp) {
                   sx = 2 << 0;
                   v.x = InternalType<T>::clamp(v.x, p.clamp);
@@ -915,47 +893,38 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 }
               } else {
                 // Just compute the values.
-                if (v.x < 0.f)
-                  v.x *= p.slope;
+                if (v.x < 0.f) v.x *= p.slope;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
-                if (v.y < 0.f)
-                  v.y *= p.slope;
+                if (v.y < 0.f) v.y *= p.slope;
                 v.y = InternalType<T>::clamp(v.y, p.clamp);
               }
             }
-          } else if (signRead) // Read signs and apply.
+          } else if (signRead)  // Read signs and apply.
           {
             if ((uint32_t)signXb < p.swLimit) {
               if ((uint32_t)(signY + 0) < p.sShape.y) {
                 int s = p.s[si0] >> signXo;
-                if (s & 1)
-                  v.x *= p.slope;
-                if (s & 2)
-                  v.x = 0.f;
+                if (s & 1) v.x *= p.slope;
+                if (s & 2) v.x = 0.f;
               }
               if ((uint32_t)(signY + 1) < p.sShape.y) {
                 int s = p.s[si1] >> signXo;
-                if (s & 1)
-                  v.y *= p.slope;
-                if (s & 2)
-                  v.y = 0.f;
+                if (s & 1) v.y *= p.slope;
+                if (s & 2) v.y = 0.f;
               }
             }
-          } else // Forward pass with no sign write.
+          } else  // Forward pass with no sign write.
           {
-            if (v.x < 0.f)
-              v.x *= p.slope;
+            if (v.x < 0.f) v.x *= p.slope;
             v.x = InternalType<T>::clamp(v.x, p.clamp);
-            if (v.y < 0.f)
-              v.y *= p.slope;
+            if (v.y < 0.f) v.y *= p.slope;
             v.y = InternalType<T>::clamp(v.y, p.clamp);
           }
 
           if (!downInline) {
             // Write into temporary buffer.
             s_tileUpXY[dst] = v.x;
-            if (relUpY0 < tileUpH - 1)
-              s_tileUpXY[dst + tileUpW] = v.y;
+            if (relUpY0 < tileUpH - 1) s_tileUpXY[dst + tileUpW] = v.y;
           } else {
             // Write directly into output buffer.
             if ((uint32_t)x < p.yShape.x) {
@@ -978,7 +947,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
         // 2 x 2-wide.
         __syncthreads();
         int minY = tileOutY ? (tileOutY - tileOutH) * down + tileUpH + p.sOfs.y
-                            : 0; // Skip already written signs.
+                            : 0;  // Skip already written signs.
         for (int idx = threadIdx.x * 4; idx < tileUpW * tileUpH;
              idx += blockDim.x * 4) {
           int relUpX0, relUpY0;
@@ -988,24 +957,24 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
           int src0 = relInX0 + tileInW * relInY0;
           int tap0y = (relInY0 * up + phaseInY - relUpY0);
 
-#define X_LOOP(TAPY, PX)                                                       \
-  for (int sx = 0; sx < fuSize / up; sx++) {                                   \
-    v.x += a * (scalar_t)c_fu[(sx * up + (((PX)-0) & (up - 1))) +              \
-                              (sy * up + (TAPY)) * MAX_FILTER_SIZE];           \
-    v.z += b * (scalar_t)c_fu[(sx * up + (((PX)-0) & (up - 1))) +              \
-                              (sy * up + (TAPY)) * MAX_FILTER_SIZE];           \
-    if ((PX) == 0) {                                                           \
-      a = b;                                                                   \
-      b = s_tileIn[src0 + 2 + sx + sy * tileInW];                              \
-    }                                                                          \
-    v.y += a * (scalar_t)c_fu[(sx * up + (((PX)-1) & (up - 1))) +              \
-                              (sy * up + (TAPY)) * MAX_FILTER_SIZE];           \
-    v.w += b * (scalar_t)c_fu[(sx * up + (((PX)-1) & (up - 1))) +              \
-                              (sy * up + (TAPY)) * MAX_FILTER_SIZE];           \
-    if ((PX) == 1) {                                                           \
-      a = b;                                                                   \
-      b = s_tileIn[src0 + 2 + sx + sy * tileInW];                              \
-    }                                                                          \
+#define X_LOOP(TAPY, PX)                                             \
+  for (int sx = 0; sx < fuSize / up; sx++) {                         \
+    v.x += a * (scalar_t)c_fu[(sx * up + (((PX)-0) & (up - 1))) +    \
+                              (sy * up + (TAPY)) * MAX_FILTER_SIZE]; \
+    v.z += b * (scalar_t)c_fu[(sx * up + (((PX)-0) & (up - 1))) +    \
+                              (sy * up + (TAPY)) * MAX_FILTER_SIZE]; \
+    if ((PX) == 0) {                                                 \
+      a = b;                                                         \
+      b = s_tileIn[src0 + 2 + sx + sy * tileInW];                    \
+    }                                                                \
+    v.y += a * (scalar_t)c_fu[(sx * up + (((PX)-1) & (up - 1))) +    \
+                              (sy * up + (TAPY)) * MAX_FILTER_SIZE]; \
+    v.w += b * (scalar_t)c_fu[(sx * up + (((PX)-1) & (up - 1))) +    \
+                              (sy * up + (TAPY)) * MAX_FILTER_SIZE]; \
+    if ((PX) == 1) {                                                 \
+      a = b;                                                         \
+      b = s_tileIn[src0 + 2 + sx + sy * tileInW];                    \
+    }                                                                \
   }
 
           vec4_t v = InternalType<T>::zero_vec4();
@@ -1065,26 +1034,22 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               int sy = __float_as_uint(v.y) >> 31;
               int sz = __float_as_uint(v.z) >> 31;
               int sw = __float_as_uint(v.w) >> 31;
-              if (sx)
-                v.x *= p.slope;
+              if (sx) v.x *= p.slope;
               if (fabsf(v.x) > p.clamp) {
                 sx = 2;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
               }
-              if (sy)
-                v.y *= p.slope;
+              if (sy) v.y *= p.slope;
               if (fabsf(v.y) > p.clamp) {
                 sy = 2;
                 v.y = InternalType<T>::clamp(v.y, p.clamp);
               }
-              if (sz)
-                v.z *= p.slope;
+              if (sz) v.z *= p.slope;
               if (fabsf(v.z) > p.clamp) {
                 sz = 2;
                 v.z = InternalType<T>::clamp(v.z, p.clamp);
               }
-              if (sw)
-                v.w *= p.slope;
+              if (sw) v.w *= p.slope;
               if (fabsf(v.w) > p.clamp) {
                 sw = 2;
                 v.w = InternalType<T>::clamp(v.w, p.clamp);
@@ -1102,26 +1067,22 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 int sy = __float_as_uint(v.y) >> 31;
                 int sz = __float_as_uint(v.z) >> 31;
                 int sw = __float_as_uint(v.w) >> 31;
-                if (sx)
-                  v.x *= p.slope;
+                if (sx) v.x *= p.slope;
                 if (fabsf(v.x) > p.clamp) {
                   sx = 2;
                   v.x = InternalType<T>::clamp(v.x, p.clamp);
                 }
-                if (sy)
-                  v.y *= p.slope;
+                if (sy) v.y *= p.slope;
                 if (fabsf(v.y) > p.clamp) {
                   sy = 2;
                   v.y = InternalType<T>::clamp(v.y, p.clamp);
                 }
-                if (sz)
-                  v.z *= p.slope;
+                if (sz) v.z *= p.slope;
                 if (fabsf(v.z) > p.clamp) {
                   sz = 2;
                   v.z = InternalType<T>::clamp(v.z, p.clamp);
                 }
-                if (sw)
-                  v.w *= p.slope;
+                if (sw) v.w *= p.slope;
                 if (fabsf(v.w) > p.clamp) {
                   sw = 2;
                   v.w = InternalType<T>::clamp(v.w, p.clamp);
@@ -1130,59 +1091,41 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 p.s[si] = sx + (sy << 2) + (sz << 4) + (sw << 6);
               } else {
                 // Just compute the values.
-                if (v.x < 0.f)
-                  v.x *= p.slope;
+                if (v.x < 0.f) v.x *= p.slope;
                 v.x = InternalType<T>::clamp(v.x, p.clamp);
-                if (v.y < 0.f)
-                  v.y *= p.slope;
+                if (v.y < 0.f) v.y *= p.slope;
                 v.y = InternalType<T>::clamp(v.y, p.clamp);
-                if (v.z < 0.f)
-                  v.z *= p.slope;
+                if (v.z < 0.f) v.z *= p.slope;
                 v.z = InternalType<T>::clamp(v.z, p.clamp);
-                if (v.w < 0.f)
-                  v.w *= p.slope;
+                if (v.w < 0.f) v.w *= p.slope;
                 v.w = InternalType<T>::clamp(v.w, p.clamp);
               }
             }
-          } else if (signRead) // Read sign and apply.
+          } else if (signRead)  // Read sign and apply.
           {
             if ((uint32_t)signY < p.sShape.y) {
               int s = 0;
-              if ((uint32_t)signXb < p.swLimit)
-                s = p.s[si];
-              if ((uint32_t)signXb + 1 < p.swLimit)
-                s |= p.s[si + 1] << 8;
+              if ((uint32_t)signXb < p.swLimit) s = p.s[si];
+              if ((uint32_t)signXb + 1 < p.swLimit) s |= p.s[si + 1] << 8;
               s >>= (signX & 3) << 1;
-              if (s & 0x01)
-                v.x *= p.slope;
-              if (s & 0x02)
-                v.x = 0.f;
-              if (s & 0x04)
-                v.y *= p.slope;
-              if (s & 0x08)
-                v.y = 0.f;
-              if (s & 0x10)
-                v.z *= p.slope;
-              if (s & 0x20)
-                v.z = 0.f;
-              if (s & 0x40)
-                v.w *= p.slope;
-              if (s & 0x80)
-                v.w = 0.f;
+              if (s & 0x01) v.x *= p.slope;
+              if (s & 0x02) v.x = 0.f;
+              if (s & 0x04) v.y *= p.slope;
+              if (s & 0x08) v.y = 0.f;
+              if (s & 0x10) v.z *= p.slope;
+              if (s & 0x20) v.z = 0.f;
+              if (s & 0x40) v.w *= p.slope;
+              if (s & 0x80) v.w = 0.f;
             }
-          } else // Forward pass with no sign write.
+          } else  // Forward pass with no sign write.
           {
-            if (v.x < 0.f)
-              v.x *= p.slope;
+            if (v.x < 0.f) v.x *= p.slope;
             v.x = InternalType<T>::clamp(v.x, p.clamp);
-            if (v.y < 0.f)
-              v.y *= p.slope;
+            if (v.y < 0.f) v.y *= p.slope;
             v.y = InternalType<T>::clamp(v.y, p.clamp);
-            if (v.z < 0.f)
-              v.z *= p.slope;
+            if (v.z < 0.f) v.z *= p.slope;
             v.z = InternalType<T>::clamp(v.z, p.clamp);
-            if (v.w < 0.f)
-              v.w *= p.slope;
+            if (v.w < 0.f) v.w *= p.slope;
             v.w = InternalType<T>::clamp(v.w, p.clamp);
           }
 
@@ -1195,12 +1138,12 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
         __syncthreads();
         uint32_t groupMask = 15 << ((threadIdx.x & 31) & ~3);
         int minY = tileOutY ? (tileOutY - tileOutH) * down + tileUpH
-                            : 0; // Skip already written signs.
+                            : 0;  // Skip already written signs.
         for (int idx = threadIdx.x; idx < tileUpW * tileUpH;
              idx += blockDim.x) {
           int relUpX0, relUpY0;
           fast_div_mod<tileUpW>(relUpX0, relUpY0, idx);
-          scalar_t v = s_tileIn[idx] * (scalar_t)c_fu[0]; // 1x1 filter.
+          scalar_t v = s_tileIn[idx] * (scalar_t)c_fu[0];  // 1x1 filter.
 
           int x = tileOutX * down + relUpX0;
           int y = tileOutY * down + relUpY0;
@@ -1227,9 +1170,9 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               }
               if ((uint32_t)signXb < p.swLimit &&
                   (uint32_t)signY < p.sShape.y && signY >= minY) {
-                s += __shfl_xor_sync(groupMask, s, 1); // Coalesce.
-                s += __shfl_xor_sync(groupMask, s, 2); // Coalesce.
-                p.s[si] = s;                           // Write.
+                s += __shfl_xor_sync(groupMask, s, 1);  // Coalesce.
+                s += __shfl_xor_sync(groupMask, s, 2);  // Coalesce.
+                p.s[si] = s;                            // Write.
               }
             } else {
               // Determine and write sign.
@@ -1245,13 +1188,12 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                   s = signXbit * 2;
                   v = InternalType<T>::clamp(v, p.clamp);
                 }
-                s += __shfl_xor_sync(groupMask, s, 1); // Coalesce.
-                s += __shfl_xor_sync(groupMask, s, 2); // Coalesce.
-                p.s[si] = s;                           // Write.
+                s += __shfl_xor_sync(groupMask, s, 1);  // Coalesce.
+                s += __shfl_xor_sync(groupMask, s, 2);  // Coalesce.
+                p.s[si] = s;                            // Write.
               } else {
                 // Just compute the value.
-                if (v < 0.f)
-                  v *= p.slope;
+                if (v < 0.f) v *= p.slope;
                 v = InternalType<T>::clamp(v, p.clamp);
               }
             }
@@ -1260,23 +1202,20 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
             if ((uint32_t)signXb < p.swLimit && (uint32_t)signY < p.sShape.y) {
               int s = p.s[si];
               s >>= signXo;
-              if (s & 1)
-                v *= p.slope;
-              if (s & 2)
-                v = 0.f;
+              if (s & 1) v *= p.slope;
+              if (s & 2) v = 0.f;
             }
-          } else // Forward pass with no sign write.
+          } else  // Forward pass with no sign write.
           {
-            if (v < 0.f)
-              v *= p.slope;
+            if (v < 0.f) v *= p.slope;
             v = InternalType<T>::clamp(v, p.clamp);
           }
 
-          if (!downInline) // Write into temporary buffer.
+          if (!downInline)  // Write into temporary buffer.
             s_tileUpXY[idx] = v;
           else if ((uint32_t)x < p.yShape.x &&
                    (uint32_t)y <
-                       p.yShape.y) // Write directly into output buffer
+                       p.yShape.y)  // Write directly into output buffer
             *((T *)((char *)p.y + (x * get_stride<index_t>(p.yStride.x) +
                                    y * get_stride<index_t>(p.yStride.y) +
                                    mapOfsOut))) = (T)(v * (scalar_t)c_fd[0]);
@@ -1391,8 +1330,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
           if ((uint32_t)outY < p.yShape.y) {
             index_t ofs = outX * get_stride<index_t>(p.yStride.x) +
                           outY * get_stride<index_t>(p.yStride.y) + mapOfsOut;
-            if (outX + 0 < p.yShape.x)
-              *((T *)((char *)p.y + ofs)) = (T)v.x;
+            if (outX + 0 < p.yShape.x) *((T *)((char *)p.y + ofs)) = (T)v.x;
             if (outX + 1 < p.yShape.x)
               *((T *)((char *)p.y + ofs + get_stride<index_t>(p.yStride.x))) =
                   (T)v.y;
@@ -1405,7 +1343,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
              idx += blockDim.x) {
           int relOutX0, relOutY0;
           fast_div_mod<tileOutW>(relOutX0, relOutY0, idx);
-          scalar_t v = s_tileUpXY[idx] * (scalar_t)c_fd[0]; // 1x1 filter.
+          scalar_t v = s_tileUpXY[idx] * (scalar_t)c_fd[0];  // 1x1 filter.
 
           int outX = tileOutX + relOutX0;
           int outY = tileOutY + relOutY0;
@@ -1417,8 +1355,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
       }
     }
 
-    if (!enableXrep)
-      break;
+    if (!enableXrep) break;
   }
 }
 
@@ -1429,15 +1366,15 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
 // 64-bit indexing is always used.
 
 template <class T, bool signWrite, bool signRead>
-static __global__ void
-filtered_lrelu_act_kernel(filtered_lrelu_act_kernel_params p) {
+static __global__ void filtered_lrelu_act_kernel(
+    filtered_lrelu_act_kernel_params p) {
   typedef typename InternalType<T>::scalar_t scalar_t;
 
   // Indexing.
   int32_t x = threadIdx.x + blockIdx.x * blockDim.x;
   int32_t ymax = signWrite ? p.sShape.y : p.xShape.y;
   int32_t qmax =
-      p.xShape.z * p.xShape.w; // Combined minibatch*channel maximum index.
+      p.xShape.z * p.xShape.w;  // Combined minibatch*channel maximum index.
 
   // Loop to accommodate oversized tensors.
   for (int32_t q = blockIdx.z; q < qmax; q += gridDim.z)
@@ -1460,34 +1397,34 @@ filtered_lrelu_act_kernel(filtered_lrelu_act_kernel_params p) {
           v *= p.gain;
           if (v < 0.f) {
             v *= p.slope;
-            s = 1; // Sign.
+            s = 1;  // Sign.
           }
           if (fabsf(v) > p.clamp) {
             v = InternalType<T>::clamp(v, p.clamp);
-            s = 2; // Clamp.
+            s = 2;  // Clamp.
           }
 
-          *pv = (T)v; // Write value.
+          *pv = (T)v;  // Write value.
         }
 
         // Coalesce into threads 0 and 16 of warp.
         uint32_t m = (threadIdx.x & 16) ? 0xffff0000u : 0x0000ffffu;
-        s <<= ((threadIdx.x & 15) << 1); // Shift into place.
-        s |= __shfl_xor_sync(m, s, 1);   // Distribute.
+        s <<= ((threadIdx.x & 15) << 1);  // Shift into place.
+        s |= __shfl_xor_sync(m, s, 1);    // Distribute.
         s |= __shfl_xor_sync(m, s, 2);
         s |= __shfl_xor_sync(m, s, 4);
         s |= __shfl_xor_sync(m, s, 8);
 
         // Write signs if leader and in p.s.
-        if (!(threadIdx.x & 15) && x < p.sShape.x) // y is always in.
+        if (!(threadIdx.x & 15) && x < p.sShape.x)  // y is always in.
         {
           uint64_t is =
-              x + p.sShape.x * (y + (int64_t)p.sShape.y * q); // Contiguous.
+              x + p.sShape.x * (y + (int64_t)p.sShape.y * q);  // Contiguous.
           ((uint32_t *)p.s)[is >> 4] = s;
         }
       } else if (signRead) {
         // Process value if in p.x.
-        if (x < p.xShape.x) // y is always in.
+        if (x < p.xShape.x)  // y is always in.
         {
           int64_t ix = x * p.xStride.x + y * p.xStride.y + z * p.xStride.z +
                        w * p.xStride.w;
@@ -1503,31 +1440,29 @@ filtered_lrelu_act_kernel(filtered_lrelu_act_kernel_params p) {
           if (sx < p.sShape.x && sy < p.sShape.y) {
             uint64_t is =
                 (sx >> 2) + (p.sShape.x >> 2) *
-                                (sy + (uint64_t)p.sShape.y * q); // Contiguous.
+                                (sy + (uint64_t)p.sShape.y * q);  // Contiguous.
             unsigned char s = p.s[is];
-            s >>= (sx & 3) << 1; // Shift into place.
-            if (s & 1)           // Sign?
+            s >>= (sx & 3) << 1;  // Shift into place.
+            if (s & 1)            // Sign?
               v *= p.slope;
-            if (s & 2) // Clamp?
+            if (s & 2)  // Clamp?
               v = 0.f;
           }
 
-          *pv = (T)v; // Write value.
+          *pv = (T)v;  // Write value.
         }
       } else {
         // Forward pass with no sign write. Process value if in p.x.
-        if (x < p.xShape.x) // y is always in.
+        if (x < p.xShape.x)  // y is always in.
         {
           int64_t ix = x * p.xStride.x + y * p.xStride.y + z * p.xStride.z +
                        w * p.xStride.w;
           T *pv = ((T *)p.x) + ix;
           scalar_t v = (scalar_t)(*pv);
           v *= p.gain;
-          if (v < 0.f)
-            v *= p.slope;
-          if (fabsf(v) > p.clamp)
-            v = InternalType<T>::clamp(v, p.clamp);
-          *pv = (T)v; // Write value.
+          if (v < 0.f) v *= p.slope;
+          if (fabsf(v) > p.clamp) v = InternalType<T>::clamp(v, p.clamp);
+          *pv = (T)v;  // Write value.
         }
       }
     }
@@ -1542,9 +1477,8 @@ void *choose_filtered_lrelu_act_kernel(void) {
 // CUDA kernel selection.
 
 template <class T, class index_t, bool signWrite, bool signRead>
-filtered_lrelu_kernel_spec
-choose_filtered_lrelu_kernel(const filtered_lrelu_kernel_params &p,
-                             int sharedKB) {
+filtered_lrelu_kernel_spec choose_filtered_lrelu_kernel(
+    const filtered_lrelu_kernel_params &p, int sharedKB) {
   filtered_lrelu_kernel_spec s = {0};
 
   // Return the first matching kernel.
@@ -1581,70 +1515,70 @@ choose_filtered_lrelu_kernel(const filtered_lrelu_kernel_params &p,
   // must be listed before those that use less, for the same reason.
 
   CASE(/*sharedKB*/ 48, /*up,fu*/ 1, 1, /*down,fd*/ 1, 1, /*mode*/ MODE_FUFD,
-       /*tw,th,warps,xrep,wskip*/ 64, 178, 32, 0, 0) // 1t-upf1-downf1
+       /*tw,th,warps,xrep,wskip*/ 64, 178, 32, 0, 0)  // 1t-upf1-downf1
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 1, 1, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 152, 95, 16, 0, 0) // 4t-ups2-downf1
+       /*tw,th,warps,xrep,wskip*/ 152, 95, 16, 0, 0)  // 4t-ups2-downf1
   CASE(/*sharedKB*/ 48, /*up,fu*/ 1, 1, /*down,fd*/ 2, 8, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 56, 22, 16, 0, 0) // 4t-upf1-downs2
+       /*tw,th,warps,xrep,wskip*/ 56, 22, 16, 0, 0)  // 4t-upf1-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 2, 8, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 56, 29, 16, 11, 0) // 4t-ups2-downs2
+       /*tw,th,warps,xrep,wskip*/ 56, 29, 16, 11, 0)  // 4t-ups2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 2, 8, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 60, 28, 16, 0, 0) // 4t-upf2-downs2
+       /*tw,th,warps,xrep,wskip*/ 60, 28, 16, 0, 0)  // 4t-upf2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 2, 8, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 56, 28, 16, 0, 0) // 4t-ups2-downf2
+       /*tw,th,warps,xrep,wskip*/ 56, 28, 16, 0, 0)  // 4t-ups2-downf2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 16, /*down,fd*/ 2, 8, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 56, 31, 16, 11, 0) // 4t-ups4-downs2
+       /*tw,th,warps,xrep,wskip*/ 56, 31, 16, 11, 0)  // 4t-ups4-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 16, /*down,fd*/ 2, 8, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 56, 36, 16, 0, 0) // 4t-ups4-downf2
+       /*tw,th,warps,xrep,wskip*/ 56, 36, 16, 0, 0)  // 4t-ups4-downf2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 4, 16, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 16, 22, 16, 12, 0) // 4t-ups2-downs4
+       /*tw,th,warps,xrep,wskip*/ 16, 22, 16, 12, 0)  // 4t-ups2-downs4
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 8, /*down,fd*/ 4, 16, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 29, 15, 16, 0, 0) // 4t-upf2-downs4
+       /*tw,th,warps,xrep,wskip*/ 29, 15, 16, 0, 0)  // 4t-upf2-downs4
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 1, 1, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 96, 150, 28, 0, 0) // 6t-ups2-downf1
+       /*tw,th,warps,xrep,wskip*/ 96, 150, 28, 0, 0)  // 6t-ups2-downf1
   CASE(/*sharedKB*/ 48, /*up,fu*/ 1, 1, /*down,fd*/ 2, 12, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 35, 24, 0, 0) // 6t-upf1-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 35, 24, 0, 0)  // 6t-upf1-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 2, 12, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 46, 16, 10, 0) // 6t-ups2-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 46, 16, 10, 0)  // 6t-ups2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 2, 12, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 58, 28, 24, 8, 0) // 6t-upf2-downs2
+       /*tw,th,warps,xrep,wskip*/ 58, 28, 24, 8, 0)  // 6t-upf2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 2, 12, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 52, 28, 16, 0, 0) // 6t-ups2-downf2
+       /*tw,th,warps,xrep,wskip*/ 52, 28, 16, 0, 0)  // 6t-ups2-downf2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 24, /*down,fd*/ 2, 12, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 51, 16, 5, 0) // 6t-ups4-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 51, 16, 5, 0)  // 6t-ups4-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 24, /*down,fd*/ 2, 12, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 32, 56, 16, 6, 0) // 6t-ups4-downf2
+       /*tw,th,warps,xrep,wskip*/ 32, 56, 16, 6, 0)  // 6t-ups4-downf2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 4, 24, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 16, 18, 16, 12, 0) // 6t-ups2-downs4
+       /*tw,th,warps,xrep,wskip*/ 16, 18, 16, 12, 0)  // 6t-ups2-downs4
   CASE(/*sharedKB*/ 96, /*up,fu*/ 2, 12, /*down,fd*/ 4, 24, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 27, 31, 32, 6, 0) // 6t-upf2-downs4 96kB
+       /*tw,th,warps,xrep,wskip*/ 27, 31, 32, 6, 0)  // 6t-upf2-downs4 96kB
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 12, /*down,fd*/ 4, 24, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 27, 13, 24, 0, 0) // 6t-upf2-downs4
+       /*tw,th,warps,xrep,wskip*/ 27, 13, 24, 0, 0)  // 6t-upf2-downs4
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 1, 1, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 148, 89, 24, 0, 0) // 8t-ups2-downf1
+       /*tw,th,warps,xrep,wskip*/ 148, 89, 24, 0, 0)  // 8t-ups2-downf1
   CASE(/*sharedKB*/ 48, /*up,fu*/ 1, 1, /*down,fd*/ 2, 16, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 31, 16, 5, 0) // 8t-upf1-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 31, 16, 5, 0)  // 8t-upf1-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 2, 16, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 41, 16, 9, 0) // 8t-ups2-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 41, 16, 9, 0)  // 8t-ups2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 2, 16, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 56, 26, 24, 0, 0) // 8t-upf2-downs2
+       /*tw,th,warps,xrep,wskip*/ 56, 26, 24, 0, 0)  // 8t-upf2-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 2, 16, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 32, 40, 16, 0, 0) // 8t-ups2-downf2
+       /*tw,th,warps,xrep,wskip*/ 32, 40, 16, 0, 0)  // 8t-ups2-downf2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 32, /*down,fd*/ 2, 16, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 32, 46, 24, 5, 0) // 8t-ups4-downs2
+       /*tw,th,warps,xrep,wskip*/ 32, 46, 24, 5, 0)  // 8t-ups4-downs2
   CASE(/*sharedKB*/ 48, /*up,fu*/ 4, 32, /*down,fd*/ 2, 16, /*mode*/ MODE_SUFD,
-       /*tw,th,warps,xrep,wskip*/ 32, 50, 16, 0, 0) // 8t-ups4-downf2
+       /*tw,th,warps,xrep,wskip*/ 32, 50, 16, 0, 0)  // 8t-ups4-downf2
   CASE(/*sharedKB*/ 96, /*up,fu*/ 2, 16, /*down,fd*/ 4, 32, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 24, 24, 32, 12, 1) // 8t-ups2-downs4 96kB
+       /*tw,th,warps,xrep,wskip*/ 24, 24, 32, 12, 1)  // 8t-ups2-downs4 96kB
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 4, 32, /*mode*/ MODE_SUSD,
-       /*tw,th,warps,xrep,wskip*/ 16, 13, 16, 10, 1) // 8t-ups2-downs4
+       /*tw,th,warps,xrep,wskip*/ 16, 13, 16, 10, 1)  // 8t-ups2-downs4
   CASE(/*sharedKB*/ 96, /*up,fu*/ 2, 16, /*down,fd*/ 4, 32, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 25, 28, 28, 4, 0) // 8t-upf2-downs4 96kB
+       /*tw,th,warps,xrep,wskip*/ 25, 28, 28, 4, 0)  // 8t-upf2-downs4 96kB
   CASE(/*sharedKB*/ 48, /*up,fu*/ 2, 16, /*down,fd*/ 4, 32, /*mode*/ MODE_FUSD,
-       /*tw,th,warps,xrep,wskip*/ 25, 10, 24, 0, 0) // 8t-upf2-downs4
+       /*tw,th,warps,xrep,wskip*/ 25, 10, 24, 0, 0)  // 8t-upf2-downs4
 
 #undef CASE
-  return s; // No kernel found.
+  return s;  // No kernel found.
 }
 
 //------------------------------------------------------------------------
@@ -1659,12 +1593,11 @@ choose_filtered_lrelu_kernel(const filtered_lrelu_kernel_params &p,
 #endif
 
 #if BUILD_FILTERED_LRELU_OP == 1
-std::tuple<torch::Tensor, torch::Tensor, int>
-filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
-                  torch::Tensor b, torch::Tensor si, int up, int down, int px0,
-                  int px1, int py0, int py1, int sx, int sy, float gain,
-                  float slope, float clamp, bool flip_filters,
-                  bool writeSigns) {
+std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
+    torch::Tensor x, torch::Tensor fu, torch::Tensor fd, torch::Tensor b,
+    torch::Tensor si, int up, int down, int px0, int px1, int py0, int py1,
+    int sx, int sy, float gain, float slope, float clamp, bool flip_filters,
+    bool writeSigns) {
   // Set CUDA device.
   TORCH_CHECK(x.is_cuda(), "x must reside on CUDA device");
   const at::cuda::OptionalCUDAGuard device_guard(device_of(x));
@@ -1683,9 +1616,9 @@ filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
                   x.size(3) <= INT_MAX,
               "x is too large");
   TORCH_CHECK(x.numel() > 0, "x is empty");
-  TORCH_CHECK((fu.dim() == 1 || fu.dim() == 2) &&
-                  (fd.dim() == 1 || fd.dim() == 2),
-              "fu and fd must be rank 1 or 2");
+  TORCH_CHECK(
+      (fu.dim() == 1 || fu.dim() == 2) && (fd.dim() == 1 || fd.dim() == 2),
+      "fu and fd must be rank 1 or 2");
   TORCH_CHECK(fu.size(0) <= INT_MAX && fu.size(-1) <= INT_MAX,
               "fu is too large");
   TORCH_CHECK(fd.size(0) <= INT_MAX && fd.size(-1) <= INT_MAX,
@@ -1710,7 +1643,7 @@ filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
   p.fuShape =
       make_int2((int)fu.size(-1),
                 fu.dim() == 2 ? (int)fu.size(0)
-                              : 0); // shape [n, 0] indicates separable filter.
+                              : 0);  // shape [n, 0] indicates separable filter.
   p.fdShape = make_int2((int)fd.size(-1), fd.dim() == 2 ? (int)fd.size(0) : 0);
   filtered_lrelu_kernel_spec test_spec =
       choose_filtered_lrelu_kernel<float, int32_t, false, false>(p, sharedKB);
@@ -1751,12 +1684,12 @@ filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
   torch::Tensor so;
   torch::Tensor s = si;
   bool readSigns = !!s.numel();
-  int64_t sw_active = 0; // Active width of sign tensor.
+  int64_t sw_active = 0;  // Active width of sign tensor.
   if (writeSigns) {
-    sw_active = yw * down - (down - 1) + fdt_w;  // Active width in elements.
-    int64_t sh = yh * down - (down - 1) + fdt_h; // Height = active height.
-    int64_t sw = (sw_active + 15) & ~15; // Width  = active width in elements,
-                                         // rounded up to multiple of 16.
+    sw_active = yw * down - (down - 1) + fdt_w;   // Active width in elements.
+    int64_t sh = yh * down - (down - 1) + fdt_h;  // Height = active height.
+    int64_t sw = (sw_active + 15) & ~15;  // Width  = active width in elements,
+                                          // rounded up to multiple of 16.
     TORCH_CHECK(sh <= INT_MAX && (sw >> 2) <= INT_MAX, "signs is too large");
     s = so = torch::empty({x.size(0), x.size(1), sh, sw >> 2},
                           x.options().dtype(torch::kUInt8),
@@ -1795,9 +1728,9 @@ filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
       make_int4((int)y.size(3), (int)y.size(2), (int)y.size(1), (int)y.size(0));
   p.sShape = (readSigns || writeSigns)
                  ? make_int2((int)s.size(3), (int)s.size(2))
-                 : make_int2(0, 0); // Width is in bytes. Contiguous.
+                 : make_int2(0, 0);  // Width is in bytes. Contiguous.
   p.sOfs = make_int2(sx, sy);
-  p.swLimit = (sw_active + 3) >> 2; // Rounded up to bytes.
+  p.swLimit = (sw_active + 3) >> 2;  // Rounded up to bytes.
 
   // x, y, b strides are in bytes.
   p.xStride = make_longlong4(sz * x.stride(3), sz * x.stride(2),
@@ -1815,8 +1748,7 @@ filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
   // Determine if indices don't fit in int32. Support negative strides although
   // Torch currently never produces those.
   bool index64b = false;
-  if (std::abs(p.bStride * x.size(1)) > INT_MAX)
-    index64b = true;
+  if (std::abs(p.bStride * x.size(1)) > INT_MAX) index64b = true;
   if (std::min(x.size(0) * p.xStride.w, 0ll) +
           std::min(x.size(1) * p.xStride.z, 0ll) +
           std::min(x.size(2) * p.xStride.y, 0ll) +
@@ -1841,15 +1773,15 @@ filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
           std::max(y.size(3) * p.yStride.x, 0ll) >
       INT_MAX)
     index64b = true;
-  if (s.numel() > INT_MAX)
-    index64b = true;
+  if (s.numel() > INT_MAX) index64b = true;
 
   // Choose CUDA kernel.
   filtered_lrelu_kernel_spec spec = {0};
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       x.scalar_type(), "filtered_lrelu_cuda", [&] {
-        if constexpr (sizeof(scalar_t) <= 4) // Exclude doubles. constexpr
-                                             // prevents template instantiation.
+        if constexpr (sizeof(scalar_t) <=
+                      4)  // Exclude doubles. constexpr
+                          // prevents template instantiation.
         {
           // Choose kernel based on index type, datatype and sign read/write
           // modes.
@@ -1877,9 +1809,9 @@ filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
       });
   TORCH_CHECK(
       spec.exec,
-      "internal error - CUDA kernel not found") // This should not happen
-                                                // because we tested earlier
-                                                // that kernel exists.
+      "internal error - CUDA kernel not found")  // This should not happen
+                                                 // because we tested earlier
+                                                 // that kernel exists.
 
   // Launch CUDA kernel.
   void *args[] = {&p};
@@ -1914,7 +1846,7 @@ filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
 
   // Set cache and shared memory configurations for main kernel.
   AT_CUDA_CHECK(cudaFuncSetCacheConfig(spec.exec, cudaFuncCachePreferShared));
-  if (spec.dynamicSharedKB) // Need dynamically allocated shared memory?
+  if (spec.dynamicSharedKB)  // Need dynamically allocated shared memory?
     AT_CUDA_CHECK(cudaFuncSetAttribute(
         spec.exec, cudaFuncAttributeMaxDynamicSharedMemorySize,
         spec.dynamicSharedKB << 10));
@@ -1922,9 +1854,9 @@ filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
       cudaFuncSetSharedMemConfig(spec.exec, cudaSharedMemBankSizeFourByte));
 
   // Launch main kernel.
-  const int maxSubGz = 65535; // CUDA maximum for block z dimension.
+  const int maxSubGz = 65535;  // CUDA maximum for block z dimension.
   for (int zofs = 0; zofs < gz;
-       zofs += maxSubGz) // Do multiple launches if gz is too big.
+       zofs += maxSubGz)  // Do multiple launches if gz is too big.
   {
     p.blockZofs = zofs;
     int subGz = std::min(maxSubGz, gz - zofs);
@@ -1937,14 +1869,14 @@ filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
   return std::make_tuple(y, so, 0);
 }
 #else
-std::tuple<torch::Tensor, torch::Tensor, int>
-filtered_lrelu_op(torch::Tensor x, torch::Tensor fu, torch::Tensor fd,
-                  torch::Tensor b, torch::Tensor si, int up, int down, int px0,
-                  int px1, int py0, int py1, int sx, int sy, float gain,
-                  float slope, float clamp, bool flip_filters,
-                  bool writeSigns) {
-  TORCH_CHECK(false, "filtered_lrelu_op is not available. Please update your "
-                     "compiler and try again.");
+std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
+    torch::Tensor x, torch::Tensor fu, torch::Tensor fd, torch::Tensor b,
+    torch::Tensor si, int up, int down, int px0, int px1, int py0, int py1,
+    int sx, int sy, float gain, float slope, float clamp, bool flip_filters,
+    bool writeSigns) {
+  TORCH_CHECK(false,
+              "filtered_lrelu_op is not available. Please update your "
+              "compiler and try again.");
   return std::tuple<torch::Tensor, torch::Tensor, int>();
 }
 #endif
@@ -1975,7 +1907,7 @@ torch::Tensor filtered_lrelu_act_op(torch::Tensor x, torch::Tensor si, int sx,
   bool readSigns = !!s.numel();
   if (writeSigns) {
     int64_t sw = x.size(3);
-    sw = (sw + 15) & ~15; // Round to a multiple of 16 for coalescing.
+    sw = (sw + 15) & ~15;  // Round to a multiple of 16 for coalescing.
     s = so = torch::empty({x.size(0), x.size(1), x.size(2), sw >> 2},
                           x.options().dtype(torch::kUInt8),
                           at::MemoryFormat::Contiguous);
@@ -2007,7 +1939,7 @@ torch::Tensor filtered_lrelu_act_op(torch::Tensor x, torch::Tensor si, int sx,
       make_longlong4(x.stride(3), x.stride(2), x.stride(1), x.stride(0));
   p.sShape = (readSigns || writeSigns)
                  ? make_int2((int)s.size(3) << 2, (int)s.size(2))
-                 : make_int2(0, 0); // Width is in elements. Contiguous.
+                 : make_int2(0, 0);  // Width is in elements. Contiguous.
   p.sOfs = make_int2(sx, sy);
 
   // Choose CUDA kernel.
@@ -2025,13 +1957,13 @@ torch::Tensor filtered_lrelu_act_op(torch::Tensor x, torch::Tensor si, int sx,
 
   // Launch CUDA kernel.
   void *args[] = {&p};
-  int bx = 128; // 4 warps per block.
+  int bx = 128;  // 4 warps per block.
 
   // Logical size of launch = writeSigns ? p.s : p.x
   uint32_t gx = writeSigns ? p.sShape.x : p.xShape.x;
   uint32_t gy = writeSigns ? p.sShape.y : p.xShape.y;
   uint32_t gz =
-      p.xShape.z * p.xShape.w; // Same as in p.sShape if signs are in use.
+      p.xShape.z * p.xShape.w;  // Same as in p.sShape if signs are in use.
   gx = (gx - 1) / bx + 1;
 
   // Make sure grid y and z dimensions are within CUDA launch limits. Kernel

--- a/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
@@ -1592,6 +1592,11 @@ filtered_lrelu_kernel_spec choose_filtered_lrelu_kernel(
 #endif
 #endif
 
+#if CUDA_VERSION < 10020
+#undef BUILD_FILTERED_LRELU_OP
+#define BUILD_FILTERED_LRELU_OP 0
+#endif
+
 #if BUILD_FILTERED_LRELU_OP == 1
 std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
     torch::Tensor x, torch::Tensor fu, torch::Tensor fd, torch::Tensor b,
@@ -1876,7 +1881,7 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
     bool writeSigns) {
   TORCH_CHECK(false,
               "filtered_lrelu_op is not available. Please update your "
-              "compiler and try again.");
+              "compiler and cuda version.");
   return std::tuple<torch::Tensor, torch::Tensor, int>();
 }
 #endif


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Disable fused_lrelu on gcc < 6

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
