### PR TITLE
[Fix] Fix torch2.0 dcn/mdcn symbolic

### DIFF
--- a/mmcv/ops/deform_conv.py
+++ b/mmcv/ops/deform_conv.py
@@ -108,8 +108,10 @@ class DeformConv2dFunction(Function):
             return output
         ctx.save_for_backward(input, offset, weight)
 
-        output = input.new_empty(
-            DeformConv2dFunction._output_size(ctx, input, weight))
+        output = input.new_empty([
+            int(i)
+            for i in DeformConv2dFunction._output_size(ctx, input, weight)
+        ])
 
         ctx.bufs_ = [input.new_empty(0), input.new_empty(0)]  # columns, ones
 

--- a/mmcv/ops/modulated_deform_conv.py
+++ b/mmcv/ops/modulated_deform_conv.py
@@ -136,8 +136,10 @@ class ModulatedDeformConv2dFunction(Function):
                 ctx, input, offset, mask, weight, bias)
             return output
         ctx.save_for_backward(input, offset, mask, weight, bias)
-        output = input.new_empty(
-            ModulatedDeformConv2dFunction._output_size(ctx, input, weight))
+        output = input.new_empty([
+            int(i) for i in ModulatedDeformConv2dFunction._output_size(
+                ctx, input, weight)
+        ])
         ctx._bufs = [input.new_empty(0), input.new_empty(0)]
         ext_module.modulated_deform_conv_forward(
             input,

--- a/tests/test_ops/test_onnx.py
+++ b/tests/test_ops/test_onnx.py
@@ -3,7 +3,6 @@ import os
 
 import numpy as np
 import onnx
-import onnxruntime as rt
 import pytest
 import torch
 import torch.nn as nn
@@ -37,6 +36,7 @@ class WrapFunction(nn.Module):
 
 
 def test_roialign():
+    rt = pytest.importorskip("onnxruntime")
     try:
         from mmcv.ops import roi_align
     except (ImportError, ModuleNotFoundError):
@@ -106,6 +106,7 @@ def test_roialign():
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason='test requires GPU')
 def test_roipool():
+    rt = pytest.importorskip("onnxruntime")
     from mmcv.ops import roi_pool
 
     # roi pool config
@@ -204,7 +205,7 @@ def test_deform_conv():
     from mmcv.ops import DeformConv2dPack
     x = torch.randn(1, 2, 4, 4, device='cuda')
     _test_symbolic(
-        DeformConv2dPack(2, 4, 3, 1, 1).cuda(), x, 'MMCVDeformConv2d')
+        DeformConv2dPack(2, 4, 3, 1, 1).cuda(), (x,), 'MMCVDeformConv2d')
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason='test requires GPU')

--- a/tests/test_ops/test_onnx.py
+++ b/tests/test_ops/test_onnx.py
@@ -36,7 +36,7 @@ class WrapFunction(nn.Module):
 
 
 def test_roialign():
-    rt = pytest.importorskip("onnxruntime")
+    rt = pytest.importorskip('onnxruntime')
     try:
         from mmcv.ops import roi_align
     except (ImportError, ModuleNotFoundError):
@@ -106,7 +106,7 @@ def test_roialign():
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason='test requires GPU')
 def test_roipool():
-    rt = pytest.importorskip("onnxruntime")
+    rt = pytest.importorskip('onnxruntime')
     from mmcv.ops import roi_pool
 
     # roi pool config
@@ -205,7 +205,7 @@ def test_deform_conv():
     from mmcv.ops import DeformConv2dPack
     x = torch.randn(1, 2, 4, 4, device='cuda')
     _test_symbolic(
-        DeformConv2dPack(2, 4, 3, 1, 1).cuda(), (x,), 'MMCVDeformConv2d')
+        DeformConv2dPack(2, 4, 3, 1, 1).cuda(), (x, ), 'MMCVDeformConv2d')
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason='test requires GPU')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Torch2.0 would parse the forward of autograd.Function, which leads to optimization failed.

## Modification

1. cast dcn/mdcn shape to int so forward can also be parsed.
2. move onnxruntime inside the test. onnxruntime is optional now.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
