### PR TITLE
Modify adaptation of bbox_overlaps op for ascend device

### DIFF
--- a/mmcv/ops/csrc/pytorch/npu/bbox_overlaps_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/bbox_overlaps_npu.cpp
@@ -18,7 +18,8 @@ void bbox_overlaps_npu(const Tensor bboxes1, const Tensor bboxes2, Tensor ious,
     bboxesFP32 = NPUNativeFunctions::npu_dtype_cast(bboxes2, at::kFloat);
     gtboxesFP32 = NPUNativeFunctions::npu_dtype_cast(bboxes1, at::kFloat);
   }
-  c10::SmallVector<int64_t, SIZE> iousSize = {gtboxesFP32.size(0), bboxesFP32.size(0)};
+  c10::SmallVector<int64_t, SIZE> iousSize = {gtboxesFP32.size(0),
+                                              bboxesFP32.size(0)};
   if (aligned) {
     iousSize = {gtboxesFP32.size(0), 1};
   }


### PR DESCRIPTION
1. At present, compared with the bbox_overlaps operator, the iou operator on ascend device has precision error in the fp16 case and does not meet the acceptance standard, so go to the fp32 branch temporarily to avoid the problem.
2. Add support for offset at 0.
3. This change is independent of torch_npu.