### PR TITLE
add tracking_uri parameter for MlflowLoggerHook

### DIFF
--- a/mmcv/runner/hooks/logger/mlflow.py
+++ b/mmcv/runner/hooks/logger/mlflow.py
@@ -14,6 +14,8 @@ class MlflowLoggerHook(LoggerHook):
     It requires `MLflow`_ to be installed.
 
     Args:
+        tracking_uri (str, optional): uri of tracking uri.
+            Default None. If not None, store all log on mlflow server.
         exp_name (str, optional): Name of the experiment to be used.
             Default None. If not None, set the active experiment.
             If experiment does not exist, an experiment with provided name
@@ -37,6 +39,7 @@ class MlflowLoggerHook(LoggerHook):
     """
 
     def __init__(self,
+                 tracking_uri: Optional[str] = None,
                  exp_name: Optional[str] = None,
                  tags: Optional[Dict] = None,
                  params: Optional[Dict] = None,
@@ -47,6 +50,7 @@ class MlflowLoggerHook(LoggerHook):
                  by_epoch: bool = True):
         super().__init__(interval, ignore_last, reset_flag, by_epoch)
         self.import_mlflow()
+        self.tracking_uri = tracking_uri
         self.exp_name = exp_name
         self.tags = tags
         self.params = params
@@ -65,6 +69,8 @@ class MlflowLoggerHook(LoggerHook):
     @master_only
     def before_run(self, runner) -> None:
         super().before_run(runner)
+        if self.tracking_uri is not None:
+            self.mlflow.set_tracking_uri(self.tracking_uri)
         if self.exp_name is not None:
             self.mlflow.set_experiment(self.exp_name)
         if self.tags is not None:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

current MlflowLoggerHook only store logs in local directory. 
This PR add tracking_uri parameter for MlflowLoggerHook and allow logs to be published to Mlflow server. 

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [X] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
