### PR TITLE
[Feature] Add the support of arf op for ascend device

### DIFF
--- a/docs/en/compatibility.md
+++ b/docs/en/compatibility.md
@@ -9,7 +9,7 @@ At the same time, MMCV released [2.x](https://github.com/open-mmlab/mmcv/tree/2.
 - `mmcv.fileio` module, removed in PR [#2179](https://github.com/open-mmlab/mmcv/pull/2179). FileIO module from mmengine will be used wherever required.
 - `mmcv.runner`, `mmcv.parallel`, `mmcv. engine` and `mmcv.device`, removed in PR [#2216](https://github.com/open-mmlab/mmcv/pull/2216).
 - All classes in `mmcv.utils` (eg `Config` and `Registry`) and many functions, removed in PR [#2217](https://github.com/open-mmlab/mmcv/pull/2217). Only a few functions related to mmcv are reserved.
-- `mmcv.onnex`, `mmcv.tensorrt` modules and related functions, removed in PR [#2225](https://github.com/open-mmlab/mmcv/pull/2225).
+- `mmcv.onnx`, `mmcv.tensorrt` modules and related functions, removed in PR [#2225](https://github.com/open-mmlab/mmcv/pull/2225).
 
 (2) It added the [`mmcv.transforms`](https://github.com/open-mmlab/mmcv/tree/2.x/mmcv/transforms) data transformation module.
 

--- a/docs/en/understand_mmcv/ops.md
+++ b/docs/en/understand_mmcv/ops.md
@@ -4,7 +4,7 @@ We implement common ops used in detection, segmentation, etc.
 
 | Device                       | CPU | CUDA | MLU | MPS | Ascend |
 | ---------------------------- | --- | ---- | --- | --- | ------ |
-| ActiveRotatedFilter          | √   | √    |     |     |        |
+| ActiveRotatedFilter          | √   | √    |     |     | √      |
 | AssignScoreWithK             |     | √    |     |     |        |
 | BallQuery                    |     | √    | √   |     |        |
 | BBoxOverlaps                 |     | √    | √   | √   | √      |

--- a/docs/zh_cn/compatibility.md
+++ b/docs/zh_cn/compatibility.md
@@ -9,7 +9,7 @@ OpenMMLab 团队于 2022 年 9 月 1 日在世界人工智能大会发布了新�
 - `mmcv.fileio` 模块，删除于 PR [#2179](https://github.com/open-mmlab/mmcv/pull/2179)。在需要使用 FileIO 的地方使用 mmengine 中的 FileIO 模块
 - `mmcv.runner`、`mmcv.parallel`、`mmcv.engine` 和 `mmcv.device`，删除于 PR [#2216](https://github.com/open-mmlab/mmcv/pull/2216)
 - `mmcv.utils` 的所有类（例如 `Config` 和 `Registry`）和大部分函数，删除于 PR [#2217](https://github.com/open-mmlab/mmcv/pull/2217)，只保留少数和 mmcv 相关的函数
-- `mmcv.onnex`、`mmcv.tensorrt` 模块以及相关的函数，删除于 PR [#2225](https://github.com/open-mmlab/mmcv/pull/2225)
+- `mmcv.onnx`、`mmcv.tensorrt` 模块以及相关的函数，删除于 PR [#2225](https://github.com/open-mmlab/mmcv/pull/2225)
 
 （2）新增了 [`mmcv.transforms`](https://github.com/open-mmlab/mmcv/tree/2.x/mmcv/transforms) 数据变换模块
 

--- a/docs/zh_cn/understand_mmcv/ops.md
+++ b/docs/zh_cn/understand_mmcv/ops.md
@@ -4,7 +4,7 @@ MMCV 提供了检测、分割等任务中常用的算子
 
 | Device                       | CPU | CUDA | MLU | MPS | Ascend |
 | ---------------------------- | --- | ---- | --- | --- | ------ |
-| ActiveRotatedFilter          | √   | √    |     |     |        |
+| ActiveRotatedFilter          | √   | √    |     |     | √      |
 | AssignScoreWithK             |     | √    |     |     |        |
 | BallQuery                    |     | √    | √   |     |        |
 | BBoxOverlaps                 |     | √    | √   | √   | √      |

--- a/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
@@ -6,8 +6,8 @@ using namespace std;
 void active_rotated_filter_forward_impl(const Tensor input,
                                         const Tensor indices, Tensor output);
 
-void active_rotated_filter_forward_npu(const Tensor input,
-                                       const Tensor indices, Tensor output) {
+void active_rotated_filter_forward_npu(const Tensor input, const Tensor indices,
+                                       Tensor output) {
   OpCommand cmd;
   cmd.Name("ActiveRotatedFilter")
       .Input(input)
@@ -16,4 +16,5 @@ void active_rotated_filter_forward_npu(const Tensor input,
       .Run();
 }
 
-REGISTER_NPU_IMPL(active_rotated_filter_forward_impl, active_rotated_filter_forward_npu);
+REGISTER_NPU_IMPL(active_rotated_filter_forward_impl,
+                  active_rotated_filter_forward_npu);

--- a/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
@@ -6,8 +6,11 @@ using namespace std;
 void active_rotated_filter_forward_impl(const Tensor input,
                                         const Tensor indices, Tensor output);
 
-void active_rotated_filter_forward_npu(const Tensor input, const Tensor indices,
-                                       Tensor output) {
+void active_rotated_filter_backward_impl(const Tensor grad_out,
+                                         const Tensor indices, Tensor grad_in);
+
+void active_rotated_filter_forward_npu(const Tensor input,
+                                       const Tensor indices, Tensor output) {
   OpCommand cmd;
   cmd.Name("ActiveRotatedFilter")
       .Input(input)
@@ -16,5 +19,18 @@ void active_rotated_filter_forward_npu(const Tensor input, const Tensor indices,
       .Run();
 }
 
+void active_rotated_filter_backward_npu(const Tensor grad_out,
+                                         const Tensor indices, Tensor grad_in) {
+  OpCommand cmd;
+  cmd.Name("ActiveRotatedFilterGrad")
+      .Input(grad_out)
+      .Input(indices)
+      .Output(grad_in)
+      .Run();
+}
+
 REGISTER_NPU_IMPL(active_rotated_filter_forward_impl,
                   active_rotated_filter_forward_npu);
+
+REGISTER_NPU_IMPL(active_rotated_filter_backward_impl,
+                  active_rotated_filter_backward_npu);

--- a/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
@@ -1,0 +1,19 @@
+#include "pytorch_npu_helper.hpp"
+
+using namespace NPU_NAME_SPACE;
+using namespace std;
+
+void active_rotated_filter_forward_impl(const Tensor input,
+                                        const Tensor indices, Tensor output);
+
+void active_rotated_filter_forward_npu(const Tensor input,
+                                       const Tensor indices, Tensor output) {
+  OpCommand cmd;
+  cmd.Name("ActiveRotatedFilter")
+      .Input(input)
+      .Input(indices)
+      .Output(output)
+      .Run();
+}
+
+REGISTER_NPU_IMPL(active_rotated_filter_forward_impl, active_rotated_filter_forward_npu);

--- a/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
@@ -20,7 +20,7 @@ void active_rotated_filter_forward_npu(const Tensor input,
 }
 
 void active_rotated_filter_backward_npu(const Tensor grad_out,
-                                         const Tensor indices, Tensor grad_in) {
+                                        const Tensor indices, Tensor grad_in) {
   OpCommand cmd;
   cmd.Name("ActiveRotatedFilterGrad")
       .Input(grad_out)

--- a/tests/test_ops/test_active_rotated_filter.py
+++ b/tests/test_ops/test_active_rotated_filter.py
@@ -246,7 +246,11 @@ expected_grad = np.array([[[[[8., 8., 8.], [8., 8., 8.], [8., 8., 8.]]]],
     pytest.param(
         'cuda',
         marks=pytest.mark.skipif(
-            not IS_CUDA_AVAILABLE, reason='requires CUDA support'))
+            not IS_CUDA_AVAILABLE, reason='requires CUDA support')),
+    pytest.param(
+        'npu',
+        marks=pytest.mark.skipif(
+            not IS_NPU_AVAILABLE, reason='requires NPU support'))
 ])
 def test_active_rotated_filter(device):
     feature = torch.tensor(
@@ -257,17 +261,3 @@ def test_active_rotated_filter(device):
     assert np.allclose(output.data.cpu().numpy(), expected_output, atol=1e-3)
     assert np.allclose(
         feature.grad.data.cpu().numpy(), expected_grad, atol=1e-3)
-
-
-@pytest.mark.parametrize('device', [
-    pytest.param(
-        'npu',
-        marks=pytest.mark.skipif(
-            not IS_NPU_AVAILABLE, reason='requires NPU support'))
-])
-def test_active_rotated_filter_npu(device):
-    feature = torch.tensor(
-        np_feature, dtype=torch.float, device=device, requires_grad=True)
-    indices = torch.tensor(np_indices, dtype=torch.int, device=device)
-    output = active_rotated_filter(feature, indices)
-    assert np.allclose(output.data.cpu().numpy(), expected_output, atol=1e-3)


### PR DESCRIPTION
1. This PR is for adaptation of the op which name is "ActiveRotatedFilter" on ascend npu device. You can use the op on npu device by this PR.
2. Fix docs's description: mmcv.onnex->mmcv.onnx.