### PR TITLE
[Enhancement] Make `build_xxx_layer` allow accepting a class type

### DIFF
--- a/mmcv/cnn/bricks/conv.py
+++ b/mmcv/cnn/bricks/conv.py
@@ -35,7 +35,8 @@ def build_conv_layer(cfg: Optional[Dict], *args, **kwargs) -> nn.Module:
         cfg_ = cfg.copy()
 
     layer_type = cfg_.pop('type')
-
+    if isinstance(layer_type, type):
+        return layer_type(*args, **kwargs, **cfg_)
     # Switch registry to the target scope. If `conv_layer` cannot be found
     # in the registry, fallback to search `conv_layer` in the
     # mmengine.MODELS.

--- a/mmcv/cnn/bricks/conv.py
+++ b/mmcv/cnn/bricks/conv.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import inspect
 from typing import Dict, Optional
 
 from mmengine.registry import MODELS
@@ -35,8 +36,8 @@ def build_conv_layer(cfg: Optional[Dict], *args, **kwargs) -> nn.Module:
         cfg_ = cfg.copy()
 
     layer_type = cfg_.pop('type')
-    if isinstance(layer_type, type):
-        return layer_type(*args, **kwargs, **cfg_)
+    if inspect.isclass(layer_type):
+        return layer_type(*args, **kwargs, **cfg_)  # type: ignore
     # Switch registry to the target scope. If `conv_layer` cannot be found
     # in the registry, fallback to search `conv_layer` in the
     # mmengine.MODELS.

--- a/mmcv/cnn/bricks/norm.py
+++ b/mmcv/cnn/bricks/norm.py
@@ -116,7 +116,7 @@ def build_norm_layer(cfg: Dict,
 
     requires_grad = cfg_.pop('requires_grad', True)
     cfg_.setdefault('eps', 1e-5)
-    if layer_type != 'GN':
+    if norm_layer is not nn.GroupNorm:
         layer = norm_layer(num_features, **cfg_)
         if layer_type == 'SyncBN' and hasattr(layer, '_specify_ddp_gpu_num'):
             layer._specify_ddp_gpu_num(1)

--- a/mmcv/cnn/bricks/norm.py
+++ b/mmcv/cnn/bricks/norm.py
@@ -98,7 +98,7 @@ def build_norm_layer(cfg: Dict,
 
     layer_type = cfg_.pop('type')
 
-    if isinstance(layer_type, type):
+    if inspect.isclass(layer_type):
         norm_layer = layer_type
     else:
         # Switch registry to the target scope. If `norm_layer` cannot be found

--- a/mmcv/cnn/bricks/norm.py
+++ b/mmcv/cnn/bricks/norm.py
@@ -98,11 +98,14 @@ def build_norm_layer(cfg: Dict,
 
     layer_type = cfg_.pop('type')
 
-    # Switch registry to the target scope. If `norm_layer` cannot be found
-    # in the registry, fallback to search `norm_layer` in the
-    # mmengine.MODELS.
-    with MODELS.switch_scope_and_registry(None) as registry:
-        norm_layer = registry.get(layer_type)
+    if isinstance(layer_type, type):
+        norm_layer = layer_type
+    else:
+        # Switch registry to the target scope. If `norm_layer` cannot be found
+        # in the registry, fallback to search `norm_layer` in the
+        # mmengine.MODELS.
+        with MODELS.switch_scope_and_registry(None) as registry:
+            norm_layer = registry.get(layer_type)
     if norm_layer is None:
         raise KeyError(f'Cannot find {norm_layer} in registry under scope '
                        f'name {registry.scope}')

--- a/mmcv/cnn/bricks/norm.py
+++ b/mmcv/cnn/bricks/norm.py
@@ -106,9 +106,9 @@ def build_norm_layer(cfg: Dict,
         # mmengine.MODELS.
         with MODELS.switch_scope_and_registry(None) as registry:
             norm_layer = registry.get(layer_type)
-    if norm_layer is None:
-        raise KeyError(f'Cannot find {norm_layer} in registry under scope '
-                       f'name {registry.scope}')
+        if norm_layer is None:
+            raise KeyError(f'Cannot find {norm_layer} in registry under '
+                           f'scope name {registry.scope}')
     abbr = infer_abbr(norm_layer)
 
     assert isinstance(postfix, (int, str))

--- a/mmcv/cnn/bricks/padding.py
+++ b/mmcv/cnn/bricks/padding.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import inspect
 from typing import Dict
 
 import torch.nn as nn
@@ -27,7 +28,7 @@ def build_padding_layer(cfg: Dict, *args, **kwargs) -> nn.Module:
 
     cfg_ = cfg.copy()
     padding_type = cfg_.pop('type')
-    if isinstance(padding_type, type):
+    if inspect.isclass(padding_type):
         return padding_type(*args, **kwargs, **cfg_)
     # Switch registry to the target scope. If `padding_layer` cannot be found
     # in the registry, fallback to search `padding_layer` in the

--- a/mmcv/cnn/bricks/padding.py
+++ b/mmcv/cnn/bricks/padding.py
@@ -27,7 +27,8 @@ def build_padding_layer(cfg: Dict, *args, **kwargs) -> nn.Module:
 
     cfg_ = cfg.copy()
     padding_type = cfg_.pop('type')
-
+    if isinstance(padding_type, type):
+        return padding_type(*args, **kwargs, **cfg_)
     # Switch registry to the target scope. If `padding_layer` cannot be found
     # in the registry, fallback to search `padding_layer` in the
     # mmengine.MODELS.

--- a/mmcv/cnn/bricks/plugin.py
+++ b/mmcv/cnn/bricks/plugin.py
@@ -79,7 +79,7 @@ def build_plugin_layer(cfg: Dict,
     cfg_ = cfg.copy()
 
     layer_type = cfg_.pop('type')
-    if isinstance(layer_type, type):
+    if inspect.isclass(layer_type):
         plugin_layer = layer_type
     else:
         # Switch registry to the target scope. If `plugin_layer` cannot be

--- a/mmcv/cnn/bricks/plugin.py
+++ b/mmcv/cnn/bricks/plugin.py
@@ -79,15 +79,18 @@ def build_plugin_layer(cfg: Dict,
     cfg_ = cfg.copy()
 
     layer_type = cfg_.pop('type')
-
-    # Switch registry to the target scope. If `plugin_layer` cannot be found
-    # in the registry, fallback to search `plugin_layer` in the
-    # mmengine.MODELS.
-    with MODELS.switch_scope_and_registry(None) as registry:
-        plugin_layer = registry.get(layer_type)
-    if plugin_layer is None:
-        raise KeyError(f'Cannot find {plugin_layer} in registry under scope '
-                       f'name {registry.scope}')
+    if isinstance(layer_type, type):
+        plugin_layer = layer_type
+    else:
+        # Switch registry to the target scope. If `plugin_layer` cannot be
+        # found in the registry, fallback to search `plugin_layer` in the
+        # mmengine.MODELS.
+        with MODELS.switch_scope_and_registry(None) as registry:
+            plugin_layer = registry.get(layer_type)
+        if plugin_layer is None:
+            raise KeyError(
+                f'Cannot find {plugin_layer} in registry under scope '
+                f'name {registry.scope}')
     abbr = infer_abbr(plugin_layer)
 
     assert isinstance(postfix, (int, str))

--- a/mmcv/cnn/bricks/upsample.py
+++ b/mmcv/cnn/bricks/upsample.py
@@ -88,7 +88,7 @@ def build_upsample_layer(cfg: Dict, *args, **kwargs) -> nn.Module:
         if upsample is None:
             raise KeyError(f'Cannot find {upsample} in registry under scope '
                            f'name {registry.scope}')
-    if upsample is nn.Upsample:
-        cfg_['mode'] = layer_type if isinstance(layer_type, str) else 'nearest'
+    if upsample is nn.Upsample and isinstance(layer_type, str):
+        cfg['mode'] = layer_type
     layer = upsample(*args, **kwargs, **cfg_)
     return layer

--- a/mmcv/cnn/bricks/upsample.py
+++ b/mmcv/cnn/bricks/upsample.py
@@ -88,7 +88,7 @@ def build_upsample_layer(cfg: Dict, *args, **kwargs) -> nn.Module:
         if upsample is None:
             raise KeyError(f'Cannot find {upsample} in registry under scope '
                            f'name {registry.scope}')
-    if upsample is nn.Upsample and isinstance(layer_type, str):
-        cfg['mode'] = layer_type
+        if upsample is nn.Upsample and isinstance(layer_type, str):
+            cfg['mode'] = layer_type
     layer = upsample(*args, **kwargs, **cfg_)
     return layer

--- a/mmcv/cnn/bricks/upsample.py
+++ b/mmcv/cnn/bricks/upsample.py
@@ -89,6 +89,6 @@ def build_upsample_layer(cfg: Dict, *args, **kwargs) -> nn.Module:
             raise KeyError(f'Cannot find {upsample} in registry under scope '
                            f'name {registry.scope}')
         if upsample is nn.Upsample and isinstance(layer_type, str):
-            cfg['mode'] = layer_type
+            cfg_['mode'] = layer_type
     layer = upsample(*args, **kwargs, **cfg_)
     return layer

--- a/mmcv/cnn/bricks/upsample.py
+++ b/mmcv/cnn/bricks/upsample.py
@@ -88,7 +88,7 @@ def build_upsample_layer(cfg: Dict, *args, **kwargs) -> nn.Module:
         if upsample is None:
             raise KeyError(f'Cannot find {upsample} in registry under scope '
                            f'name {registry.scope}')
-        if upsample is nn.Upsample and isinstance(layer_type, str):
+        if upsample is nn.Upsample:
             cfg_['mode'] = layer_type
     layer = upsample(*args, **kwargs, **cfg_)
     return layer

--- a/mmcv/cnn/bricks/upsample.py
+++ b/mmcv/cnn/bricks/upsample.py
@@ -81,12 +81,13 @@ def build_upsample_layer(cfg: Dict, *args, **kwargs) -> nn.Module:
     # Switch registry to the target scope. If `upsample` cannot be found
     # in the registry, fallback to search `upsample` in the
     # mmengine.MODELS.
-    with MODELS.switch_scope_and_registry(None) as registry:
-        upsample = registry.get(layer_type)
-    if upsample is None:
-        raise KeyError(f'Cannot find {upsample} in registry under scope '
-                       f'name {registry.scope}')
+    else:
+        with MODELS.switch_scope_and_registry(None) as registry:
+            upsample = registry.get(layer_type)
+        if upsample is None:
+            raise KeyError(f'Cannot find {upsample} in registry under scope '
+                           f'name {registry.scope}')
     if upsample is nn.Upsample:
-        cfg_['mode'] = layer_type
+        cfg_['mode'] = layer_type if isinstance(layer_type, str) else 'nearest'
     layer = upsample(*args, **kwargs, **cfg_)
     return layer

--- a/mmcv/cnn/bricks/upsample.py
+++ b/mmcv/cnn/bricks/upsample.py
@@ -76,6 +76,8 @@ def build_upsample_layer(cfg: Dict, *args, **kwargs) -> nn.Module:
 
     layer_type = cfg_.pop('type')
 
+    if isinstance(layer_type, type):
+        upsample = layer_type
     # Switch registry to the target scope. If `upsample` cannot be found
     # in the registry, fallback to search `upsample` in the
     # mmengine.MODELS.

--- a/mmcv/cnn/bricks/upsample.py
+++ b/mmcv/cnn/bricks/upsample.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import inspect
 from typing import Dict
 
 import torch
@@ -76,7 +77,7 @@ def build_upsample_layer(cfg: Dict, *args, **kwargs) -> nn.Module:
 
     layer_type = cfg_.pop('type')
 
-    if isinstance(layer_type, type):
+    if inspect.isclass(layer_type):
         upsample = layer_type
     # Switch registry to the target scope. If `upsample` cannot be found
     # in the registry, fallback to search `upsample` in the

--- a/mmcv/ops/nms.py
+++ b/mmcv/ops/nms.py
@@ -293,8 +293,9 @@ def batched_nms(boxes: Tensor,
                 max_coordinate + torch.tensor(1).to(boxes))
             boxes_for_nms = boxes + offsets[:, None]
 
-    nms_type = nms_cfg_.pop('type', 'nms')
-    nms_op = eval(nms_type)
+    nms_op = nms_cfg_.pop('type', 'nms')
+    if isinstance(nms_op, str):
+        nms_op = eval(nms_op)
 
     split_thr = nms_cfg_.pop('split_thr', 10000)
     # Won't split to multiple nms nodes when exporting to onnx

--- a/tests/test_cnn/test_build_layers.py
+++ b/tests/test_cnn/test_build_layers.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import inspect
 from importlib import import_module
 
 import numpy as np
@@ -190,7 +191,7 @@ def test_build_activation_layer():
     for module_name in ['activation', 'hsigmoid', 'hswish', 'swish']:
         act_module = import_module(f'mmcv.cnn.bricks.{module_name}')
         for key, value in act_module.__dict__.items():
-            if isinstance(value, type) and issubclass(value, nn.Module):
+            if inspect.isclass(value) and issubclass(value, nn.Module):
                 act_names.append(key)
 
     with pytest.raises(TypeError):
@@ -235,7 +236,7 @@ def test_build_padding_layer():
     for module_name in ['padding']:
         pad_module = import_module(f'mmcv.cnn.bricks.{module_name}')
         for key, value in pad_module.__dict__.items():
-            if isinstance(value, type) and issubclass(value, nn.Module):
+            if inspect.isclass(value) and issubclass(value, nn.Module):
                 pad_names.append(key)
 
     with pytest.raises(TypeError):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Make `build_xxx_layer` accept cfg dict with a `class` type

In MMEngine, `build_from_cfg` allows accepting a read `class` type like this:

```python
from mmengine.hooks import LoggerHook

cfg = dict(type=LoggerHook)
hook = build_from_cfg(cfg)
```

However, build_xxx_layer in MMCV does not allow accepting a class type:

```python
from mmcv.cnn import build_conv_layer
from torch.nn import Conv2d

cfg = dict(type=Conv2d, ...)
layer = build_conv_layer(cfg)  # will raise an error
```

This PR makes `build_xxx_layer` can build layer from the class type.


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
