### PR TITLE
[Fix] fix numerical error in `Jarvis` 

### DIFF
--- a/mmcv/ops/csrc/common/cuda/convex_iou_cuda_kernel.cuh
+++ b/mmcv/ops/csrc/common/cuda/convex_iou_cuda_kernel.cuh
@@ -431,8 +431,13 @@ __device__ inline void Jarvis(Point* in_poly, int& n_poly) {
     k_index = max_index;
     for (int i = 1; i < n_poly; i++) {
       sign = cross(in_poly[Stack[top1]], in_poly[i], p_k);
-      if ((sign > 0) || ((sign == 0) && (dis(in_poly[Stack[top1]], in_poly[i]) >
-                                         dis(in_poly[Stack[top1]], p_k)))) {
+      if(fabs(sign) < 1e-3) {
+        if (dis(in_poly[Stack[top1]], in_poly[i]) > dis(in_poly[Stack[top1]], p_k)) {
+          p_k = in_poly[i];
+          k_index = i;
+        }
+      }
+      else if (sign > 0) {
         p_k = in_poly[i];
         k_index = i;
       }
@@ -449,8 +454,13 @@ __device__ inline void Jarvis(Point* in_poly, int& n_poly) {
     k_index = max_index;
     for (int i = 1; i < n_poly; i++) {
       sign = cross(in_poly[Stack[top2]], in_poly[i], p_k);
-      if ((sign < 0) || (sign == 0) && (dis(in_poly[Stack[top2]], in_poly[i]) >
-                                        dis(in_poly[Stack[top2]], p_k))) {
+      if(fabs(sign) < 1e-3) {
+        if (dis(in_poly[Stack[top2]], in_poly[i]) > dis(in_poly[Stack[top2]], p_k)) {
+          p_k = in_poly[i];
+          k_index = i;
+        }
+      }
+      else if (sign < 0) {
         p_k = in_poly[i];
         k_index = i;
       }
@@ -570,8 +580,13 @@ __device__ inline void Jarvis_and_index(Point* in_poly, int& n_poly,
     k_index = max_index;
     for (int i = 1; i < n_poly; i++) {
       sign = cross(in_poly[Stack[top1]], in_poly[i], p_k);
-      if ((sign > 0) || ((sign == 0) && (dis(in_poly[Stack[top1]], in_poly[i]) >
-                                         dis(in_poly[Stack[top1]], p_k)))) {
+      if(fabs(sign) < 1e-3) {
+        if (dis(in_poly[Stack[top1]], in_poly[i]) > dis(in_poly[Stack[top1]], p_k)) {
+          p_k = in_poly[i];
+          k_index = i;
+        }
+      }
+      else if (sign > 0) {
         p_k = in_poly[i];
         k_index = i;
       }
@@ -590,8 +605,13 @@ __device__ inline void Jarvis_and_index(Point* in_poly, int& n_poly,
     k_index = max_index;
     for (int i = 1; i < n_poly; i++) {
       sign = cross(in_poly[Stack[top2]], in_poly[i], p_k);
-      if ((sign < 0) || (sign == 0) && (dis(in_poly[Stack[top2]], in_poly[i]) >
-                                        dis(in_poly[Stack[top2]], p_k))) {
+      if(fabs(sign) < 1e-3) {
+        if (dis(in_poly[Stack[top2]], in_poly[i]) > dis(in_poly[Stack[top2]], p_k)) {
+          p_k = in_poly[i];
+          k_index = i;
+        }
+      }
+      else if (sign < 0) {
         p_k = in_poly[i];
         k_index = i;
       }

--- a/mmcv/ops/csrc/common/cuda/min_area_polygons_cuda.cuh
+++ b/mmcv/ops/csrc/common/cuda/min_area_polygons_cuda.cuh
@@ -28,6 +28,7 @@ __device__ inline void swap1(Point *a, Point *b) {
   b->x = temp.x;
   b->y = temp.y;
 }
+
 __device__ inline float cross(Point o, Point a, Point b) {
   return (a.x - o.x) * (b.y - o.y) - (b.x - o.x) * (a.y - o.y);
 }
@@ -35,6 +36,7 @@ __device__ inline float cross(Point o, Point a, Point b) {
 __device__ inline float dis(Point a, Point b) {
   return (a.x - b.x) * (a.x - b.x) + (a.y - b.y) * (a.y - b.y);
 }
+
 __device__ inline void minBoundingRect(Point *ps, int n_points, float *minbox) {
   float convex_points[2][MAXN];
   for (int j = 0; j < n_points; j++) {
@@ -159,12 +161,6 @@ __device__ inline void minBoundingRect(Point *ps, int n_points, float *minbox) {
 
 // convex_find
 __device__ inline void Jarvis(Point *in_poly, int &n_poly) {
-  int n_input = n_poly;
-  Point input_poly[20];
-  for (int i = 0; i < n_input; i++) {
-    input_poly[i].x = in_poly[i].x;
-    input_poly[i].y = in_poly[i].y;
-  }
   Point p_max, p_k;
   int max_index, k_index;
   int Stack[20], top1, top2;
@@ -200,8 +196,13 @@ __device__ inline void Jarvis(Point *in_poly, int &n_poly) {
     k_index = max_index;
     for (int i = 1; i < n_poly; i++) {
       sign = cross(in_poly[Stack[top1]], in_poly[i], p_k);
-      if ((sign > 0) || ((sign == 0) && (dis(in_poly[Stack[top1]], in_poly[i]) >
-                                         dis(in_poly[Stack[top1]], p_k)))) {
+      if(fabs(sign) < 1e-3) {
+        if (dis(in_poly[Stack[top1]], in_poly[i]) > dis(in_poly[Stack[top1]], p_k)) {
+          p_k = in_poly[i];
+          k_index = i;
+        }
+      }
+      else if (sign > 0) {
         p_k = in_poly[i];
         k_index = i;
       }
@@ -221,8 +222,13 @@ __device__ inline void Jarvis(Point *in_poly, int &n_poly) {
     k_index = max_index;
     for (int i = 1; i < n_poly; i++) {
       sign = cross(in_poly[Stack[top2]], in_poly[i], p_k);
-      if ((sign < 0) || (sign == 0) && (dis(in_poly[Stack[top2]], in_poly[i]) >
-                                        dis(in_poly[Stack[top2]], p_k))) {
+      if(fabs(sign) < 1e-3) {
+        if (dis(in_poly[Stack[top2]], in_poly[i]) > dis(in_poly[Stack[top2]], p_k)) {
+          p_k = in_poly[i];
+          k_index = i;
+        }
+      }
+      else if (sign < 0) {
         p_k = in_poly[i];
         k_index = i;
       }


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fixes #2407, open-mmlab/mmrotate#614

```
[[67.189827, 445.142517,
80.672424, 726.558838,
154.913605, 711.699219,
94.742928, 574.717041,
116.207588, 755.282104,
99.939827, 489.668854,
14.599480, 462.490112,
35.282326, 545.151672,
87.332382, 536.160767]]
```
![Figure_1](https://user-images.githubusercontent.com/18318646/235841216-6cd2dbcd-f502-47e5-bef0-4f6c17a61614.png)


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
