### PR TITLE
[Enhance] Raise a error if fails to read image

### DIFF
--- a/mmcv/transforms/loading.py
+++ b/mmcv/transforms/loading.py
@@ -105,6 +105,8 @@ class LoadImageFromFile(BaseTransform):
                 return None
             else:
                 raise e
+        # in some cases, images are not read successfully, the img would be
+        # `None`, refer to https://github.com/open-mmlab/mmpretrain/issues/1427
         assert img is not None, f'failed to load image: {filename}'
         if self.to_float32:
             img = img.astype(np.float32)

--- a/mmcv/transforms/loading.py
+++ b/mmcv/transforms/loading.py
@@ -105,6 +105,7 @@ class LoadImageFromFile(BaseTransform):
                 return None
             else:
                 raise e
+        assert img is not None, f"Loading image '{filename}' fails."
         if self.to_float32:
             img = img.astype(np.float32)
 

--- a/mmcv/transforms/loading.py
+++ b/mmcv/transforms/loading.py
@@ -105,7 +105,7 @@ class LoadImageFromFile(BaseTransform):
                 return None
             else:
                 raise e
-        assert img is not None, f"Loading image '{filename}' fails."
+        assert img is not None, f'failed to load image: {filename}'
         if self.to_float32:
             img = img.astype(np.float32)
 


### PR DESCRIPTION
## Motivation

inspired by https://github.com/open-mmlab/mmpretrain/issues/1427

raise error info if imfrombytes fails

run:
```
LoadImageFromFile()(dict(img_path='https://user-images.githubusercontent.com/9102141/87268895-3e0d0780-c4fe-11ea-849e-6140b7e0d4de.gif')
```

### before modifcation
![image](https://user-images.githubusercontent.com/18586273/236819281-2a8e7388-24b1-46e6-9430-c9f705c5a5f0.png)


### After modifcartion
![image](https://user-images.githubusercontent.com/18586273/236819191-ae3cc495-8d17-4d02-8217-82352ab12ecb.png)


## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
