### PR TITLE
[Feature] Add the support of arf op for ascend device (main)

### DIFF
--- a/docs/en/compatibility.md
+++ b/docs/en/compatibility.md
@@ -31,7 +31,8 @@ pip install openmim
 mim install mmcv-full
 
 # do not contain ops
-pip install "mmcv < 2.0.0"
+pip install openmim
+mim install "mmcv < 2.0.0"
 ```
 
 </td>
@@ -43,7 +44,8 @@ pip install openmim
 mim install mmcv
 
 # Ops are not included, because the starting version of mmcv-lite is 2.0.0rc1, so there is no need to add version restrictions
-pip install mmcv-lite
+pip install openmim
+mim install mmcv-lite
 ```
 
 </td>

--- a/docs/en/compatibility.md
+++ b/docs/en/compatibility.md
@@ -9,7 +9,7 @@ The OpenMMLab team released MMCV v2.0.0 on April 6, 2023. In the 2.x version, it
 - `mmcv.fileio` module, removed in PR [#2179](https://github.com/open-mmlab/mmcv/pull/2179). FileIO module from mmengine will be used wherever required.
 - `mmcv.runner`, `mmcv.parallel`, `mmcv. engine` and `mmcv.device`, removed in PR [#2216](https://github.com/open-mmlab/mmcv/pull/2216).
 - All classes in `mmcv.utils` (eg `Config` and `Registry`) and many functions, removed in PR [#2217](https://github.com/open-mmlab/mmcv/pull/2217). Only a few functions related to mmcv are reserved.
-- `mmcv.onnex`, `mmcv.tensorrt` modules and related functions, removed in PR [#2225](https://github.com/open-mmlab/mmcv/pull/2225).
+- `mmcv.onnx`, `mmcv.tensorrt` modules and related functions, removed in PR [#2225](https://github.com/open-mmlab/mmcv/pull/2225).
 - Removed all root registrars in MMCV and registered classes or functions to the [root registrar](https://github.com/open-mmlab/mmengine/blob/main/mmengine/registry/root.py) in MMEngine.
 
 (2) It added the [`mmcv.transforms`](https://github.com/open-mmlab/mmcv/tree/main/mmcv/transforms) data transformation module.
@@ -27,10 +27,11 @@ The OpenMMLab team released MMCV v2.0.0 on April 6, 2023. In the 2.x version, it
 
 ```bash
 # Contains ops, because the highest version of mmcv-full is less than 2.0.0, so there is no need to add version restrictions
+pip install openmim
 mim install mmcv-full
 
 # do not contain ops
-mmcv install "mmcv < 2.0.0"
+pip install "mmcv < 2.0.0"
 ```
 
 </td>
@@ -38,11 +39,11 @@ mmcv install "mmcv < 2.0.0"
 
 ```bash
 # Contains ops
-mim install openmim
+pip install openmim
 mim install mmcv
 
 # Ops are not included, because the starting version of mmcv-lite is 2.0.0rc1, so there is no need to add version restrictions
-mim install mmcv-lite
+pip install mmcv-lite
 ```
 
 </td>

--- a/docs/en/understand_mmcv/ops.md
+++ b/docs/en/understand_mmcv/ops.md
@@ -4,7 +4,7 @@ We implement common ops used in detection, segmentation, etc.
 
 | Device                       | CPU | CUDA | MLU | MPS | Ascend |
 | ---------------------------- | --- | ---- | --- | --- | ------ |
-| ActiveRotatedFilter          | √   | √    |     |     |        |
+| ActiveRotatedFilter          | √   | √    |     |     | √      |
 | AssignScoreWithK             |     | √    |     |     |        |
 | BallQuery                    |     | √    | √   |     |        |
 | BBoxOverlaps                 |     | √    | √   | √   | √      |

--- a/docs/zh_cn/compatibility.md
+++ b/docs/zh_cn/compatibility.md
@@ -9,7 +9,7 @@ OpenMMLab 团队于 2023 年 4 月 6 日发布 MMCV [v2.0.0](https://github.com/
 - `mmcv.fileio` 模块，删除于 PR [#2179](https://github.com/open-mmlab/mmcv/pull/2179)。在需要使用 FileIO 的地方使用 mmengine 中的 FileIO 模块
 - `mmcv.runner`、`mmcv.parallel`、`mmcv.engine` 和 `mmcv.device`，删除于 PR [#2216](https://github.com/open-mmlab/mmcv/pull/2216)
 - `mmcv.utils` 的所有类（例如 `Config` 和 `Registry`）和大部分函数，删除于 PR [#2217](https://github.com/open-mmlab/mmcv/pull/2217)，只保留少数和 mmcv 相关的函数
-- `mmcv.onnex`、`mmcv.tensorrt` 模块以及相关的函数，删除于 PR [#2225](https://github.com/open-mmlab/mmcv/pull/2225)
+- `mmcv.onnx`、`mmcv.tensorrt` 模块以及相关的函数，删除于 PR [#2225](https://github.com/open-mmlab/mmcv/pull/2225)
 - 删除 MMCV 所有的根注册器并将类或者函数注册到 MMEngine 的[根注册器](https://github.com/open-mmlab/mmengine/blob/main/mmengine/registry/root.py)
 
 （2）新增了 [`mmcv.transforms`](https://github.com/open-mmlab/mmcv/tree/main/mmcv/transforms) 数据变换模块
@@ -27,10 +27,11 @@ OpenMMLab 团队于 2023 年 4 月 6 日发布 MMCV [v2.0.0](https://github.com/
 
 ```bash
 # 包含算子，因为 mmcv-full 的最高版本小于 2.0.0，所以无需加版本限制
+pip install openmim
 mim install mmcv-full
 
 # 不包含算子
-mmcv install "mmcv < 2.0.0"
+pip install "mmcv < 2.0.0"
 ```
 
 </td>
@@ -38,7 +39,7 @@ mmcv install "mmcv < 2.0.0"
 
 ```bash
 # 包含算子
-mim install openmim
+pip install openmim
 mim install mmcv
 
 # 不包含算子，因为 mmcv-lite 的起始版本为 2.0.0，所以无需加版本限制

--- a/docs/zh_cn/compatibility.md
+++ b/docs/zh_cn/compatibility.md
@@ -31,7 +31,8 @@ pip install openmim
 mim install mmcv-full
 
 # 不包含算子
-pip install "mmcv < 2.0.0"
+pip install openmim
+mim install "mmcv < 2.0.0"
 ```
 
 </td>
@@ -43,7 +44,8 @@ pip install openmim
 mim install mmcv
 
 # 不包含算子，因为 mmcv-lite 的起始版本为 2.0.0，所以无需加版本限制
-pip install mmcv-lite
+pip install openmim
+mim install mmcv-lite
 ```
 
 </td>

--- a/docs/zh_cn/understand_mmcv/ops.md
+++ b/docs/zh_cn/understand_mmcv/ops.md
@@ -4,7 +4,7 @@ MMCV 提供了检测、分割等任务中常用的算子
 
 | Device                       | CPU | CUDA | MLU | MPS | Ascend |
 | ---------------------------- | --- | ---- | --- | --- | ------ |
-| ActiveRotatedFilter          | √   | √    |     |     |        |
+| ActiveRotatedFilter          | √   | √    |     |     | √      |
 | AssignScoreWithK             |     | √    |     |     |        |
 | BallQuery                    |     | √    | √   |     |        |
 | BBoxOverlaps                 |     | √    | √   | √   | √      |

--- a/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
@@ -1,0 +1,36 @@
+#include "pytorch_npu_helper.hpp"
+
+using namespace NPU_NAME_SPACE;
+using namespace std;
+
+void active_rotated_filter_forward_impl(const Tensor input,
+                                        const Tensor indices, Tensor output);
+
+void active_rotated_filter_backward_impl(const Tensor grad_out,
+                                         const Tensor indices, Tensor grad_in);
+
+void active_rotated_filter_forward_npu(const Tensor input,
+                                       const Tensor indices, Tensor output) {
+  OpCommand cmd;
+  cmd.Name("ActiveRotatedFilter")
+      .Input(input)
+      .Input(indices)
+      .Output(output)
+      .Run();
+}
+
+void active_rotated_filter_backward_npu(const Tensor grad_out,
+                                        const Tensor indices, Tensor grad_in) {
+  OpCommand cmd;
+  cmd.Name("ActiveRotatedFilterGrad")
+      .Input(grad_out)
+      .Input(indices)
+      .Output(grad_in)
+      .Run();
+}
+
+REGISTER_NPU_IMPL(active_rotated_filter_forward_impl,
+                  active_rotated_filter_forward_npu);
+
+REGISTER_NPU_IMPL(active_rotated_filter_backward_impl,
+                  active_rotated_filter_backward_npu);

--- a/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
+++ b/mmcv/ops/csrc/pytorch/npu/active_rotated_filter_npu.cpp
@@ -9,8 +9,8 @@ void active_rotated_filter_forward_impl(const Tensor input,
 void active_rotated_filter_backward_impl(const Tensor grad_out,
                                          const Tensor indices, Tensor grad_in);
 
-void active_rotated_filter_forward_npu(const Tensor input,
-                                       const Tensor indices, Tensor output) {
+void active_rotated_filter_forward_npu(const Tensor input, const Tensor indices,
+                                       Tensor output) {
   OpCommand cmd;
   cmd.Name("ActiveRotatedFilter")
       .Input(input)

--- a/tests/test_ops/test_active_rotated_filter.py
+++ b/tests/test_ops/test_active_rotated_filter.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from mmcv.ops import active_rotated_filter
+from mmcv.utils import IS_CUDA_AVAILABLE, IS_NPU_AVAILABLE
 
 np_feature = np.array([[[[[-1.4934e-01, 1.1341e+00, -1.6241e-01],
                           [-1.0986e+00, -1.1463e+00, -1.3176e+00],
@@ -245,7 +246,11 @@ expected_grad = np.array([[[[[8., 8., 8.], [8., 8., 8.], [8., 8., 8.]]]],
     pytest.param(
         'cuda',
         marks=pytest.mark.skipif(
-            not torch.cuda.is_available(), reason='requires CUDA support')),
+            not IS_CUDA_AVAILABLE, reason='requires CUDA support')),
+    pytest.param(
+        'npu',
+        marks=pytest.mark.skipif(
+            not IS_NPU_AVAILABLE, reason='requires NPU support'))
 ])
 def test_active_rotated_filter(device):
     feature = torch.tensor(


### PR DESCRIPTION
1. This PR is for adaptation of the op which name is "ActiveRotatedFilter" on ascend npu device. You can use the op on npu device by this PR.
2. Fix docs's description: "mmcv.onnex"->"mmcv.onnx", "mim"->"pip".
