### PR TITLE
[Fix] Fix the support for ROCm

### DIFF
--- a/mmcv/ops/conv2d_gradfix.py
+++ b/mmcv/ops/conv2d_gradfix.py
@@ -295,7 +295,7 @@ def _conv2d_gradfix(
                 name = ''
                 flags = []
 
-                if is_rocm_pytorch:
+                if is_rocm_pytorch():
                     name = 'aten::miopen_convolution_transpose_backward_weight'
                     if not transpose:
                         name = 'aten::miopen_convolution_backward_weight'

--- a/mmcv/ops/conv2d_gradfix.py
+++ b/mmcv/ops/conv2d_gradfix.py
@@ -283,18 +283,6 @@ def _conv2d_gradfix(
                     output_padding=output_padding,
                     output_mask=[0, 1, 0])[1]
             else:
-                is_rocm_pytorch = False
-                try:
-                    from torch.utils.cpp_extension import ROCM_HOME
-                    if ((torch.version.hip is not None)
-                            and (ROCM_HOME is not None)):
-                        is_rocm_pytorch = True
-                except ImportError:
-                    pass
-
-                name = ''
-                flags = []
-
                 if is_rocm_pytorch():
                     name = 'aten::miopen_convolution_transpose_backward_weight'
                     if not transpose:

--- a/mmcv/ops/conv2d_gradfix.py
+++ b/mmcv/ops/conv2d_gradfix.py
@@ -16,6 +16,7 @@ from typing import Dict, Optional, Tuple, Union
 
 import torch
 from mmengine.utils import digit_version
+from mmengine.utils.dl_utils.parrots_wrapper import is_rocm_pytorch
 
 enabled = True
 weight_gradients_disabled = False
@@ -283,18 +284,9 @@ def _conv2d_gradfix(
                     output_padding=output_padding,
                     output_mask=[0, 1, 0])[1]
             else:
-                is_rocm_pytorch = False
-                try:
-                    from torch.utils.cpp_extension import ROCM_HOME
-                    if ((torch.version.hip is not None)
-                            and (ROCM_HOME is not None)):
-                        is_rocm_pytorch = True
-                except ImportError:
-                    pass
-
                 name = ''
                 flags = []
-                if is_rocm_pytorch:
+                if is_rocm_pytorch():
                     name = 'aten::miopen_convolution_transpose_backward_weight'
                     if not transpose:
                         name = 'aten::miopen_convolution_backward_weight'

--- a/mmcv/ops/conv2d_gradfix.py
+++ b/mmcv/ops/conv2d_gradfix.py
@@ -284,8 +284,6 @@ def _conv2d_gradfix(
                     output_padding=output_padding,
                     output_mask=[0, 1, 0])[1]
             else:
-                name = ''
-                flags = []
                 if is_rocm_pytorch():
                     name = 'aten::miopen_convolution_transpose_backward_weight'
                     if not transpose:

--- a/mmcv/ops/conv2d_gradfix.py
+++ b/mmcv/ops/conv2d_gradfix.py
@@ -283,7 +283,18 @@ def _conv2d_gradfix(
                     output_padding=output_padding,
                     output_mask=[0, 1, 0])[1]
             else:
-                if is_rocm_pytorch():
+                is_rocm_pytorch = False
+                try:
+                    from torch.utils.cpp_extension import ROCM_HOME
+                    if ((torch.version.hip is not None)
+                            and (ROCM_HOME is not None)):
+                        is_rocm_pytorch = True
+                except ImportError:
+                    pass
+
+                name = ''
+                flags = []
+                if is_rocm_pytorch:
                     name = 'aten::miopen_convolution_transpose_backward_weight'
                     if not transpose:
                         name = 'aten::miopen_convolution_backward_weight'

--- a/mmcv/ops/corner_pool.py
+++ b/mmcv/ops/corner_pool.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from mmengine.utils import digit_version
 from torch import Tensor, nn
 
 _mode_dict = {'top': 0, 'bottom': 1, 'left': 2, 'right': 3}
@@ -70,7 +71,8 @@ class CornerPool(nn.Module):
         self.mode = mode
 
     def forward(self, x: Tensor) -> Tensor:
-        if torch.__version__ != 'parrots' and torch.__version__ >= '1.5.0':
+        if (torch.__version__ != 'parrots' and
+                digit_version(torch.__version__) >= digit_version('1.5.0')):
             dim, flip = self.cummax_dim_flip[self.mode]
             if flip:
                 x = x.flip(dim)

--- a/mmcv/ops/csrc/pytorch/cuda/bias_act_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/bias_act_cuda.cu
@@ -291,7 +291,7 @@ torch::Tensor bias_act_op(const torch::Tensor &x, const torch::Tensor &b,
   void *args[] = {&p};
 #ifdef MMCV_WITH_HIP
   AT_CUDA_CHECK(hipLaunchKernel(kernel, gridSize, blockSize, args, 0,
-                                 at::cuda::getCurrentCUDAStream()));
+                                at::cuda::getCurrentCUDAStream()));
 #else
   AT_CUDA_CHECK(cudaLaunchKernel(kernel, gridSize, blockSize, args, 0,
                                  at::cuda::getCurrentCUDAStream()));

--- a/mmcv/ops/csrc/pytorch/cuda/bias_act_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/bias_act_cuda.cu
@@ -289,7 +289,13 @@ torch::Tensor bias_act_op(const torch::Tensor &x, const torch::Tensor &b,
   int blockSize = 4 * 32;
   int gridSize = (p.sizeX - 1) / (p.loopX * blockSize) + 1;
   void *args[] = {&p};
+#ifndef MMCV_WITH_HIP
   AT_CUDA_CHECK(cudaLaunchKernel(kernel, gridSize, blockSize, args, 0,
                                  at::cuda::getCurrentCUDAStream()));
+#else
+  AT_CUDA_CHECK(hipLaunchKernel(kernel, gridSize, blockSize, args, 0,
+                                 at::cuda::getCurrentCUDAStream()));
+#endif
+
   return y;
 }

--- a/mmcv/ops/csrc/pytorch/cuda/bias_act_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/bias_act_cuda.cu
@@ -289,11 +289,11 @@ torch::Tensor bias_act_op(const torch::Tensor &x, const torch::Tensor &b,
   int blockSize = 4 * 32;
   int gridSize = (p.sizeX - 1) / (p.loopX * blockSize) + 1;
   void *args[] = {&p};
-#ifndef MMCV_WITH_HIP
-  AT_CUDA_CHECK(cudaLaunchKernel(kernel, gridSize, blockSize, args, 0,
+#ifdef MMCV_WITH_HIP
+  AT_CUDA_CHECK(hipLaunchKernel(kernel, gridSize, blockSize, args, 0,
                                  at::cuda::getCurrentCUDAStream()));
 #else
-  AT_CUDA_CHECK(hipLaunchKernel(kernel, gridSize, blockSize, args, 0,
+  AT_CUDA_CHECK(cudaLaunchKernel(kernel, gridSize, blockSize, args, 0,
                                  at::cuda::getCurrentCUDAStream()));
 #endif
 

--- a/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
@@ -672,12 +672,12 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 // Combine signs.
                 uint32_t s = sx + sy + sw + sz;
                 s <<= (signX & 3) << 1;
-#ifndef MMCV_WITH_HIP
-                s |= __shfl_xor_sync(groupMask, s, 1);
-                s |= __shfl_xor_sync(groupMask, s, 2);
-#else
+#ifdef MMCV_WITH_HIP
                 s |= __shfl_xor(s, 1);
                 s |= __shfl_xor(s, 2);
+#else
+                s |= __shfl_xor_sync(groupMask, s, 1);
+                s |= __shfl_xor_sync(groupMask, s, 2);
 #endif
 
                 // Write signs.
@@ -725,12 +725,12 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 // Combine signs.
                 uint32_t s = sx + sy + sw + sz;
                 s <<= (signX & 3) << 1;
-#ifndef MMCV_WITH_HIP
-                s |= __shfl_xor_sync(groupMask, s, 1);
-                s |= __shfl_xor_sync(groupMask, s, 2);
-#else
+#ifdef MMCV_WITH_HIP
                 s |= __shfl_xor(s, 1);
                 s |= __shfl_xor(s, 2);
+#else
+                s |= __shfl_xor_sync(groupMask, s, 1);
+                s |= __shfl_xor_sync(groupMask, s, 2);
 #endif
 
                 // Write signs.
@@ -862,12 +862,12 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 // Combine signs.
                 int s = sx + sy;
                 s <<= signXo;
-#ifndef MMCV_WITH_HIP
-                s |= __shfl_xor_sync(groupMask, s, 1);
-                s |= __shfl_xor_sync(groupMask, s, 2);
-#else
+#ifdef MMCV_WITH_HIP
                 s |= __shfl_xor(s, 1);
                 s |= __shfl_xor(s, 2);
+#else
+                s |= __shfl_xor_sync(groupMask, s, 1);
+                s |= __shfl_xor_sync(groupMask, s, 2);
 #endif
 
                 // Write signs.
@@ -897,12 +897,12 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 // Combine signs.
                 int s = sx + sy;
                 s <<= signXo;
-#ifndef MMCV_WITH_HIP
-                s |= __shfl_xor_sync(groupMask, s, 1);
-                s |= __shfl_xor_sync(groupMask, s, 2);
-#else
+#ifdef MMCV_WITH_HIP
                 s |= __shfl_xor(s, 1);
                 s |= __shfl_xor(s, 2);
+#else
+                s |= __shfl_xor_sync(groupMask, s, 1);
+                s |= __shfl_xor_sync(groupMask, s, 2);
 #endif
 
                 // Write signs.
@@ -1191,12 +1191,12 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
               }
               if ((uint32_t)signXb < p.swLimit &&
                   (uint32_t)signY < p.sShape.y && signY >= minY) {
-#ifndef MMCV_WITH_HIP
-                s += __shfl_xor_sync(groupMask, s, 1);  // Coalesce.
-                s += __shfl_xor_sync(groupMask, s, 2);  // Coalesce.
-#else
+#ifdef MMCV_WITH_HIP
                 s += __shfl_xor(s, 1);  // Coalesce.
                 s += __shfl_xor(s, 2);  // Coalesce.
+#else
+                s += __shfl_xor_sync(groupMask, s, 1);  // Coalesce.
+                s += __shfl_xor_sync(groupMask, s, 2);  // Coalesce.
 #endif
                 p.s[si] = s;                            // Write.
               }
@@ -1214,12 +1214,12 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                   s = signXbit * 2;
                   v = InternalType<T>::clamp(v, p.clamp);
                 }
-#ifndef MMCV_WITH_HIP
-                s += __shfl_xor_sync(groupMask, s, 1);  // Coalesce.
-                s += __shfl_xor_sync(groupMask, s, 2);  // Coalesce.
-#else
+#ifdef MMCV_WITH_HIP
                 s += __shfl_xor(s, 1);  // Coalesce.
                 s += __shfl_xor(s, 2);  // Coalesce.
+#else
+                s += __shfl_xor_sync(groupMask, s, 1);  // Coalesce.
+                s += __shfl_xor_sync(groupMask, s, 2);  // Coalesce.
 #endif
                 p.s[si] = s;                            // Write.
               } else {
@@ -1441,16 +1441,16 @@ static __global__ void filtered_lrelu_act_kernel(
         // Coalesce into threads 0 and 16 of warp.
         uint32_t m = (threadIdx.x & 16) ? 0xffff0000u : 0x0000ffffu;
         s <<= ((threadIdx.x & 15) << 1);  // Shift into place.
-#ifndef MMCV_WITH_HIP
-        s |= __shfl_xor_sync(m, s, 1);    // Distribute.
-        s |= __shfl_xor_sync(m, s, 2);
-        s |= __shfl_xor_sync(m, s, 4);
-        s |= __shfl_xor_sync(m, s, 8);
-#else
+#ifdef MMCV_WITH_HIP
         s |= __shfl_xor(s, 1);    // Distribute.
         s |= __shfl_xor(s, 2);
         s |= __shfl_xor(s, 4);
         s |= __shfl_xor(s, 8);
+#else
+        s |= __shfl_xor_sync(m, s, 1);    // Distribute.
+        s |= __shfl_xor_sync(m, s, 2);
+        s |= __shfl_xor_sync(m, s, 4);
+        s |= __shfl_xor_sync(m, s, 8);
 #endif
 
         // Write signs if leader and in p.s.
@@ -1676,14 +1676,14 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
 
   // Figure out how much shared memory is available on the device.
   int maxSharedBytes = 0;
-#ifndef MMCV_WITH_HIP
-  AT_CUDA_CHECK(cudaDeviceGetAttribute(&maxSharedBytes,
-                                       cudaDevAttrMaxSharedMemoryPerBlockOptin,
-                                       x.device().index()));
-#else
+#ifdef MMCV_WITH_HIP
   cudaDeviceGetAttribute(&maxSharedBytes,
                          hipDeviceAttributeSharedMemPerBlockOptin,
                          x.device().index());
+#else
+  AT_CUDA_CHECK(cudaDeviceGetAttribute(&maxSharedBytes,
+                                       cudaDevAttrMaxSharedMemoryPerBlockOptin,
+                                       x.device().index()));
 #endif
   int sharedKB = maxSharedBytes >> 10;
 
@@ -1882,12 +1882,12 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
     p.tilesXrep = 0;
     p.tilesXdim = 0;
   }
-#ifndef MMCV_WITH_HIP
-  // Launch filter setup kernel.
-  AT_CUDA_CHECK(cudaLaunchKernel(spec.setup, 1, 1024, args, 0,
+#ifdef MMCV_WITH_HIP
+  AT_CUDA_CHECK(hipLaunchKernel(spec.setup, 1, 1024, args, 0,
                                  at::cuda::getCurrentCUDAStream()));
 #else
-  AT_CUDA_CHECK(hipLaunchKernel(spec.setup, 1, 1024, args, 0,
+  // Launch filter setup kernel.
+  AT_CUDA_CHECK(cudaLaunchKernel(spec.setup, 1, 1024, args, 0,
                                  at::cuda::getCurrentCUDAStream()));
 #endif
 
@@ -1902,13 +1902,13 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
   // Set cache and shared memory configurations for main kernel.
   AT_CUDA_CHECK(cudaFuncSetCacheConfig(spec.exec, cudaFuncCachePreferShared));
   if (spec.dynamicSharedKB)  // Need dynamically allocated shared memory?
-#ifndef MMCV_WITH_HIP
-    AT_CUDA_CHECK(cudaFuncSetAttribute(
-        spec.exec, cudaFuncAttributeMaxDynamicSharedMemorySize,
-        spec.dynamicSharedKB << 10));
-#else
+#ifdef MMCV_WITH_HIP
     AT_CUDA_CHECK(hipFuncSetAttribute(
         spec.exec, hipFuncAttributeMaxDynamicSharedMemorySize,
+        spec.dynamicSharedKB << 10));
+#else
+    AT_CUDA_CHECK(cudaFuncSetAttribute(
+        spec.exec, cudaFuncAttributeMaxDynamicSharedMemorySize,
         spec.dynamicSharedKB << 10));
 #endif
   AT_CUDA_CHECK(
@@ -1921,12 +1921,12 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
   {
     p.blockZofs = zofs;
     int subGz = std::min(maxSubGz, gz - zofs);
-#ifndef MMCV_WITH_HIP
-    AT_CUDA_CHECK(cudaLaunchKernel(spec.exec, dim3(gx, gy, subGz), bx, args,
+#ifdef MMCV_WITH_HIP
+    AT_CUDA_CHECK(hipLaunchKernel(spec.exec, dim3(gx, gy, subGz), bx, args,
                                    spec.dynamicSharedKB << 10,
                                    at::cuda::getCurrentCUDAStream()));
 #else
-    AT_CUDA_CHECK(hipLaunchKernel(spec.exec, dim3(gx, gy, subGz), bx, args,
+    AT_CUDA_CHECK(cudaLaunchKernel(spec.exec, dim3(gx, gy, subGz), bx, args,
                                    spec.dynamicSharedKB << 10,
                                    at::cuda::getCurrentCUDAStream()));
 #endif
@@ -2044,12 +2044,13 @@ torch::Tensor filtered_lrelu_act_op(torch::Tensor x, torch::Tensor si, int sx,
   gz = std::min(gz, gmax);
 
   // Launch.
-#ifndef MMCV_WITH_HIP
-  AT_CUDA_CHECK(cudaLaunchKernel(func, dim3(gx, gy, gz), bx, args, 0,
-                                 at::cuda::getCurrentCUDAStream()));
-#else
+#ifdef MMCV_WITH_HIP
   AT_CUDA_CHECK(hipLaunchKernel(func, dim3(gx, gy, gz), bx, args, 0,
                                  at::cuda::getCurrentCUDAStream()));
+#else
+  AT_CUDA_CHECK(cudaLaunchKernel(func, dim3(gx, gy, gz), bx, args, 0,
+                                 at::cuda::getCurrentCUDAStream()));
 #endif
+
   return so;
 }

--- a/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
@@ -1198,7 +1198,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 s += __shfl_xor_sync(groupMask, s, 1);  // Coalesce.
                 s += __shfl_xor_sync(groupMask, s, 2);  // Coalesce.
 #endif
-                p.s[si] = s;                            // Write.
+                p.s[si] = s;  // Write.
               }
             } else {
               // Determine and write sign.
@@ -1221,7 +1221,7 @@ static __global__ void filtered_lrelu_kernel(filtered_lrelu_kernel_params p) {
                 s += __shfl_xor_sync(groupMask, s, 1);  // Coalesce.
                 s += __shfl_xor_sync(groupMask, s, 2);  // Coalesce.
 #endif
-                p.s[si] = s;                            // Write.
+                p.s[si] = s;  // Write.
               } else {
                 // Just compute the value.
                 if (v < 0.f) v *= p.slope;
@@ -1442,12 +1442,12 @@ static __global__ void filtered_lrelu_act_kernel(
         uint32_t m = (threadIdx.x & 16) ? 0xffff0000u : 0x0000ffffu;
         s <<= ((threadIdx.x & 15) << 1);  // Shift into place.
 #ifdef MMCV_WITH_HIP
-        s |= __shfl_xor(s, 1);    // Distribute.
+        s |= __shfl_xor(s, 1);  // Distribute.
         s |= __shfl_xor(s, 2);
         s |= __shfl_xor(s, 4);
         s |= __shfl_xor(s, 8);
 #else
-        s |= __shfl_xor_sync(m, s, 1);    // Distribute.
+        s |= __shfl_xor_sync(m, s, 1);  // Distribute.
         s |= __shfl_xor_sync(m, s, 2);
         s |= __shfl_xor_sync(m, s, 4);
         s |= __shfl_xor_sync(m, s, 8);
@@ -1884,7 +1884,7 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
   }
 #ifdef MMCV_WITH_HIP
   AT_CUDA_CHECK(hipLaunchKernel(spec.setup, 1, 1024, args, 0,
-                                 at::cuda::getCurrentCUDAStream()));
+                                at::cuda::getCurrentCUDAStream()));
 #else
   // Launch filter setup kernel.
   AT_CUDA_CHECK(cudaLaunchKernel(spec.setup, 1, 1024, args, 0,
@@ -1923,8 +1923,8 @@ std::tuple<torch::Tensor, torch::Tensor, int> filtered_lrelu_op(
     int subGz = std::min(maxSubGz, gz - zofs);
 #ifdef MMCV_WITH_HIP
     AT_CUDA_CHECK(hipLaunchKernel(spec.exec, dim3(gx, gy, subGz), bx, args,
-                                   spec.dynamicSharedKB << 10,
-                                   at::cuda::getCurrentCUDAStream()));
+                                  spec.dynamicSharedKB << 10,
+                                  at::cuda::getCurrentCUDAStream()));
 #else
     AT_CUDA_CHECK(cudaLaunchKernel(spec.exec, dim3(gx, gy, subGz), bx, args,
                                    spec.dynamicSharedKB << 10,
@@ -2046,7 +2046,7 @@ torch::Tensor filtered_lrelu_act_op(torch::Tensor x, torch::Tensor si, int sx,
   // Launch.
 #ifdef MMCV_WITH_HIP
   AT_CUDA_CHECK(hipLaunchKernel(func, dim3(gx, gy, gz), bx, args, 0,
-                                 at::cuda::getCurrentCUDAStream()));
+                                at::cuda::getCurrentCUDAStream()));
 #else
   AT_CUDA_CHECK(cudaLaunchKernel(func, dim3(gx, gy, gz), bx, args, 0,
                                  at::cuda::getCurrentCUDAStream()));

--- a/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/filtered_lrelu.cu
@@ -1447,7 +1447,7 @@ static __global__ void filtered_lrelu_act_kernel(
         s |= __shfl_xor(s, 4);
         s |= __shfl_xor(s, 8);
 #else
-        s |= __shfl_xor_sync(m, s, 1);  // Distribute.
+        s |= __shfl_xor_sync(m, s, 1);                  // Distribute.
         s |= __shfl_xor_sync(m, s, 2);
         s |= __shfl_xor_sync(m, s, 4);
         s |= __shfl_xor_sync(m, s, 8);

--- a/mmcv/ops/csrc/pytorch/cuda/upfirdn2d_kernel.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/upfirdn2d_kernel.cu
@@ -734,7 +734,12 @@ torch::Tensor upfirdn2d_op(torch::Tensor x, torch::Tensor f, int upx, int upy,
 
   // Launch CUDA kernel.
   void *args[] = {&p};
+#ifndef MMCV_WITH_HIP
   AT_CUDA_CHECK(cudaLaunchKernel(spec.kernel, gridSize, blockSize, args, 0,
                                  at::cuda::getCurrentCUDAStream()));
+#else
+  AT_CUDA_CHECK(hipLaunchKernel(spec.kernel, gridSize, blockSize, args, 0,
+                                 at::cuda::getCurrentCUDAStream()));
+#endif
   return y;
 }

--- a/mmcv/ops/csrc/pytorch/cuda/upfirdn2d_kernel.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/upfirdn2d_kernel.cu
@@ -736,7 +736,7 @@ torch::Tensor upfirdn2d_op(torch::Tensor x, torch::Tensor f, int upx, int upy,
   void *args[] = {&p};
 #ifdef MMCV_WITH_HIP
   AT_CUDA_CHECK(hipLaunchKernel(spec.kernel, gridSize, blockSize, args, 0,
-                                 at::cuda::getCurrentCUDAStream()));
+                                at::cuda::getCurrentCUDAStream()));
 #else
   AT_CUDA_CHECK(cudaLaunchKernel(spec.kernel, gridSize, blockSize, args, 0,
                                  at::cuda::getCurrentCUDAStream()));

--- a/mmcv/ops/csrc/pytorch/cuda/upfirdn2d_kernel.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/upfirdn2d_kernel.cu
@@ -734,12 +734,13 @@ torch::Tensor upfirdn2d_op(torch::Tensor x, torch::Tensor f, int upx, int upy,
 
   // Launch CUDA kernel.
   void *args[] = {&p};
-#ifndef MMCV_WITH_HIP
-  AT_CUDA_CHECK(cudaLaunchKernel(spec.kernel, gridSize, blockSize, args, 0,
-                                 at::cuda::getCurrentCUDAStream()));
-#else
+#ifdef MMCV_WITH_HIP
   AT_CUDA_CHECK(hipLaunchKernel(spec.kernel, gridSize, blockSize, args, 0,
                                  at::cuda::getCurrentCUDAStream()));
+#else
+  AT_CUDA_CHECK(cudaLaunchKernel(spec.kernel, gridSize, blockSize, args, 0,
+                                 at::cuda::getCurrentCUDAStream()));
 #endif
+
   return y;
 }

--- a/tests/test_ops/test_filtered_lrelu.py
+++ b/tests/test_ops/test_filtered_lrelu.py
@@ -114,10 +114,22 @@ class TestFilteredLrelu:
             self.input_tensor, bias=self.bias, flip_filter=True)
         assert out.shape == (1, 3, 16, 16)
 
-    @pytest.mark.skipif(
-        not torch.cuda.is_available()
-        or digit_version(torch.version.cuda) < digit_version('10.2'),
-        reason='requires cuda>=10.2')
+    is_rocm_pytorch = False
+    try:
+        from torch.utils.cpp_extension import ROCM_HOME
+        is_rocm_pytorch = True if ((torch.version.hip is not None) and
+                                   (ROCM_HOME is not None)) else False
+    except ImportError:
+        pass
+
+    is_skipif = True
+    if is_rocm_pytorch:
+        is_skipif = False
+    else:
+        is_skipif = (not torch.cuda.is_available() or
+                     digit_version(torch.version.cuda) < digit_version('10.2'))
+
+    @pytest.mark.skipif(is_skipif, reason='requires cuda>=10.2')
     def test_filtered_lrelu_cuda(self):
         out = filtered_lrelu(self.input_tensor.cuda(), bias=self.bias.cuda())
         assert out.shape == (1, 3, 16, 16)

--- a/tests/test_ops/test_filtered_lrelu.py
+++ b/tests/test_ops/test_filtered_lrelu.py
@@ -2,6 +2,7 @@
 import pytest
 import torch
 from mmengine.utils import digit_version
+from mmengine.utils.dl_utils.parrots_wrapper import is_rocm_pytorch
 
 from mmcv.ops import filtered_lrelu
 
@@ -114,22 +115,10 @@ class TestFilteredLrelu:
             self.input_tensor, bias=self.bias, flip_filter=True)
         assert out.shape == (1, 3, 16, 16)
 
-    is_rocm_pytorch = False
-    try:
-        from torch.utils.cpp_extension import ROCM_HOME
-        is_rocm_pytorch = True if ((torch.version.hip is not None) and
-                                   (ROCM_HOME is not None)) else False
-    except ImportError:
-        pass
-
-    is_skipif = True
-    if is_rocm_pytorch:
-        is_skipif = False
-    else:
-        is_skipif = (not torch.cuda.is_available() or
-                     digit_version(torch.version.cuda) < digit_version('10.2'))
-
-    @pytest.mark.skipif(is_skipif, reason='requires cuda>=10.2')
+    @pytest.mark.skipif(
+        not torch.cuda.is_available() or is_rocm_pytorch()
+        or digit_version(torch.version.cuda) < digit_version('10.2'),
+        reason='requires cuda>=10.2')
     def test_filtered_lrelu_cuda(self):
         out = filtered_lrelu(self.input_tensor.cuda(), bias=self.bias.cuda())
         assert out.shape == (1, 3, 16, 16)

--- a/tests/test_ops/test_filtered_lrelu.py
+++ b/tests/test_ops/test_filtered_lrelu.py
@@ -114,22 +114,10 @@ class TestFilteredLrelu:
             self.input_tensor, bias=self.bias, flip_filter=True)
         assert out.shape == (1, 3, 16, 16)
 
-    is_rocm_pytorch = False
-    try:
-        from torch.utils.cpp_extension import ROCM_HOME
-        is_rocm_pytorch = True if ((torch.version.hip is not None) and
-                                   (ROCM_HOME is not None)) else False
-    except ImportError:
-        pass
-
-    is_skipif = True
-    if is_rocm_pytorch:
-        is_skipif = False
-    else:
-        is_skipif = (not torch.cuda.is_available() or
-                     digit_version(torch.version.cuda) < digit_version('10.2'))
-
-    @pytest.mark.skipif(is_skipif, reason='requires cuda>=10.2')
+    @pytest.mark.skipif(
+        not torch.cuda.is_available() or is_rocm_pytorch() or
+        or digit_version(torch.version.cuda) < digit_version('10.2'),
+        reason='requires cuda>=10.2')
     def test_filtered_lrelu_cuda(self):
         out = filtered_lrelu(self.input_tensor.cuda(), bias=self.bias.cuda())
         assert out.shape == (1, 3, 16, 16)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This PR enables HIP as a backened for pytorch only.

## Modification

1. conv2d_gradfix.py :Torch version comparison, if the version number has rc or a, there is an error.Conv calls the conversion from cudnn to miopen.
2. corner_pool.py：Torch version comparison, if the version number has rc or a, there is an error.
3. bias_act_cuda.cu/upfirdn2d_kernel.cu : Torch hipify transcoding rule is missing.
4. filtered_lrelu.cu ： cuda : __shfl_xor_sync -> rocm : __shfl_xor
5. test_filtered_lrelu.py ： Test case, add rocm judgment.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
