### PR TITLE
[Fix] Fix arf op's write conflict when num_orientations is not 1

### DIFF
--- a/mmcv/ops/csrc/common/cuda/active_rotated_filter_cuda_kernel.cuh
+++ b/mmcv/ops/csrc/common/cuda/active_rotated_filter_cuda_kernel.cuh
@@ -15,18 +15,19 @@ __global__ void active_rotated_filter_forward_cuda_kernel(
     const int nthreads, const scalar_t* weight_data, const int* indices_data,
     const int num_input_planes, const int num_output_planes,
     const int num_orientations, const int num_rotations, const int nEntry,
-    scalar_t* output_data) {
+    const int kH, const int kW, scalar_t* output_data) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     int l = index % nEntry;
     int j = (index / nEntry) % num_input_planes;
     int i = index / nEntry / num_input_planes;
     int k;
+    int fmIndex = (l / (kH * kW)) * kH * kW;
     scalar_t val = *(weight_data + index);
     for (k = 0; k < num_rotations; k++) {
       int idx = (int)(*(indices_data + l * num_rotations + k)) - 1;
-      scalar_t* target = output_data +
-                         i * (num_rotations * num_input_planes * nEntry) +
-                         k * (num_input_planes * nEntry) + j * (nEntry) + idx;
+      scalar_t* target =
+          output_data + i * (num_rotations * num_input_planes * nEntry) +
+          k * (num_input_planes * nEntry) + j * (nEntry) + idx + fmIndex;
       *target = val;
     }
   }
@@ -37,12 +38,14 @@ __global__ void active_rotated_filter_backward_cuda_kernel(
     const int nthreads, const scalar_t* gradWeight_data,
     const int* indices_data, const int num_input_planes,
     const int num_output_planes, const int num_orientations,
-    const int num_rotations, const int nEntry, scalar_t* weight_data) {
+    const int num_rotations, const int nEntry, const int kH, const int kW,
+    scalar_t* weight_data) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     int l = index % nEntry;
     int j = (index / nEntry) % num_input_planes;
     int i = index / nEntry / num_input_planes;
     int k;
+    int fmIndex = (l / (kH * kW)) * kH * kW;
     scalar_t* val = weight_data + index;
     *val = 0;
     scalar_t tmp = 0;
@@ -50,7 +53,7 @@ __global__ void active_rotated_filter_backward_cuda_kernel(
       int idx = (int)(*(indices_data + l * num_rotations + k)) - 1;
       scalar_t target =
           *(gradWeight_data + i * (num_rotations * num_input_planes * nEntry) +
-            k * (num_input_planes * nEntry) + j * (nEntry) + idx);
+            k * (num_input_planes * nEntry) + j * (nEntry) + idx + fmIndex);
       tmp = tmp + target;
     }
     *val = tmp;

--- a/mmcv/ops/csrc/pytorch/cpu/active_rotated_filter.cpp
+++ b/mmcv/ops/csrc/pytorch/cpu/active_rotated_filter.cpp
@@ -19,11 +19,12 @@ void active_rotated_filter_forward_cpu_kernel(
       for (l = 0; l < nEntry; l++) {
         int weightIndex = i * num_input_planes * nEntry + j * nEntry + l;
         T val = *(weightData + weightIndex);
+        int fmIndex = (l / (kH * kW)) * kH * kW;
         for (k = 0; k < num_rotations; k++) {
           int index = (int)(*(indicesData + l * num_rotations + k)) - 1;
-          T* target = outputData +
-                      i * (num_rotations * num_input_planes * nEntry) +
-                      k * (num_input_planes * nEntry) + j * (nEntry) + index;
+          T* target =
+              outputData + i * (num_rotations * num_input_planes * nEntry) +
+              k * (num_input_planes * nEntry) + j * (nEntry) + index + fmIndex;
           *target = val;
         }
       }
@@ -48,11 +49,12 @@ void active_rotated_filter_backward_cpu_kernel(
         int gradInputIndex = i * num_input_planes * nEntry + j * nEntry + l;
         T* val = gradInputData + gradInputIndex;
         *val = 0;
+        int fmIndex = (l / (kH * kW)) * kH * kW;
         for (k = 0; k < num_rotations; k++) {
           int index = (int)(*(indicesData + l * num_rotations + k)) - 1;
           const T* target =
               gradOutputData + i * (num_rotations * num_input_planes * nEntry) +
-              k * (num_input_planes * nEntry) + j * (nEntry) + index;
+              k * (num_input_planes * nEntry) + j * (nEntry) + index + fmIndex;
           *val = *val + *target;
         }
       }

--- a/mmcv/ops/csrc/pytorch/cuda/active_rotated_filter_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/active_rotated_filter_cuda.cu
@@ -24,7 +24,7 @@ void ActiveRotatedFilterForwardCUDAKernelLauncher(const Tensor input,
             <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK, 0, stream>>>(
                 output_size, input.data_ptr<scalar_t>(),
                 indices.data_ptr<int>(), num_input_planes, num_output_planes,
-                num_orientations, num_rotations, nEntry,
+                num_orientations, num_rotations, nEntry, kH, kW,
                 output.data_ptr<scalar_t>());
       });
   AT_CUDA_CHECK(cudaGetLastError());
@@ -51,7 +51,7 @@ void ActiveRotatedFilterBackwardCUDAKernelLauncher(const Tensor grad_out,
             <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK, 0, stream>>>(
                 output_size, grad_out.data_ptr<scalar_t>(),
                 indices.data_ptr<int>(), num_input_planes, num_output_planes,
-                num_orientations, num_rotations, nEntry,
+                num_orientations, num_rotations, nEntry, kH, kW,
                 grad_in.data_ptr<scalar_t>());
       });
   AT_CUDA_CHECK(cudaGetLastError());


### PR DESCRIPTION
## Motivation

1. When num_orientations is not 1, the calculation result of active_rotated_filter op on cpu is inconsistent with that on cuda.
2. Issue link: [2718](https://github.com/open-mmlab/mmcv/issues/2718)，the modified code can pass the sample test.
3. This change does not affect scenarios where num_orientations is 1.

## Modification

Indexes are added to prevent data from being written to only the first feature map.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
