### PR TITLE
[Docs] small fix for RandomResize doc

### DIFF
--- a/mmcv/transforms/processing.py
+++ b/mmcv/transforms/processing.py
@@ -1400,7 +1400,7 @@ class RandomResize(BaseTransform):
         target\\_scale[0] \\sim Uniform([ratio\\_range[0], ratio\\_range[1]])
             * scale[0]
     .. math::
-        target\\_scale[0] \\sim Uniform([ratio\\_range[0], ratio\\_range[1]])
+        target\\_scale[1] \\sim Uniform([ratio\\_range[0], ratio\\_range[1]])
             * scale[1]
 
     Following the resize order of weight and height in cv2, ``ratio_range[0]``


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

I think the index of the second target_scale should be 1 instead of 0 in docstring.

## Modification

doc correction only.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
