### PR TITLE
[Enhance] Add ConvModule.turn_on_fast_conv_bn_eval to reduce repetitive code and dynamically bind conv during forward

### DIFF
--- a/mmcv/cnn/bricks/conv_module.py
+++ b/mmcv/cnn/bricks/conv_module.py
@@ -209,8 +209,7 @@ class ConvModule(nn.Module):
         else:
             self.norm_name = None  # type: ignore
 
-        if fast_conv_bn_eval:
-            self.turn_on_fast_conv_bn_eval()
+        self.turn_on_fast_conv_bn_eval(fast_conv_bn_eval)
 
         # build activation layer
         if self.with_activation:
@@ -283,11 +282,12 @@ class ConvModule(nn.Module):
             layer_index += 1
         return x
 
-    def turn_on_fast_conv_bn_eval(self):
+    def turn_on_fast_conv_bn_eval(self, fast_conv_bn_eval=True):
         # fast_conv_bn_eval works for conv + bn
         # with `track_running_stats` option
-        if self.norm and isinstance(self.norm, _BatchNorm) \
-                    and self.norm.track_running_stats:
+        if fast_conv_bn_eval and self.norm \
+                            and isinstance(self.norm, _BatchNorm) \
+                            and self.norm.track_running_stats:
             self.fast_conv_bn_eval_forward = partial(fast_conv_bn_eval_forward,
                                                      self.norm, self.conv)
         else:
@@ -331,7 +331,6 @@ class ConvModule(nn.Module):
         self.norm_name, norm = 'bn', bn
         self.add_module(self.norm_name, norm)
 
-        if fast_conv_bn_eval:
-            self.turn_on_fast_conv_bn_eval()
+        self.turn_on_fast_conv_bn_eval(fast_conv_bn_eval)
 
         return self

--- a/mmcv/cnn/bricks/conv_module.py
+++ b/mmcv/cnn/bricks/conv_module.py
@@ -273,10 +273,11 @@ class ConvModule(nn.Module):
                     self.conv.forward = partial(self.fast_conv_bn_eval_forward,
                                                 self.norm, self.conv)
                     layer_index += 1
-                else:
+                    x = self.conv(x)
                     self.conv.forward = partial(self.original_conv_forward,
                                                 self.conv)
-                x = self.conv(x)
+                else:
+                    x = self.conv(x)
             elif layer == 'norm' and norm and self.with_norm:
                 x = self.norm(x)
             elif layer == 'act' and activate and self.with_activation:

--- a/mmcv/cnn/bricks/conv_module.py
+++ b/mmcv/cnn/bricks/conv_module.py
@@ -274,8 +274,7 @@ class ConvModule(nn.Module):
                                                 self.norm, self.conv)
                     layer_index += 1
                     x = self.conv(x)
-                    self.conv.forward = partial(self.original_conv_forward,
-                                                self.conv)
+                    del self.conv.forward
                 else:
                     x = self.conv(x)
             elif layer == 'norm' and norm and self.with_norm:
@@ -294,7 +293,6 @@ class ConvModule(nn.Module):
             self.fast_conv_bn_eval_forward = fast_conv_bn_eval_forward
         else:
             self.fast_conv_bn_eval_forward = None  # type: ignore
-        self.original_conv_forward = self.conv.__class__.forward
 
     @staticmethod
     def create_from_conv_bn(conv: torch.nn.modules.conv._ConvNd,

--- a/tests/test_cnn/test_conv_module.py
+++ b/tests/test_cnn/test_conv_module.py
@@ -76,14 +76,26 @@ def test_conv_module():
     assert output.shape == (1, 8, 255, 255)
 
     # conv + norm with fast mode
-    conv = ConvModule(
-        3, 8, 2, norm_cfg=dict(type='BN'), fast_conv_bn_eval=True)
-    conv.norm.eval()
-    x = torch.rand(1, 3, 256, 256)
-    fast_mode_output = conv(x)
-    conv.conv.forward = conv.original_conv_forward
-    plain_implementation = conv.activate(conv.norm(conv.conv(x)))
-    assert torch.allclose(fast_mode_output, plain_implementation, atol=1e-5)
+    fast_conv = ConvModule(
+        3, 8, 2, norm_cfg=dict(type='BN'), fast_conv_bn_eval=True).eval()
+    plain_conv = ConvModule(
+        3, 8, 2, norm_cfg=dict(type='BN'), fast_conv_bn_eval=False).eval()
+    for fast_param, plain_param in zip(fast_conv.state_dict().values(),
+                                       plain_conv.state_dict().values()):
+        plain_param.copy_(fast_param)
+
+    fast_mode_output = fast_conv(x)
+    plain_mode_output = plain_conv(x)
+    assert torch.allclose(fast_mode_output, plain_mode_output, atol=1e-5)
+
+    # `conv` attribute can be dynamically modified in fast mode
+    fast_conv = ConvModule(
+        3, 8, 2, norm_cfg=dict(type='BN'), fast_conv_bn_eval=True).eval()
+    new_conv = nn.Conv2d(3, 8, 2).eval()
+    fast_conv.conv = new_conv
+    fast_mode_output = fast_conv(x)
+    plain_mode_output = fast_conv.activate(fast_conv.norm(new_conv(x)))
+    assert torch.allclose(fast_mode_output, plain_mode_output, atol=1e-5)
 
     # conv + act
     conv = ConvModule(3, 8, 2)


### PR DESCRIPTION
## Motivation

Reduce repetitive code for the `fast_conv_bn_eval` feature introduced in https://github.com/open-mmlab/mmcv/pull/2807 .

## Modification

Create a simple `turn_on_fast_conv_bn_eval` function, and call this function in `__init__` and `create_from_conv_bn`. In the future, `mmengine` might also require this function. See https://github.com/open-mmlab/mmengine/pull/1202 for details.

This PR also subsumes the https://github.com/open-mmlab/mmcv/pull/2836 PR to dynamically bind conv during forward. Test examples added for this case.

## BC-breaking (Optional)

It does not break backward-compatibility, as it just introduces a new function.

## Use cases (Optional)

An existing `ConvModule` object can call `turn_on_fast_conv_bn_eval` to turn on the `fast_conv_bn_eval` feature.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
