### PR TITLE
[Fix] Make `conv` attribute can be dynamically modified in fast-conv mode

### DIFF
--- a/mmcv/cnn/bricks/conv_module.py
+++ b/mmcv/cnn/bricks/conv_module.py
@@ -279,9 +279,11 @@ class ConvModule(nn.Module):
                     self.conv.forward = partial(fast_conv_bn_eval_forward,
                                                 self.bn, self.conv)
                     layer_index += 1
-                x = self.conv(x)
-                # clear the partial function attribute
-                self.conv.__dict__.pop('forward', None)
+                    x = self.conv(x)
+                    # clear the partial function attribute
+                    self.conv.__dict__.pop('forward', None)
+                else:
+                    x = self.conv(x)
             elif layer == 'norm' and norm and self.with_norm:
                 x = self.norm(x)
             elif layer == 'act' and activate and self.with_activation:

--- a/tests/test_cnn/test_conv_module.py
+++ b/tests/test_cnn/test_conv_module.py
@@ -76,14 +76,26 @@ def test_conv_module():
     assert output.shape == (1, 8, 255, 255)
 
     # conv + norm with fast mode
-    conv = ConvModule(
-        3, 8, 2, norm_cfg=dict(type='BN'), fast_conv_bn_eval=True)
-    conv.norm.eval()
-    x = torch.rand(1, 3, 256, 256)
-    fast_mode_output = conv(x)
-    conv.conv.forward = conv.original_conv_forward
-    plain_implementation = conv.activate(conv.norm(conv.conv(x)))
-    assert torch.allclose(fast_mode_output, plain_implementation, atol=1e-5)
+    fast_conv = ConvModule(
+        3, 8, 2, norm_cfg=dict(type='BN'), fast_conv_bn_eval=True).eval()
+    plain_conv = ConvModule(
+        3, 8, 2, norm_cfg=dict(type='BN'), fast_conv_bn_eval=False).eval()
+    for fast_param, plain_param in zip(fast_conv.state_dict().values(),
+                                       plain_conv.state_dict().values()):
+        plain_param.copy_(fast_param)
+
+    fast_mode_output = fast_conv(x)
+    plain_mode_output = plain_conv(x)
+    assert torch.allclose(fast_mode_output, plain_mode_output, atol=1e-5)
+
+    # `conv` attribute can be dynamically modified in fast mode
+    fast_conv = ConvModule(
+        3, 8, 2, norm_cfg=dict(type='BN'), fast_conv_bn_eval=True).eval()
+    new_conv = nn.Conv2d(3, 8, 2).eval()
+    fast_conv.conv = new_conv
+    fast_mode_output = fast_conv(x)
+    plain_mode_output = fast_conv.activate(fast_conv.norm(new_conv(x)))
+    assert torch.allclose(fast_mode_output, plain_mode_output, atol=1e-5)
 
     # conv + act
     conv = ConvModule(3, 8, 2)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`conv` attribute in `ConvModule` cannot be modified dynamically since the bounded method `self.original_conv_forward` will bind the `conv` instance:

https://github.com/open-mmlab/mmcv/blob/8d87bf44caa80a2fe6d89f25f026b31624a82225/mmcv/cnn/bricks/conv_module.py#L220

This PR solves this problem

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
