### PR TITLE
[Enhancement] support `dipu_mock_cuda=False` in `dipu` for mmcv ext ops with cpu fallback

### DIFF
--- a/mmcv/ops/csrc/pytorch/bbox_overlaps.cpp
+++ b/mmcv/ops/csrc/pytorch/bbox_overlaps.cpp
@@ -33,7 +33,8 @@ void bbox_overlaps_diopi(const Tensor bboxes1, const Tensor bboxes2,
   diopiContextHandle_t ch = &ctx;
   auto bboxes2_p = toDiopiTensorHandle(bboxes2);
   auto ious_p = toDiopiTensorHandle(ious);
-  if (reinterpret_cast<void *>(diopiBboxOverlapsMmcv) != nullptr) {
+  bool is_mock_cuda = bboxes1.device().type() == c10::DeviceType::PrivateUse1;
+  if (is_mock_cuda && reinterpret_cast<void *>(diopiBboxOverlapsMmcv) != nullptr) {
     auto ret = diopiBboxOverlapsMmcv(ch, ious_p, bboxes1_p, bboxes2_p, mode,
                                      offset, aligned);
     if (ret == diopiSuccess) return;

--- a/mmcv/ops/csrc/pytorch/bbox_overlaps.cpp
+++ b/mmcv/ops/csrc/pytorch/bbox_overlaps.cpp
@@ -33,8 +33,7 @@ void bbox_overlaps_diopi(const Tensor bboxes1, const Tensor bboxes2,
   diopiContextHandle_t ch = &ctx;
   auto bboxes2_p = toDiopiTensorHandle(bboxes2);
   auto ious_p = toDiopiTensorHandle(ious);
-  bool is_mock_cuda = bboxes1.device().type() == c10::DeviceType::PrivateUse1;
-  if (is_mock_cuda && reinterpret_cast<void *>(diopiBboxOverlapsMmcv) != nullptr) {
+  if (reinterpret_cast<void *>(diopiBboxOverlapsMmcv) != nullptr) {
     auto ret = diopiBboxOverlapsMmcv(ch, ious_p, bboxes1_p, bboxes2_p, mode,
                                      offset, aligned);
     if (ret == diopiSuccess) return;

--- a/mmcv/ops/csrc/pytorch/bbox_overlaps.cpp
+++ b/mmcv/ops/csrc/pytorch/bbox_overlaps.cpp
@@ -33,7 +33,9 @@ void bbox_overlaps_diopi(const Tensor bboxes1, const Tensor bboxes2,
   diopiContextHandle_t ch = &ctx;
   auto bboxes2_p = toDiopiTensorHandle(bboxes2);
   auto ious_p = toDiopiTensorHandle(ious);
-  if (reinterpret_cast<void *>(diopiBboxOverlapsMmcv) != nullptr) {
+  bool is_mock_cuda = bboxes1.device().type() == c10::DeviceType::PrivateUse1;
+  if (is_mock_cuda &&
+      reinterpret_cast<void *>(diopiBboxOverlapsMmcv) != nullptr) {
     auto ret = diopiBboxOverlapsMmcv(ch, ious_p, bboxes1_p, bboxes2_p, mode,
                                      offset, aligned);
     if (ret == diopiSuccess) return;

--- a/mmcv/ops/csrc/pytorch/nms.cpp
+++ b/mmcv/ops/csrc/pytorch/nms.cpp
@@ -42,7 +42,8 @@ Tensor nms_diopi(Tensor boxes, Tensor scores, float iou_threshold, int offset) {
   auto outp = toDiopiTensorHandle(out);
   diopiTensorHandle_t* outhandle = &outp;
   auto scores_p = toDiopiTensorHandle(scores);
-  if (reinterpret_cast<void*>(diopiNmsMmcv) != nullptr) {
+  bool is_mock_cuda = boxes.device().type() == c10::DeviceType::PrivateUse1;
+  if (is_mock_cuda && reinterpret_cast<void*>(diopiNmsMmcv) != nullptr) {
     auto ret =
         diopiNmsMmcv(ch, outhandle, boxes_p, scores_p, iou_threshold, offset);
     if (ret == diopiSuccess) {

--- a/mmcv/ops/csrc/pytorch/roi_align.cpp
+++ b/mmcv/ops/csrc/pytorch/roi_align.cpp
@@ -53,7 +53,8 @@ void roi_align_forward_diopi(Tensor input, Tensor rois, Tensor output,
   auto out_p = toDiopiTensorHandle(output);
   auto argmax_y_p = toDiopiTensorHandle(argmax_y);
   auto argmax_x_p = toDiopiTensorHandle(argmax_x);
-  if (reinterpret_cast<void*>(diopiRoiAlignMmcv) != nullptr) {
+  bool is_mock_cuda = input.device().type() == c10::DeviceType::PrivateUse1;
+  if (is_mock_cuda && reinterpret_cast<void*>(diopiRoiAlignMmcv) != nullptr) {
     auto ret = diopiRoiAlignMmcv(
         ch, out_p, argmax_y_p, argmax_x_p, input_p, rois_p, aligned_height,
         aligned_width, sampling_ratio, pool_mode, spatial_scale, aligned);
@@ -91,7 +92,8 @@ void roi_align_backward_diopi(Tensor grad_output, Tensor rois, Tensor argmax_y,
   auto grad_input_ = toDiopiTensorHandle(grad_input);
   diopiContext ctx(dipu::getCurrentDIPUStream().rawstream());
   diopiContextHandle_t ch = &ctx;
-  if (reinterpret_cast<void*>(diopiRoiAlignBackwardMmcv) != nullptr) {
+  bool is_mock_cuda = grad_output.device().type() == c10::DeviceType::PrivateUse1;
+  if (is_mock_cuda && reinterpret_cast<void*>(diopiRoiAlignBackwardMmcv) != nullptr) {
     auto ret = diopiRoiAlignBackwardMmcv(ch, grad_input_, grad_output_, rois_,
                                          argmax_y_, argmax_x_, aligned_height,
                                          aligned_width, sampling_ratio,

--- a/mmcv/ops/csrc/pytorch/roi_align.cpp
+++ b/mmcv/ops/csrc/pytorch/roi_align.cpp
@@ -92,8 +92,10 @@ void roi_align_backward_diopi(Tensor grad_output, Tensor rois, Tensor argmax_y,
   auto grad_input_ = toDiopiTensorHandle(grad_input);
   diopiContext ctx(dipu::getCurrentDIPUStream().rawstream());
   diopiContextHandle_t ch = &ctx;
-  bool is_mock_cuda = grad_output.device().type() == c10::DeviceType::PrivateUse1;
-  if (is_mock_cuda && reinterpret_cast<void*>(diopiRoiAlignBackwardMmcv) != nullptr) {
+  bool is_mock_cuda =
+      grad_output.device().type() == c10::DeviceType::PrivateUse1;
+  if (is_mock_cuda &&
+      reinterpret_cast<void*>(diopiRoiAlignBackwardMmcv) != nullptr) {
     auto ret = diopiRoiAlignBackwardMmcv(ch, grad_input_, grad_output_, rois_,
                                          argmax_y_, argmax_x_, aligned_height,
                                          aligned_width, sampling_ratio,


### PR DESCRIPTION
support mmcv dipu_mock_cuda=False for ops with cpu fallback