### PR TITLE
[Fix] fix an error about copy.deepcopy(Named tensor) are not supported with the tracer

### DIFF
--- a/mmcv/cnn/bricks/transformer.py
+++ b/mmcv/cnn/bricks/transformer.py
@@ -662,7 +662,7 @@ class BaseTransformerLayer(BaseModule):
         operation_order (tuple[str]): The execution order of operation
             in transformer. Such as ('self_attn', 'norm', 'ffn', 'norm').
             Support `prenorm` when you specifying first element as `norm`.
-            Default：None.
+            Default: None.
         norm_cfg (dict): Config dict for normalization layer.
             Default: dict(type='LN').
         init_cfg (obj:`mmcv.ConfigDict`): The Config for initialization.
@@ -814,7 +814,7 @@ class BaseTransformerLayer(BaseModule):
             attn_masks = [None for _ in range(self.num_attn)]
         elif isinstance(attn_masks, torch.Tensor):
             attn_masks = [
-                copy.deepcopy(attn_masks) for _ in range(self.num_attn)
+                attn_masks.detach().clone() for _ in range(self.num_attn)
             ]
             warnings.warn(f'Use same attn_mask in all attentions in '
                           f'{self.__class__.__name__} ')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Environment:
```
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
OrderedDict([('sys.platform', 'darwin'), ('Python', '3.8.15 (default, Nov 10 2022, 13:17:42) [Clang 14.0.6 ]'), ('CUDA available', False), ('numpy_random_seed', 2147483648), ('GCC', 'Apple clang version 11.0.0 (clang-1100.0.33.8)'), ('PyTorch', '1.13.1'), ('PyTorch compiling details', 'PyTorch built with:\n  - GCC 4.2\n  - C++ Version: 201402\n  - clang 14.0.0\n  - Intel(R) Math Kernel Library Version 2020.0.1 Product Build 20200208 for Intel(R) 64 architecture applications\n  - Intel(R) MKL-DNN v2.6.0 (Git Hash 52b5f107dd9cf10910aaa19cb47f3abf9b349815)\n  - LAPACK is enabled (usually provided by MKL)\n  - NNPACK is enabled\n  - CPU capability usage: NO AVX\n  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, CXX_COMPILER=/Applications/Xcode_14.0.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++, CXX_FLAGS= -Wno-deprecated -fvisibility-inlines-hidden -Wno-deprecated-declarations -DUSE_PTHREADPOOL -DNDEBUG -DUSE_KINETO -DLIBKINETO_NOCUPTI -DUSE_FBGEMM -DUSE_QNNPACK -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DUSE_PYTORCH_METAL_EXPORT -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -DEDGE_PROFILER_USE_KINETO -DUSE_COREML_DELEGATE -O2 -fPIC -Wno-narrowing -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Wno-missing-field-initializers -Wno-type-limits -Wno-array-bounds -Wno-unknown-pragmas -Wunused-local-typedefs -Wno-unused-parameter -Wno-unused-function -Wno-unused-result -Wno-strict-overflow -Wno-strict-aliasing -Wno-error=deprecated-declarations -Wvla-extension -Wno-range-loop-analysis -Wno-pass-failed -Wno-error=pedantic -Wno-error=redundant-decls -Wno-error=old-style-cast -Wconstant-conversion -Wno-invalid-partial-specialization -Wno-typedef-redefinition -Wno-unused-private-field -Wno-inconsistent-missing-override -Wno-c++14-extensions -Wno-constexpr-not-const -Wno-missing-braces -Wunused-lambda-capture -Wunused-local-typedef -Qunused-arguments -fcolor-diagnostics -fdiagnostics-color=always -fno-math-errno -fno-trapping-math -Werror=format -Werror=cast-function-type -DUSE_MPS -fno-objc-arc -Wno-unguarded-availability-new -Wno-unused-private-field -Wno-missing-braces -Wno-c++14-extensions -Wno-constexpr-not-const, LAPACK_INFO=mkl, PERF_WITH_AVX512=1, TORCH_VERSION=1.13.1, USE_CUDA=OFF, USE_CUDNN=OFF, USE_EXCEPTION_PTR=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=OFF, USE_NNPACK=ON, USE_OPENMP=OFF, USE_ROCM=OFF, \n'), ('TorchVision', '0.14.1'), ('OpenCV', '4.6.0'), ('MMEngine', '0.8.1'), ('MMCV', '2.0.1'), ('MMCV Compiler', 'clang 11.0.0'), ('MMCV CUDA Compiler', 'not available')])
```

Reproduces the problem - code sample

mmocr==1.0.1
```shell
python tools/analysis_tools/get_flops.py configs/textrecog/abinet/abinet_20e_st-an_mj.py --shape 32 128
```

Reproduces the problem - error message

```
/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/module_losses/ce_module_loss.py:101: UserWarning: padding does not exist in the dictionary
  warnings.warn(
/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/postprocessors/base.py:60: UserWarning: padding does not exist in the dictionary
  warnings.warn(
Traceback (most recent call last):
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
    cli.main()
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
    run()
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 284, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 321, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 135, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
  File "/Users/wangnu/Documents/GitHub/mmocr/tools/analysis_tools/get_flops.py", line 56, in <module>
    main()
  File "/Users/wangnu/Documents/GitHub/mmocr/tools/analysis_tools/get_flops.py", line 46, in main
    flops_data = flop_count_table(flops)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/fvcore/nn/print_model_statistics.py", line 632, in flop_count_table
    stats = {params_header: params, flops_header: flops.by_module()}
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/fvcore/nn/jit_analysis.py", line 291, in by_module
    stats = self._analyze()
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/fvcore/nn/jit_analysis.py", line 551, in _analyze
    graph = _get_scoped_trace_graph(self._model, self._inputs, self._aliases)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/fvcore/nn/jit_analysis.py", line 176, in _get_scoped_trace_graph
    graph, _ = _get_trace_graph(module, inputs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/jit/_trace.py", line 1184, in _get_trace_graph
    outs = ONNXTracedModule(f, strict, _force_outplace, return_inputs, _return_inputs_states)(*args, **kwargs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/jit/_trace.py", line 127, in forward
    graph, out = torch._C._create_graph_by_tracing(
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/jit/_trace.py", line 118, in wrapper
    outs.append(self.inner(*trace_inputs))
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1212, in _call_impl
    result = forward_call(*input, **kwargs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1182, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/recognizers/base.py", line 92, in forward
    return self._forward(inputs, data_samples, **kwargs)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/recognizers/encoder_decoder_recognizer.py", line 130, in _forward
    return self.decoder(feat, out_enc, data_samples)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1212, in _call_impl
    result = forward_call(*input, **kwargs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1182, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/decoders/base.py", line 166, in forward
    return self.forward_test(feat, out_enc, data_samples)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/decoders/abi_fuser.py", line 145, in forward_test
    raw_result = self.forward_train(feat, logits, data_samples)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/decoders/abi_fuser.py", line 114, in forward_train
    out_dec = self.language_decoder(feat, text_logits,
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1212, in _call_impl
    result = forward_call(*input, **kwargs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1182, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/decoders/base.py", line 166, in forward
    return self.forward_test(feat, out_enc, data_samples)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/decoders/abi_language_decoder.py", line 180, in forward_test
    return self.forward_train(feat, logits, data_samples)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/decoders/abi_language_decoder.py", line 146, in forward_train
    output = m(
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1212, in _call_impl
    result = forward_call(*input, **kwargs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1182, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmcv/cnn/bricks/transformer.py", line 816, in forward
    attn_masks = [
  File "/Users/wangnu/Documents/GitHub/mmocr/mmcv/cnn/bricks/transformer.py", line 817, in <listcomp>
    copy.deepcopy(attn_masks) for _ in range(self.num_attn)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/copy.py", line 153, in deepcopy
    y = copier(memo)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/_tensor.py", line 135, in __deepcopy__
    new_storage = self.storage().__deepcopy__(memo)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/storage.py", line 597, in __deepcopy__
    return self._new_wrapped_storage(copy.deepcopy(self._storage, memo))
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/copy.py", line 153, in deepcopy
    y = copier(memo)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/storage.py", line 97, in __deepcopy__
    new_storage = self.clone()
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/storage.py", line 111, in clone
    return type(self)(self.nbytes(), device=self.device).copy_(self)
RuntimeError: NYI: Named tensors are not supported with the tracer
```


## Modification

I have identified the cause of the problem（thanks ChatGPT）：
<img width="1183" alt="image" src="https://github.com/open-mmlab/mmcv/assets/34083603/82b89285-41e4-46c0-943a-b74d6ab47381">

With above modifications, the error is indeed resolved, but i am not sure whether this replacement is necessary

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
