### PR TITLE
CodeCamp2023-288

### DIFF
--- a/mmcv/runner/hooks/logger/segmind.py
+++ b/mmcv/runner/hooks/logger/segmind.py
@@ -6,7 +6,8 @@ from .base import LoggerHook
 
 @HOOKS.register_module()
 class SegmindLoggerHook(LoggerHook):
-    """Class to log metrics to Segmind.
+    """Segmind is no longer supported.
+    Class to log metrics to Segmind.
 
     It requires `Segmind`_ to be installed.
 


### PR DESCRIPTION




## Motivation

The original task was to add the Segmind backend for Visualizer, but since Segmind no longer supports training visualization, the mentor suggested changing the task to adding the Neptune backend.

## Modification

1. According to the latest API documentation provided by Neptune, modify and enhance the NeptuneLoggerHook, and update the user instructions.
2. Update the user instructions for the SegmindLoggerHook.


## BC-breaking (Optional)

The changes won't break the backward-compatibility of the downstream repositories



## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
