### PR TITLE
[CodeCamp2023]-Task#288

### DIFF
--- a/mmcv/runner/hooks/logger/segmind.py
+++ b/mmcv/runner/hooks/logger/segmind.py
@@ -19,8 +19,8 @@ class SegmindLoggerHook(LoggerHook):
             Default False.
         by_epoch (bool): Whether EpochBasedRunner is used. Default True.
 
-    .. _Segmind:
-        https://docs.segmind.com/python-library
+    .. _Segmind-old:
+        https://github.com/segmind/segmind-old
     """
 
     def __init__(self,

--- a/mmcv/runner/hooks/logger/segmind.py
+++ b/mmcv/runner/hooks/logger/segmind.py
@@ -6,7 +6,8 @@ from .base import LoggerHook
 
 @HOOKS.register_module()
 class SegmindLoggerHook(LoggerHook):
-    """Class to log metrics to Segmind.
+    """Segmind is no longer supported.
+    Class to log metrics to Segmind.
 
     It requires `Segmind`_ to be installed.
 

--- a/mmcv/runner/hooks/logger/segmind.py
+++ b/mmcv/runner/hooks/logger/segmind.py
@@ -6,8 +6,7 @@ from .base import LoggerHook
 
 @HOOKS.register_module()
 class SegmindLoggerHook(LoggerHook):
-    """Segmind is no longer supported.
-    Class to log metrics to Segmind.
+    """Segmind is no longer supported. Class to log metrics to Segmind.
 
     It requires `Segmind`_ to be installed.
 

--- a/mmcv/runner/hooks/logger/segmind.py
+++ b/mmcv/runner/hooks/logger/segmind.py
@@ -6,8 +6,9 @@ from .base import LoggerHook
 
 @HOOKS.register_module()
 class SegmindLoggerHook(LoggerHook):
-    """Segmind is no longer supported. Class to log metrics to Segmind.
+    """Segmind is no longer supported.
 
+    Class to log metrics to Segmind.
     It requires `Segmind`_ to be installed.
 
     Args:


### PR DESCRIPTION

## Motivation

Task#288: Add Segmind backend to Visualizer

## Modification

The original task was to add the Segmind backend for V, but since Segmind no longer supports training visualization, the mentor suggested changing the task to adding the Neptune backend.

1. add neptune backend to Visualizer and update the user instructions
2. segmind is no longer supported and update the user instructions




## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
