### PR TITLE
[Feature] Support AMP in box_iou_rotated

### DIFF
--- a/mmcv/ops/box_iou_rotated.py
+++ b/mmcv/ops/box_iou_rotated.py
@@ -141,6 +141,10 @@ def box_iou_rotated(bboxes1: torch.Tensor,
         bboxes2 = bboxes2 * flip_mat
     bboxes1 = bboxes1.contiguous()
     bboxes2 = bboxes2.contiguous()
+
+    # cast "bboxes2" according to the type of "bboxes1"
+    bboxes2 = bboxes2.type_as(bboxes1)
+
     ext_module.box_iou_rotated(
         bboxes1, bboxes2, ious, mode_flag=mode_flag, aligned=aligned)
     if not aligned:

--- a/mmcv/ops/csrc/common/cuda/box_iou_rotated_cuda.cuh
+++ b/mmcv/ops/csrc/common/cuda/box_iou_rotated_cuda.cuh
@@ -28,8 +28,8 @@ __global__ void box_iou_rotated_cuda_kernel(
 
       int base1 = b1 * 5;
 
-      float block_boxes1[5];
-      float block_boxes2[5];
+      T block_boxes1[5];
+      T block_boxes2[5];
 
       block_boxes1[0] = dev_boxes1[base1 + 0];
       block_boxes1[1] = dev_boxes1[base1 + 1];
@@ -55,8 +55,8 @@ __global__ void box_iou_rotated_cuda_kernel(
 
       int base1 = b1 * 5;
 
-      float block_boxes1[5];
-      float block_boxes2[5];
+      T block_boxes1[5];
+      T block_boxes2[5];
 
       block_boxes1[0] = dev_boxes1[base1 + 0];
       block_boxes1[1] = dev_boxes1[base1 + 1];

--- a/mmcv/ops/csrc/pytorch/cuda/box_iou_rotated_cuda.cu
+++ b/mmcv/ops/csrc/pytorch/cuda/box_iou_rotated_cuda.cu
@@ -16,10 +16,13 @@ void box_iou_rotated_cuda(const Tensor boxes1, const Tensor boxes2, Tensor ious,
 
   at::cuda::CUDAGuard device_guard(boxes1.device());
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-  box_iou_rotated_cuda_kernel<scalar_t>
-      <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK, 0, stream>>>(
-          num_boxes1, num_boxes2, boxes1.data_ptr<scalar_t>(),
-          boxes2.data_ptr<scalar_t>(), (scalar_t*)ious.data_ptr<scalar_t>(),
-          mode_flag, aligned);
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+    boxes1.scalar_type(), "box_iou_rotated_cuda_kernel", [&] {
+        box_iou_rotated_cuda_kernel<scalar_t>
+            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK, 0, stream>>>(
+                num_boxes1, num_boxes2, boxes1.data_ptr<scalar_t>(),
+                boxes2.data_ptr<scalar_t>(), (scalar_t*)ious.data_ptr<scalar_t>(),
+                mode_flag, aligned);
+    });
   AT_CUDA_CHECK(cudaGetLastError());
 }

--- a/tests/test_ops/test_box_iou_rotated.py
+++ b/tests/test_ops/test_box_iou_rotated.py
@@ -3,6 +3,16 @@ import numpy as np
 import pytest
 import torch
 
+from mmcv.ops import box_iou_rotated
+
+try:
+    # If PyTorch version >= 1.6.0 and fp16 is enabled, torch.cuda.amp.autocast
+    # would be imported and used; we should test if our modules support it.
+    from torch.cuda.amp import autocast
+    _IS_AUTOCAST_AVAILABLE = True
+except ImportError:
+    _IS_AUTOCAST_AVAILABLE = False
+
 
 class TestBoxIoURotated:
 
@@ -83,6 +93,32 @@ class TestBoxIoURotated:
         ious = box_iou_rotated(boxes1, boxes2, aligned=True, clockwise=False)
         assert np.allclose(
             ious.cpu().numpy(), np_expect_ious_aligned, atol=1e-4)
+
+    @pytest.mark.skipif(
+        not _IS_AUTOCAST_AVAILABLE, reason='requires autocast support')
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason='requires CUDA support')
+    def test_box_iou_rotated_with_autocast(self, device):
+        np_boxes1 = np.asarray(
+            [[1.0, 1.0, 3.0, 4.0, 0.5], [2.0, 2.0, 3.0, 4.0, 0.6],
+             [7.0, 7.0, 8.0, 8.0, 0.4]],
+            dtype=np.float32)
+        np_boxes2 = np.asarray(
+            [[0.0, 2.0, 2.0, 5.0, 0.3], [2.0, 1.0, 3.0, 3.0, 0.5],
+             [5.0, 5.0, 6.0, 7.0, 0.4]],
+            dtype=np.float32)
+        np_expect_ious = np.asarray(
+            [[0.3708, 0.4351, 0.0000], [0.1104, 0.4487, 0.0424],
+             [0.0000, 0.0000, 0.3622]],
+            dtype=np.float16)
+
+        boxes1 = torch.from_numpy(np_boxes1).to(device).type(torch.half)
+        boxes2 = torch.from_numpy(np_boxes2).to(device)
+
+        with autocast(enabled=True):
+            # test cw angle definition
+            ious = box_iou_rotated(boxes1, boxes2)
+        assert np.allclose(ious.cpu().numpy(), np_expect_ious, atol=1e-2)
 
     def test_box_iou_rotated_iof_cpu(self):
         from mmcv.ops import box_iou_rotated


### PR DESCRIPTION
## Motivation

Currently, `box_iou_rotated` does not support fp16 type.

## Modification

Support AMP in `box_iou_rotated`.

**Note that this PR does not support AMP for `diff_iou_rotated_2d`.**
I tried to support it, but it is quite challenging to prevent overflow and underflow in complex operations.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
