### PR TITLE
use c++17 in PyTorch 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,7 +201,10 @@ def get_extensions():
         extra_compile_args = {'cxx': []}
 
         if platform.system() != 'Windows':
-            extra_compile_args['cxx'] = ['-std=c++14']
+            if parse_version(torch.__version__) >= parse_version('2.0.0'):
+                extra_compile_args['cxx'] = ['-std=c++17']
+            else:
+                extra_compile_args['nvcc'] += ['-std=c++14']
         else:
             # TODO: In Windows, C++17 is chosen to compile extensions in
             # PyTorch2.0 , but a compile error will be reported.
@@ -418,7 +421,10 @@ def get_extensions():
         # to compile those cpp files, so there is no need to add the
         # argument
         if 'nvcc' in extra_compile_args and platform.system() != 'Windows':
-            extra_compile_args['nvcc'] += ['-std=c++14']
+            if parse_version(torch.__version__) >= parse_version('2.0.0'):
+                extra_compile_args['cxx'] = ['-std=c++17']
+            else:
+                extra_compile_args['nvcc'] += ['-std=c++14']
 
         ext_ops = extension(
             name=ext_name,


### PR DESCRIPTION
This fixed the issues in #2916 for me.
However, I'm not sure what the best practices are when it comes to c++ compilation so there is probably a cleaner solution for this.