### PR TITLE
[Fix] fix data race risk of `cache_randomness`

### DIFF
--- a/mmcv/transforms/utils.py
+++ b/mmcv/transforms/utils.py
@@ -81,6 +81,9 @@ class cache_randomness:
 
     def __get__(self, obj, cls):
         self.instance_ref = weakref.ref(obj)
+        # Return a copy to avoid multiple transform instances sharing
+        # one `cache_randomness` instance, which may cause data races
+        # in multithreading cases.
         return copy.copy(self)
 
 

--- a/mmcv/transforms/utils.py
+++ b/mmcv/transforms/utils.py
@@ -81,7 +81,7 @@ class cache_randomness:
 
     def __get__(self, obj, cls):
         self.instance_ref = weakref.ref(obj)
-        return copy.deepcopy(self)
+        return copy.copy(self)
 
 
 def avoid_cache_randomness(cls):

--- a/mmcv/transforms/utils.py
+++ b/mmcv/transforms/utils.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
+import copy
 import functools
 import inspect
 import weakref
@@ -80,7 +81,7 @@ class cache_randomness:
 
     def __get__(self, obj, cls):
         self.instance_ref = weakref.ref(obj)
-        return self
+        return copy.deepcopy(self)
 
 
 def avoid_cache_randomness(cls):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

**fix the bug mentioned in #2926**

## Modification

Please briefly describe what modification is made in this PR.

**The bug mentioned in #2926 is caused by the data race of multithreading. I do not think it is a good idea to use a pointer here to point to different instances. This can lead to disaster in concurrent situations. To keep modifications minimal, I implemented a version that creates a new copy every time "cache_randomness" is accessed to avoid data races of multithreading. Since this class "cache_randomness" only contains two pointers, one pointing to the class method (rather than the bound method) and the other to the class, the additional overhead brought here is subtle.**

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

**I do not think it breaks**

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
