### PR TITLE
[Feature] Support nms rotated op using diopi

### DIFF
--- a/mmcv/ops/csrc/pytorch/nms_rotated.cpp
+++ b/mmcv/ops/csrc/pytorch/nms_rotated.cpp
@@ -2,6 +2,18 @@
 // modified from
 // https://github.com/facebookresearch/detectron2/blob/master/detectron2/layers/csrc/nms_rotated/nms_rotated.h
 #include "pytorch_cpp_helper.hpp"
+#include "pytorch_device_registry.hpp"
+#ifdef MMCV_WITH_DIOPI
+#include <diopi/diopirt.h>
+#include <diopi/functions.h>
+#include <diopi/functions_mmcv.h>
+
+#include "csrc_dipu/base/basedef.h"
+#include "csrc_dipu/diopirt/diopirt_impl.h"
+
+using dipu::diopi_helper::toDiopiScalar;
+using dipu::diopi_helper::toDiopiTensorHandle;
+#endif
 
 Tensor nms_rotated_cpu(const Tensor dets, const Tensor scores,
                        const float iou_threshold);
@@ -22,12 +34,55 @@ Tensor nms_rotated_mlu(const Tensor dets, const Tensor scores,
                        const float iou_threshold);
 #endif
 
+#ifdef MMCV_WITH_DIOPI
+Tensor nms_rotated_diopi(const Tensor dets, const Tensor scores,
+                         const Tensor order, const Tensor dets_sorted,
+                         const Tensor labels, const float iou_threshold,
+                         const int multi_label) {
+  auto dets_p = toDiopiTensorHandle(dets);
+  diopiDevice_t device;
+  diopiGetTensorDevice(dets_p, &device);
+  if (device == diopi_host) {
+    return nms_rotated_cpu(dets.contiguous(), scores.contiguous(),
+                           iou_threshold);
+  }
+  diopiContext ctx(dipu::getCurrentDIPUStream().rawstream());
+  diopiContextHandle_t ch = &ctx;
+  Tensor out;
+  auto out_p = toDiopiTensorHandle(out);
+  diopiTensorHandle_t *out_handle = &out_p;
+  auto scores_p = toDiopiTensorHandle(scores);
+  auto order_p = toDiopiTensorHandle(order);
+  auto dets_sorted_p = toDiopiTensorHandle(dets_sorted);
+  auto labels_p = toDiopiTensorHandle(labels);
+  bool is_mock_cuda = dets.device().type() == dipu::DIPU_DEVICE_TYPE;
+  if (is_mock_cuda &&
+      reinterpret_cast<void *>(diopiNmsRotatedMmcv) != nullptr) {
+    auto ret = diopiNmsRotatedMmcv(ch, out_handle, dets_p, scores_p, order_p,
+                                   dets_sorted_p, labels_p, iou_threshold,
+                                   static_cast<bool>(multi_label));
+    if (ret == diopiSuccess) {
+      auto tensorhandle = reinterpret_cast<Tensor *>(*out_handle);
+      return *tensorhandle;
+    }
+  }
+  LOG(WARNING) << "Fallback to cpu: mmcv ext op nms_rotated";
+  auto dets_cpu = dets.cpu();
+  auto scores_cpu = scores.cpu();
+  return nms_rotated_cpu(dets_cpu, scores_cpu, iou_threshold);
+}
+#endif
+
 // Interface for Python
 // inline is needed to prevent multiple function definitions when this header is
 // included by different cpps
 Tensor nms_rotated(const Tensor dets, const Tensor scores, const Tensor order,
                    const Tensor dets_sorted, const Tensor labels,
                    const float iou_threshold, const int multi_label) {
+#ifdef MMCV_WITH_DIOPI
+  return nms_rotated_diopi(dets, scores, order, dets_sorted, labels,
+                           iou_threshold, multi_label);
+#endif
   assert(dets.device().is_cuda() == scores.device().is_cuda());
   if (dets.device().is_cuda()) {
 #ifdef MMCV_WITH_CUDA


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The Pointpillars model requires the use of the mmcv extension op `nms_rotated` during the val stage. To support `nms_rotated` op with the implementation of diopi op, we need the corresponding adaptation in mmcv.
When adopting the adaptation, we can get the desired inference result.
![image](https://github.com/open-mmlab/mmcv/assets/131418410/d0bf801e-6c49-4fa0-a75f-94d60f660a86)


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
