### PR TITLE
[Feature] remove an 'assert' statement in favor of a 'raise' statement to make MultiScaleDeformableAttention compatible with torch.compile()

### DIFF
--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -332,7 +332,10 @@ class MultiScaleDeformableAttention(BaseModule):
 
         bs, num_query, _ = query.shape
         bs, num_value, _ = value.shape
-        assert (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() == num_value
+        if (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() != num_value:
+            raise ValueError(
+                'The sequence length of `value` must be equal to'
+                'the flattened features maps summed over all levels.')
 
         value = self.value_proj(value)
         if key_padding_mask is not None:

--- a/mmcv/ops/multi_scale_deform_attn.py
+++ b/mmcv/ops/multi_scale_deform_attn.py
@@ -333,9 +333,9 @@ class MultiScaleDeformableAttention(BaseModule):
         bs, num_query, _ = query.shape
         bs, num_value, _ = value.shape
         if (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() != num_value:
-            raise ValueError(
-                'The sequence length of `value` must be equal to'
-                'the flattened features maps summed over all levels.')
+            raise ValueError('The sequence length of `value` must be equal to'
+                             'size of the flattened features maps summed over'
+                             'all levels.')
 
         value = self.value_proj(value)
         if key_padding_mask is not None:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The goal is to make MultiScaleDeformableAttention compatible with torch.compile().

## Modification

The only modification is to change an assert statement to a raise statement and add an error message.

## BC-breaking (Optional)

N/A

## Use cases (Optional)

The use case is using torch.compile() to make training and inference faster.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
