### PR TITLE
Fix KeyError in MultiScaleFlipAug by ensuring correct key handling

### DIFF
--- a/mmcv/transforms/processing.py
+++ b/mmcv/transforms/processing.py
@@ -861,7 +861,7 @@ class MultiScaleFlipAug(BaseTransform):
 
                 inputs.append(packed_results['inputs'])  # type: ignore
                 data_samples.append(
-                    packed_results['data_sample'])  # type: ignore
+                    packed_results['data_samples'])  # type: ignore
         return dict(inputs=inputs, data_sample=data_samples)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Motivation

This PR fixes a bug in the MultiScaleFlipAug transform where 'data_sample' was incorrectly used instead of 'data_samples'.

## Modification

Replaced 'data_sample' with 'data_samples' in the MultiScaleFlipAug transform to prevent a KeyError.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.

- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.

**After PR**:

- [ ] Tested the modification with relevant downstream projects.
- [ ] Signed the CLA.
