### PR TITLE
fixed issue #2470 (some windows support for ffmpeg calls)

### DIFF
--- a/mmcv/utils/misc.py
+++ b/mmcv/utils/misc.py
@@ -8,6 +8,7 @@ from collections import abc
 from importlib import import_module
 from inspect import getfullargspec
 from itertools import repeat
+import platform
 
 
 # From PyTorch internals
@@ -251,10 +252,16 @@ def _check_py_package(package):
 
 
 def _check_executable(cmd):
-    if subprocess.call(f'which {cmd}', shell=True) != 0:
-        return False
-    else:
-        return True
+    if platform.system() == 'Linux':
+        if subprocess.call(f'which {cmd}', shell=True) != 0:
+            return False
+        else:
+            return True
+    if platform.system() == 'Windows':
+        if subprocess.call(f'where {cmd}', shell=True) != 0:
+            return False
+        else:
+            return True
 
 
 def requires_package(prerequisites):

--- a/mmcv/video/processing.py
+++ b/mmcv/video/processing.py
@@ -45,8 +45,8 @@ def convert_video(in_file: str,
             options.append(f'-loglevel {v}')
         else:
             options.append(f'-{k} {v}')
-    cmd = f'ffmpeg -y {pre_options} -i {in_file} {" ".join(options)} ' \
-          f'{out_file}'
+    cmd = f'ffmpeg -y {pre_options} -i "{in_file}" {" ".join(options)} ' \
+          f'"{out_file}"'
     if print_cmd:
         print(cmd)
     subprocess.call(cmd, shell=True)


### PR DESCRIPTION
## Motivation

Support on Windows

## Modification

1) Added quotes around paths given to ffmpeg command (executed by mmcv.video.processing.py:convert_video() ), in order to support the spaces in windows paths.
2) Changed "which" to "where" when the platform is Windows in mmcv.utils.misc.py:_check_executable()

## BC-breaking (Optional)
No

## Use cases (Optional)
No new use case

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

None, I've tried to run the linting tools, but I got some exceptions that I didn't understand when trying to use them, maybe they don't work on Windows.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
