### PR TITLE
Do not use deprecated `.type().scalarType()`

### DIFF
--- a/mmcv/ops/csrc/pytorch/spconv_utils.h
+++ b/mmcv/ops/csrc/pytorch/spconv_utils.h
@@ -35,7 +35,7 @@ struct TorchGPU : public tv::GPU {
 
 template <typename scalar_t>
 void check_torch_dtype(const torch::Tensor &tensor) {
-  switch (tensor.type().scalarType()) {
+  switch (tensor.scalar_type()) {
     case at::ScalarType::Double: {
       auto val = std::is_same<std::remove_const_t<scalar_t>, double>::value;
       TV_ASSERT_RT_ERR(val, "error");


### PR DESCRIPTION
## Motivation

Code should not rely on deprecated APIs as they might get removed in the future

## Modification

`at::Tensor::type()` method is deprecated and `tensor.scalar_type()` is a recommended way to replace `tensor.type().scalarType()` invocation

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
