### PR TITLE
Efficient channel swapping

### DIFF
--- a/mmcv/image/io.py
+++ b/mmcv/image/io.py
@@ -284,7 +284,8 @@ def imfrombytes(content: bytes,
         flag = imread_flags[flag] if is_str(flag) else flag
         img = cv2.imdecode(img_np, flag)
         if flag == IMREAD_COLOR and channel_order == 'rgb':
-            cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)
+            # Faster than cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)
+            img = img[..., ::-1]
         return img
 
 

--- a/mmcv/image/photometric.py
+++ b/mmcv/image/photometric.py
@@ -44,7 +44,8 @@ def imnormalize_(img, mean, std, to_rgb=True):
     mean = np.float64(mean.reshape(1, -1))
     stdinv = 1 / np.float64(std.reshape(1, -1))
     if to_rgb:
-        cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)  # inplace
+        # Faster than cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)
+        img = img[..., ::-1]
     cv2.subtract(img, mean, img)  # inplace
     cv2.multiply(img, stdinv, img)  # inplace
     return img
@@ -56,8 +57,9 @@ def imdenormalize(img, mean, std, to_bgr=True):
     std = std.reshape(1, -1).astype(np.float64)
     img = cv2.multiply(img, std)  # make a copy
     cv2.add(img, mean, img)  # inplace
+    # Faster than cv2.cvtColor(img, cv2.COLOR_RGB2BGR, img)
     if to_bgr:
-        cv2.cvtColor(img, cv2.COLOR_RGB2BGR, img)  # inplace
+        img = img[..., ::-1]
     return img
 
 
@@ -427,7 +429,8 @@ def adjust_lighting(img, eigval, eigvec, alphastd=0.1, to_rgb=True):
 
     img = img.copy().astype(np.float32)
     if to_rgb:
-        cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)  # inplace
+        # Faster than cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)
+        img = img[..., ::-1]
 
     alpha = np.random.normal(0, alphastd, n_eigval)
     alter = eigvec \


### PR DESCRIPTION
## Motivation

Swapping the channels manually is much faster than the conversion function. It is also independent of the image size.

```py
In [1]: import numpy as np

In [2]: import cv2

In [3]: bla = (np.random.rand(1080, 1920, 3) * 255).astype(np.float32)

In [4]: bla2 = (np.random.rand(2080, 3920, 3) * 255).astype(np.float32)

In [5]: timeit cv2.cvtColor(bla, cv2.COLOR_BGR2RGB)
818 μs ± 14.3 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [6]: timeit cv2.cvtColor(bla2, cv2.COLOR_BGR2RGB)
11.7 ms ± 79.6 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [7]: timeit bla[..., ::-1]
77.7 ns ± 3.16 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [8]: timeit bla2[..., ::-1]
75.7 ns ± 0.438 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

## Modification

Replace `cvtColor` calls to manually swapping for BGR2RGB or vice-versa.

## BC-breaking (Optional)

Nope

## Use cases (Optional)

No new features

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
