### PR TITLE
support turbojpeg for mmcv imread

### DIFF
--- a/mmcv/image/io.py
+++ b/mmcv/image/io.py
@@ -265,6 +265,12 @@ def imfrombytes(content: bytes,
             f'backend: {backend} is not supported. Supported '
             "backends are 'cv2', 'turbojpeg', 'pillow', 'tifffile'")
     if backend == 'turbojpeg':
+        if TurboJPEG is None:
+              raise ImportError('`PyTurboJPEG` is not installed')
+        global jpeg
+        if jpeg is None:
+            jpeg = TurboJPEG()
+
         img = jpeg.decode(  # type: ignore
             content, _jpegflag(flag, channel_order))
         if img.shape[-1] == 1:


### PR DESCRIPTION

## Motivation
When decode a 3840*2160 jpeg image, Turbojpeg is more than twice as fast as cv2. I pass backend = "turbojpeg" to imread function and get an error:

Traceback (most recent call last):
  File "/home/zs/test_turbojpeg.py", line 4, in <module>
    imread(img_path, backend="turbojpeg")
  File "/home/zs/mmcv/mmcv/image/io.py", line 226, in imread
    return imfrombytes(img_bytes, flag, channel_order, backend)
  File "/home/zs/mmcv/mmcv/image/io.py", line 268, in imfrombytes
    img = jpeg.decode(  # type: ignore
AttributeError: 'NoneType' object has no attribute 'decode'

Since turbojpeg doesn't support APIs such as resize, etc. I can't  set turbojpeg as the default backend through use_backend("turbojpeg").

So, we need an pr to support turbojpeg for decoding jpeg image. 


## Modification

update "imfrombytes" implementation to support image decoding with turbojpeg backend.

## BC-breaking (Optional)

No

## Use cases (Optional)

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
