### PR TITLE
Remove dist calculation duplicate

### DIFF
--- a/mmcv/ops/csrc/common/box_iou_rotated_utils.hpp
+++ b/mmcv/ops/csrc/common/box_iou_rotated_utils.hpp
@@ -182,6 +182,7 @@ HOST_DEVICE_INLINE int convex_hull_graham(const Point<T> (&p)[24],
   q[0] = q[t];
   q[t] = tmp;
 
+#if defined(__CUDACC__) || defined(__MUSACC__)
   // Step 3:
   // Sort point 1 ~ num_in according to their relative cross-product values
   // (essentially sorting according to angles)
@@ -191,7 +192,6 @@ HOST_DEVICE_INLINE int convex_hull_graham(const Point<T> (&p)[24],
     dist[i] = dot_2d<T>(q[i], q[i]);
   }
 
-#if defined(__CUDACC__) || defined(__MUSACC__)
   // CUDA version
   // In the future, we can potentially use thrust
   // for sorting here to improve speed (though not guaranteed)
@@ -372,6 +372,11 @@ HOST_DEVICE_INLINE T single_box_iou_rotated(T const* const box1_raw,
   } else if (mode_flag == 1) {
     baseS = area1;
   }
+
+  if (baseS <= static_cast<T>(1e-14)) {
+    return static_cast<T>(0);
+  }
+
   const T iou = intersection / baseS;
   return iou;
 }


### PR DESCRIPTION
## Motivation

Remove redundant calculation and make calculation safe

## Modification

Removes redundant duplicate of dist calculation.
Adds safe check for division

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
