### PR TITLE
build: ➖ Remove pkg_resources usage to fix Python 3.12 failure

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ split_before_expression_after_opening_paren = true
 [isort]
 line_length = 79
 multi_line_output = 0
-extra_standard_library = pkg_resources,setuptools,logging,os,warnings,abc
+extra_standard_library = setuptools,logging,os,warnings,abc
 known_first_party = mmcv
 known_third_party = addict,cv2,matplotlib,numpy,onnx,packaging,pytest,pytorch_sphinx_theme,scipy,sphinx,torch,torchvision,yaml,yapf
 no_lines_before = STDLIB,LOCALFOLDER

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ import glob
 import os
 import platform
 import re
-from pkg_resources import DistributionNotFound, get_distribution, parse_version
+from importlib.metadata import version, PackageNotFoundError
+from packaging.version import parse as parse_version
 from setuptools import find_packages, setup
 
 EXT_TYPE = ''
@@ -33,8 +34,8 @@ def choose_requirement(primary, secondary):
     return secondary."""
     try:
         name = re.split(r'[!<>=]', primary)[0]
-        get_distribution(name)
-    except DistributionNotFound:
+        version(name)
+    except PackageNotFoundError:
         return secondary
 
     return str(primary)


### PR DESCRIPTION
## Motivation

Python 3.12 removes pkg_resources, which causes MMCV to fail during PEP 517
build isolation with the following error:

```ModuleNotFoundError: No module named 'pkg_resources'```


This breaks installation for Python 3.12, even though the affected code paths are only used for version handling.


## Modification

Replaces: `pkg_resources.get_distribution` and `pkg_resources.parse_version`
with: `importlib.metadata.version` and `packaging.version.parse`

Removes pkg_resources from build/tooling configuration

## Use cases (Optional)

This change allows MMCV to be installed successfully on Python 3.12

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmcv/blob/master/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects, like MMDet or MMCls.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
