### PR TITLE
[Fix] Honor channel order for RGB TIFF images

### DIFF
--- a/mmcv/image/io.py
+++ b/mmcv/image/io.py
@@ -276,8 +276,15 @@ def imfrombytes(content: bytes,
             img = _pillow2array(img, flag, channel_order)
         return img
     elif backend == 'tifffile':
-        with io.BytesIO(content) as buff:
-            img = tifffile.imread(buff)
+        with io.BytesIO(content) as buff, tifffile.TiffFile(buff) as tif:
+            img = tif.asarray()
+            axes = tif.series[0].axes
+            if (channel_order == 'bgr'
+                    and tif.pages.first.photometric == tifffile.PHOTOMETRIC.RGB
+                    and 'S' in axes):
+                sample_axis = axes.index('S')
+                indices = [2, 1, 0] + list(range(3, img.shape[sample_axis]))
+                img = np.take(img, indices, axis=sample_axis)
         return img
     else:
         img_np = np.frombuffer(content, np.uint8)

--- a/tests/test_image/test_io.py
+++ b/tests/test_image/test_io.py
@@ -10,6 +10,7 @@ import cv2
 import mmengine
 import numpy as np
 import pytest
+import tifffile
 import torch
 from mmengine.fileio.file_client import HTTPBackend, PetrelBackend
 from numpy.testing import assert_allclose, assert_array_equal
@@ -258,6 +259,8 @@ class TestIO:
         mmcv.use_backend('tifffile')
         img_tifffile = mmcv.imread(self.tiff_path)
         assert img_tifffile.shape == (200, 150, 5)
+        assert_array_equal(img_tifffile,
+                           mmcv.imread(self.tiff_path, channel_order='rgb'))
 
         mmcv.use_backend('cv2')
 
@@ -382,6 +385,31 @@ class TestIO:
             with open(self.img_path, 'rb') as f:
                 img_bytes = f.read()
             mmcv.imfrombytes(img_bytes, backend='unsupported_backend')
+
+    @pytest.mark.parametrize(('num_channels', 'planar_config'),
+                             [(3, 'contig'), (4, 'contig'), (3, 'separate')])
+    def test_tifffile_channel_order(self, num_channels, planar_config):
+        sample_axis = 0 if planar_config == 'separate' else -1
+        shape = ((num_channels, 2, 3) if sample_axis == 0 else
+                 (2, 3, num_channels))
+        img_rgb = np.arange(np.prod(shape), dtype=np.uint8).reshape(shape)
+        with tempfile.NamedTemporaryFile(suffix='.tif') as tiff_file:
+            tifffile.imwrite(
+                tiff_file.name,
+                img_rgb,
+                photometric='rgb',
+                planarconfig=planar_config)
+            content = Path(tiff_file.name).read_bytes()
+
+        img_bgr = mmcv.imfrombytes(content, backend='tifffile')
+        img_rgb_decoded = mmcv.imfrombytes(
+            content, backend='tifffile', channel_order='rgb')
+        expected_bgr = np.take(
+            img_rgb, [2, 1, 0] + list(range(3, num_channels)),
+            axis=sample_axis)
+
+        assert_array_equal(img_bgr, expected_bgr)
+        assert_array_equal(img_rgb_decoded, img_rgb)
 
     def test_imwrite(self):
         img = mmcv.imread(self.img_path)


### PR DESCRIPTION
## Motivation

Fixes #1101.

The `tifffile` backend returns standard color TIFF data in native RGB order, but MMCV's documented default is BGR. The backend previously returned the raw array without consulting `channel_order`, so default reads displayed red and blue channels incorrectly.

## Modification

- Read TIFF metadata to identify images whose photometric interpretation is RGB and locate their sample axis.
- Reorder the first three samples for BGR output while preserving alpha or other extra samples and supporting both contiguous and planar layouts.
- Keep non-RGB multi-channel TIFF data unchanged, preserving the backend's remote-sensing use case.
- Add regression coverage for RGB, RGBA, planar RGB, explicit RGB output, and the existing five-channel non-RGB fixture.

## BC-breaking (Optional)

No. This makes the `tifffile` backend honor the existing `channel_order` contract. Callers that need native RGB output can continue to pass `channel_order='rgb'` explicitly.

## Validation

- `pytest -q tests/test_image` (61 passed)
- Flake8, isort, YAPF, codespell, and whitespace checks pass for both changed files.
- No documentation update is needed because this restores the documented `channel_order` behavior.